### PR TITLE
Fix typos, inconsistencies and grammar in german and english strings

### DIFF
--- a/evap/fsr/views.py
+++ b/evap/fsr/views.py
@@ -282,7 +282,7 @@ def course_edit(request, semester_id, course_id):
 
     # check course state
     if not course.can_fsr_edit():
-        messages.add_message(request, messages.ERROR, _("Editting not possible in current state."))
+        messages.add_message(request, messages.ERROR, _("Editing not possible in current state."))
         return redirect('evap.fsr.views.semester_view', semester_id)
 
     form = CourseForm(request.POST or None, instance=course)

--- a/evap/locale/de/LC_MESSAGES/django.po
+++ b/evap/locale/de/LC_MESSAGES/django.po
@@ -920,7 +920,7 @@ msgid "Successfully created course."
 msgstr "Veranstaltung erfolgreich erstellt."
 
 #: fsr/views.py:285
-msgid "Editting not possible in current state."
+msgid "Editing not possible in current state."
 msgstr "Bearbeiten ist im aktuellen Zustand nicht möglich."
 
 #: fsr/views.py:308


### PR DESCRIPTION
This fixes #318. Don't forget to call `python manage.py compilemessages` in order to see the fixed translations!
