### PR TITLE
do not test python 2.6, 3.3 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "pypy"
 matrix:
   allow_failures:
     - python: "pypy"
-    - python: "3.3"
-    - python: "3.4"
 install:
   - pip install -r requirements.txt --use-mirrors
   - pip install coveralls --use-mirrors


### PR DESCRIPTION
there is no need to test python 2.6, we don't support it and there is one PR being merged that breaks 2.6 compatibility.

i'll move testing of 3.3 and 3.4 to the py3 branch.
