### PR TITLE
Replace nth-child with nth-of-type to correct voting colors on errors

### DIFF
--- a/evap/static/css/evap.css
+++ b/evap/static/css/evap.css
@@ -148,11 +148,11 @@ td.vote-inputs > div > label {
     font-weight: normal;
 }
 
-td.vote-inputs > div:nth-child(1) > label { color: #5f8634; }
-td.vote-inputs > div:nth-child(2) > label { color: #83933b; }
-td.vote-inputs > div:nth-child(3) > label { color: #a89f3e; }
-td.vote-inputs > div:nth-child(4) > label { color: #aa6f3e; }
-td.vote-inputs > div:nth-child(5) > label { color: #a53e3f; }
+td.vote-inputs > div:nth-of-type(1) > label { color: #5f8634; }
+td.vote-inputs > div:nth-of-type(2) > label { color: #83933b; }
+td.vote-inputs > div:nth-of-type(3) > label { color: #a89f3e; }
+td.vote-inputs > div:nth-of-type(4) > label { color: #aa6f3e; }
+td.vote-inputs > div:nth-of-type(5) > label { color: #a53e3f; }
 
 td.vote-inputs > textarea {
     width: 99%;


### PR DESCRIPTION
This fixes #418.

![errors](https://cloud.githubusercontent.com/assets/2820802/5061272/f731f51e-6d8d-11e4-942d-a9da674a469e.png)

The problem was that `div:nth-child(2)` selects the second child, but only if it is a `div`. This meant that an additional error moved all indices by one.
`div:nth-of-type(2)` selects the second element of type `div`, which is what we want. This might break if the vote input divs contain more divs, but I don't see a reason why we should do that.
