### PR TITLE
#103: enddate of a course (evaluated in the future) is shown

### DIFF
--- a/evap/locale/de/LC_MESSAGES/django.po
+++ b/evap/locale/de/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EvaP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-08-10 16:13+0200\n"
+"POT-Creation-Date: 2012-08-10 16:32+0200\n"
 "PO-Revision-Date: 2012-02-12 15:06+0100\n"
 "Last-Translator: Michael Gruenewald <mail@michaelgruenewald.eu>\n"
 "Language-Team: \n"
@@ -1234,8 +1234,12 @@ msgid "You will be able to vote on the following courses soon:"
 msgstr "Sie können bald die folgenden Veranstaltungen bewerten:"
 
 #: .\student\templates\student_index.html.py:32
-msgid "starting"
-msgstr "beginnt am"
+msgid "can be voted on from"
+msgstr "Evaluierbar vom"
+
+#: .\student\templates\student_index.html.py:32
+msgid "till"
+msgstr "bis zum"
 
 #: .\student\templates\student_vote.html.py:47
 msgid "Vote"
@@ -1965,6 +1969,9 @@ msgstr ""
 #: .\templates\index.html.py:80
 msgid "Generate Key"
 msgstr "Schlüssel erzeugen"
+
+#~ msgid "starting"
+#~ msgstr "beginnt am"
 
 #~ msgid "What kinds of questionnaires are there?"
 #~ msgstr "Welche Arten von Fragebögen gibt es?"

--- a/evap/student/templates/student_index.html
+++ b/evap/student/templates/student_index.html
@@ -29,7 +29,7 @@
         {% trans "You will be able to vote on the following courses soon:" %}
         <ul>
             {% for course in future_courses %}
-                <li>{{ course.name }} ({% trans "starting" %} {{ course.vote_start_date|date:"DATE_FORMAT" }})</li>
+                <li>{{ course.name }} ({% trans "can be voted on from" %} {{ course.vote_start_date|date:"DATE_FORMAT" }} {% trans "till" %} {{ course.vote_end_date|date:"DATE_FORMAT" }})</li>
             {% endfor %}
         </ul>
     {% endif %}


### PR DESCRIPTION
Second version of this pull request.

This is some work on ticket #103.
On the index page for students the evaluation period of course that can be evaluated in the future the enddate will now be shown.
