### PR TITLE
do not test python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"


### PR DESCRIPTION
there is no need to test python 2.6. remove it to speed tests up and to be nice to travis.
