### PR TITLE
Fix #289

### DIFF
--- a/evap/evaluation/management/commands/create_user.py
+++ b/evap/evaluation/management/commands/create_user.py
@@ -36,7 +36,7 @@ def read_value(question, validator_func):
         try:
             validator_func(value)
         except exceptions.ValidationError, e:
-            sys.stderr.write(str(e.messages[0]))
+            sys.stderr.write(str(e.messages[0]) + '\n')
             continue
         else:
             return value


### PR DESCRIPTION
Instead of using internal details of the `createsuperuser` script, the validations framework can validate the input with the corresponding `django.contrib.auth.User` fields.
