### PR TITLE
#103: enddate of a course (evaluated in the future) is shown

### DIFF
--- a/evap/locale/de/LC_MESSAGES/django.po
+++ b/evap/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EvaP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-08-10 14:20+0200\n"
+"POT-Creation-Date: 2012-08-10 14:43+0200\n"
 "PO-Revision-Date: 2012-02-12 15:06+0100\n"
 "Last-Translator: Michael Gruenewald <mail@michaelgruenewald.eu>\n"
 "Language-Team: \n"
@@ -1234,8 +1234,8 @@ msgid "You will be able to vote on the following courses soon:"
 msgstr "Sie können bald die folgenden Veranstaltungen bewerten:"
 
 #: .\student\templates\student_index.html.py:32
-msgid "can be evaluated from"
-msgstr "evaluierbar vom"
+msgid "can be voted on from"
+msgstr "Evaluierbar vom"
 
 #: .\student\templates\student_index.html.py:32
 msgid "till"

--- a/evap/student/templates/student_index.html
+++ b/evap/student/templates/student_index.html
@@ -29,7 +29,7 @@
         {% trans "You will be able to vote on the following courses soon:" %}
         <ul>
             {% for course in future_courses %}
-                <li>{{ course.name }} ({% trans "can be evaluated from" %} {{ course.vote_start_date|date:"DATE_FORMAT" }} {% trans "till" %} {{ course.vote_end_date|date:"DATE_FORMAT" }})</li>
+                <li>{{ course.name }} ({% trans "can be voted on from" %} {{ course.vote_start_date|date:"DATE_FORMAT" }} {% trans "till" %} {{ course.vote_end_date|date:"DATE_FORMAT" }})</li>
             {% endfor %}
         </ul>
     {% endif %}


### PR DESCRIPTION
This is some work on ticket #103.
On the index page for students the evaluation period of course that can be evaluated in the future the enddate will now be shown.
