### PR TITLE
remove raven dependency, fixes #273

### DIFF
--- a/evap/settings.py
+++ b/evap/settings.py
@@ -212,14 +212,6 @@ INSTALLED_APPS = (
     'evap.contributor',
 #   'django_auth_kerberos',
 )
-if not DEBUG:
-    INSTALLED_APPS += (
-        'raven.contrib.django.raven_compat',
-    )
-
-RAVEN_CONFIG = {
-    'dsn': 'http://public:secret@example.com/1',
-}
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
@@ -235,10 +227,6 @@ LOGGING = {
          }
      },
     'handlers': {
-        'sentry': {
-            'level': 'ERROR',
-            'class': 'raven.contrib.django.handlers.SentryHandler',
-        },
         'mail_admins': {
             'level': 'ERROR',
             'filters': ['require_debug_false'],
@@ -258,16 +246,6 @@ LOGGING = {
         'evap.evaluation.management.commands.import_evaj': {
             'handlers': ['console'],
             'level': 'INFO'
-        },
-        'raven': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
-        },
-        'sentry.errors': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
         }
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ django-webtest>=1.4.2
 django-widget-tweaks
 WebTest>=1.3
 WebOb>=1.1.1
-raven
 #django_auth_kerberos


### PR DESCRIPTION
this PR removes the raven dependency and related settings. vagrant up runs fine and still builds a working evap, i didn't know what else i should test.

fixes #273.
