### PR TITLE
remove --use-mirrors from pip commands, it's deprecated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
   allow_failures:
     - python: "pypy"
 install:
-  - pip install -r requirements.txt --use-mirrors
-  - pip install coveralls --use-mirrors
+  - pip install -r requirements.txt
+  - pip install coveralls
 script:
   - coverage run manage.py test evap.evaluation evap.fsr evap.contributor evap.results evap.student
 after_success:


### PR DESCRIPTION
travis complains that `--use-mirrors` is deprecated, and it's actually already removed in current pip versions. it seems like the mirrors got replaced by a CDN, so it seems that it's enough to just remove `--use-mirrors`.

see http://pip.readthedocs.org/en/latest/news.html and https://pypi.python.org/mirrors

@02strich, could you confirm this?
