### PR TITLE
add the django debug toolbar settings

### DIFF
--- a/evap/settings.py
+++ b/evap/settings.py
@@ -253,6 +253,18 @@ LOGGING = {
     }
 }
 
+#django debug toolbar settings
+ENABLE_DEBUG_TOOLBAR = False
+if DEBUG and ENABLE_DEBUG_TOOLBAR:
+    DEBUG_TOOLBAR_PATCH_SETTINGS = False
+    INSTALLED_APPS += ('debug_toolbar',)
+    MIDDLEWARE_CLASSES = ('debug_toolbar.middleware.DebugToolbarMiddleware',) + MIDDLEWARE_CLASSES
+    def show_toolbar(request):
+        return True
+    DEBUG_TOOLBAR_CONFIG = {
+        'SHOW_TOOLBAR_CALLBACK': 'evap.settings.show_toolbar',
+    }
+
 # Create a localsettings.py if you want to override settings per machine
 # or user, e.g. for development or different settings in deployments using
 # multiple servers.

--- a/evap/urls.py
+++ b/evap/urls.py
@@ -23,3 +23,9 @@ if settings.DEBUG:
     urlpatterns += patterns('',
         url(r'^media/(?P<path>.*)$', 'django.views.static.serve', {'document_root': settings.MEDIA_ROOT}),
    )
+
+if settings.DEBUG and settings.ENABLE_DEBUG_TOOLBAR:
+    import debug_toolbar
+    urlpatterns += patterns('',
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 coverage
+django-debug-toolbar


### PR DESCRIPTION
fixes #388. disabled by default because @janno42 said so.
