### PR TITLE
changed related names

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -86,7 +86,7 @@ class Questionnaire(models.Model):
 
     @property
     def can_fsr_delete(self):
-        return not self.assigned_to.exists()
+        return not self.contributions.exists()
 
 
 class Course(models.Model):
@@ -313,9 +313,8 @@ class Contribution(models.Model):
     """A contributor who is assigned to a course and his questionnaires."""
 
     course = models.ForeignKey(Course, verbose_name=_(u"course"), related_name='contributions')
-    contributor = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_(u"contributor"), blank=True, null=True, related_name='contributors')
-    questionnaires = models.ManyToManyField(Questionnaire, verbose_name=_(u"questionnaires"),
-                                            blank=True, related_name="assigned_to")
+    contributor = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_(u"contributor"), blank=True, null=True, related_name='contributions')
+    questionnaires = models.ManyToManyField(Questionnaire, verbose_name=_(u"questionnaires"), blank=True, related_name="contributions")
     responsible = models.BooleanField(verbose_name = _(u"responsible"), default=False)
     can_edit = models.BooleanField(verbose_name = _(u"can edit"), default=False)
 
@@ -526,16 +525,16 @@ class UserProfile(models.Model):
 
     @property
     def is_contributor(self):
-        return self.user.contributors.exists()
+        return self.user.contributions.exists()
 
     @property
     def is_editor(self):
-        return self.user.contributors.filter(can_edit=True).exists()
+        return self.user.contributions.filter(can_edit=True).exists()
 
     @property
     def is_responsible(self):
-        #in the user list, self.user.contributors is prefetched, therefore use it directly and don't filter it
-        return any(contribution.responsible for contribution in self.user.contributors.all())
+        #in the user list, self.user.contributions is prefetched, therefore use it directly and don't filter it
+        return any(contribution.responsible for contribution in self.user.contributions.all())
 
     @property
     def is_delegate(self):

--- a/evap/fsr/templates/fsr_questionnaire_index.html
+++ b/evap/fsr/templates/fsr_questionnaire_index.html
@@ -29,7 +29,7 @@
                                     <strong>{{ questionnaire.name }}</strong> {% if questionnaire.obsolete %}<span class="label">{% trans "obsolete" %}</span>{% endif %}
                                     <br>
                                     {% blocktrans count questionnaire.question_set.all.count as count %}{{ count }} question {% plural %} {{ count }} questions{% endblocktrans %},
-                                    {% blocktrans count questionnaire.assigned_to.count as count %}used {{ count }} time {% plural %} used {{ count }} times {% endblocktrans %}
+                                    {% blocktrans count questionnaire.contributions.count as count %}used {{ count }} time {% plural %} used {{ count }} times {% endblocktrans %}
                                 </td>
                                 <td class="right">
                                     {% if not questionnaire.obsolete %}
@@ -72,7 +72,7 @@
                                     <strong>{{ questionnaire.name }}</strong> {% if questionnaire.obsolete %}<span class="label">{% trans "obsolete" %}</span>{% endif %}
                                     <br>
                                     {% blocktrans count questionnaire.question_set.all.count as count %}{{ count }} question {% plural %} {{ count }} questions{% endblocktrans %},
-                                    {% blocktrans count questionnaire.assigned_to.count as count %}used {{ count }} time {% plural %} used {{ count }} times {% endblocktrans %}
+                                    {% blocktrans count questionnaire.contributions.count as count %}used {{ count }} time {% plural %} used {{ count }} times {% endblocktrans %}
                                 </td>
                                 <td class="right">
                                     {% if not questionnaire.obsolete %}

--- a/evap/fsr/views.py
+++ b/evap/fsr/views.py
@@ -548,13 +548,13 @@ def questionnaire_delete(request, questionnaire_id):
 
 @fsr_required
 def user_index(request):
-    users = User.objects.order_by("last_name", "first_name", "username").select_related('userprofile').prefetch_related('contributors')
+    users = User.objects.order_by("last_name", "first_name", "username").select_related('userprofile').prefetch_related('contributions')
 
     filter = request.GET.get('filter')
     if filter == "fsr":
         users = users.filter(is_staff=True)
     elif filter == "responsibles":
-        users = users.filter(contributors__responsible=True).distinct()
+        users = users.filter(contributions__responsible=True).distinct()
 
     return render_to_response("fsr_user_index.html", dict(users=users, filter=filter), context_instance=RequestContext(request))
 


### PR DESCRIPTION
Fixes #374.
A migration was not needed because related_names are not stored in the database.
