### PR TITLE
Fix #423: Create userprofile during login if it does not already exist

### DIFF
--- a/evap/evaluation/views.py
+++ b/evap/evaluation/views.py
@@ -50,6 +50,8 @@ def index(request):
 
         return render_to_response("index.html", dict(new_key_form=new_key_form, login_key_form=login_key_form, login_username_form=login_username_form), context_instance=RequestContext(request))
     else:
+        userprofile, _ = UserProfile.objects.get_or_create(user=request.user)
+
         # check for redirect variable
         redirect_to = request.GET.get("next", None)
         if redirect_to is not None:
@@ -57,7 +59,7 @@ def index(request):
                 if request.user.is_staff:
                     return redirect(redirect_to)
             elif redirect_to.startswith("/contributor/"):
-                if UserProfile.get_for_user(request.user).is_contributor:
+                if userprofile.is_contributor:
                     return redirect(redirect_to)
             else:
                 return redirect(redirect_to)
@@ -65,7 +67,7 @@ def index(request):
         # redirect user to appropriate start page
         if request.user.is_staff:
             return redirect('evap.fsr.views.index')
-        elif UserProfile.get_for_user(request.user).is_editor_or_delegate:
+        elif userprofile.is_editor_or_delegate:
             return redirect('evap.contributor.views.index')
         else:
             return redirect('evap.student.views.index')


### PR DESCRIPTION
Fixes #423.
This checks during login whether a UserProfile already exists and creates it if necessary.

I couldn't check whether it's working in the real environment with Kerberos authentication, but I manually deleted the UserProfile of a user and tried logging in. The UserProfile was created as expected.
