### PR TITLE
Simple passwords

### DIFF
--- a/deployment/modules/evap/templates/localsettings.py.erb
+++ b/deployment/modules/evap/templates/localsettings.py.erb
@@ -3,7 +3,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.<%= @db_connector -%>',   # 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': 'evap',                         # Or path to database file if using sqlite3.
         'USER': 'evap',                         # Not used with sqlite3.
-        'PASSWORD': '0Am5dWVSC9kd',             # Not used with sqlite3.
+        'PASSWORD': 'evap',             # Not used with sqlite3.
         'HOST': '127.0.0.1',                    # Set to empty string for localhost. Not used with sqlite3.
         'PORT': '',                             # Set to empty string for default. Not used with sqlite3.
     }

--- a/deployment/site.pp
+++ b/deployment/site.pp
@@ -21,12 +21,12 @@ node default {
     #    root_password  => '7FzSCogWAFCt'
     #} -> mysql::db { 'evap':
     #    user           => 'evap',
-    #    password       => '0Am5dWVSC9kd',
+    #    password       => 'evap',
     #} -> package { 'python-mysqldb':
     #    ensure         => latest,
     class { 'postgresql::server':
     } -> postgresql::server::role { 'evap':
-        password_hash  => postgresql_password('evap', '0Am5dWVSC9kd'),
+        password_hash  => postgresql_password('evap', 'evap'),
         createdb       => true
     } -> postgresql::server::db { 'evap':
         user           => 'evap',


### PR DESCRIPTION
this PR sets the database passwords in the vagrant VM to 'evap'.

i repeatedly found myself opening site.pp, copy the password and paste it into my shell, which shouldn't be necessary IMO.
