### PR TITLE
Ensure relogin possibility

### DIFF
--- a/evap/urls.py
+++ b/evap/urls.py
@@ -8,7 +8,7 @@ admin.autodiscover()
 urlpatterns = patterns('',
     url(r"^$", 'evap.evaluation.views.index'),
     url(r"^faq$", 'evap.evaluation.views.faq'),
-    url(r"^login$", 'django.views.generic.simple.redirect_to', {'url': "/"}),
+    url(r"^login$", 'django.views.generic.simple.redirect_to', {'url': "/", 'permanent': False}),
     url(r"^logout$", 'django.contrib.auth.views.logout', {'next_page': "/"}),
     
     url(r"^fsr/", include('evap.fsr.urls')),


### PR DESCRIPTION
At the moment the application redirects the user with a "301 moved permanently" status code to the main site after a successful login. The 301 indicates that the browser should cache this information. If you need to reauthorize (after logout or inactivity), the browser may not do the request to /login and opens / directly.

Problem occurred: with chrome 27.0.1453.116 m on windows 8
