### PR TITLE
fix #245: do not send mails to a person twice if he/she is delegate and editor.

### DIFF
--- a/evap/evaluation/views.py
+++ b/evap/evaluation/views.py
@@ -29,7 +29,7 @@ def index(request):
             profile.generate_login_key()
             profile.save()
 
-            EmailTemplate.get_login_key_template().send_user(new_key_form.get_user())
+            EmailTemplate.get_login_key_template().send_to_user(new_key_form.get_user())
 
             messages.success(request, _(u"Successfully sent email with new login key."))
         elif login_key_form.is_valid():

--- a/evap/fsr/forms.py
+++ b/evap/fsr/forms.py
@@ -139,7 +139,7 @@ class CourseEmailForm(forms.Form, BootstrapMixin):
     def send(self):
         self.template.subject = self.cleaned_data.get('subject')
         self.template.body = self.cleaned_data.get('body')
-        self.template.send_courses([self.instance], send_to_editors=self.cleaned_data.get('sendToEditors'), send_to_contributors=self.cleaned_data.get('sendToContributors'), send_to_due_participants=self.cleaned_data.get('sendToDueParticipants'), send_to_all_participants=self.cleaned_data.get('sendToAllParticipants'))
+        self.template.send_to_users_in_courses([self.instance], send_to_editors=self.cleaned_data.get('sendToEditors'), send_to_contributors=self.cleaned_data.get('sendToContributors'), send_to_due_participants=self.cleaned_data.get('sendToDueParticipants'), send_to_all_participants=self.cleaned_data.get('sendToAllParticipants'))
 
 class QuestionnaireForm(forms.ModelForm, BootstrapMixin):
     class Meta:

--- a/evap/fsr/management/commands/run_tasks.py
+++ b/evap/fsr/management/commands/run_tasks.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
     def check_reminders(self):
         check_date = datetime.date.today() + datetime.timedelta(days=settings.REMIND_X_DAYS_AHEAD_OF_END_DATE)
         found_courses = [course for course in Course.objects.all() if course.state == "inEvaluation" and course.vote_end_date == check_date]
-        EmailTemplate.get_reminder_template().send_courses(found_courses, send_to_due_participants=True)
+        EmailTemplate.get_reminder_template().send_to_users_in_courses(found_courses, send_to_due_participants=True)
 
     def handle(self, *args, **options):
         if len(args) > 0 and args[0] == 'daily':

--- a/evap/fsr/views.py
+++ b/evap/fsr/views.py
@@ -113,7 +113,7 @@ def semester_publish(request, semester_id):
                 selected_courses.append(course)
 
         try:
-            EmailTemplate.get_publish_template().send_courses(selected_courses, send_to_contributors=True, send_to_all_participants=True)
+            EmailTemplate.get_publish_template().send_to_users_in_courses(selected_courses, send_to_contributors=True, send_to_all_participants=True)
         except:
             messages.add_message(request, messages.WARNING, _("Could not send emails to participants and contributors"))
         messages.add_message(request, messages.INFO, _("Successfully published %d courses.") % (len(selected_courses)))
@@ -219,7 +219,7 @@ def semester_contributor_ready(request, semester_id):
                 course.save()
                 selected_courses.append(course)
 
-        EmailTemplate.get_review_template().send_courses(selected_courses, send_to_editors=True)
+        EmailTemplate.get_review_template().send_to_users_in_courses(selected_courses, send_to_editors=True)
 
         messages.add_message(request, messages.INFO, _("Successfully marked %d courses as ready for lecturer review.") % (len(selected_courses)))
         return redirect('evap.fsr.views.semester_view', semester_id)


### PR DESCRIPTION
fixes #245.

this only fixes the case that a person is editor of a course and delegate/cc-user of the responsible. there are numerous edge cases that are not fixed, e.g. if he is a delegate of another editor, but being delegate and editor should be the most common case, all other cases are rather theoretical i think.

the actual change is one line, but i've come a long way here and did a bit of refactoring before settling for this simple solution.
