### PR TITLE
Fix disabled error codes being in the wrong parent in .prospector.yaml

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -21,7 +21,11 @@ pep8:
     - N806  # variable in function should be lowercase - lots of false positives, mostly Formset classes made from factories
     - N804  # first argument of a classmethod should be named 'cls' - one false positive and pylint does it better
     - E266  # too many leading '#' for block comment - that's used in settings on purpose
-    - F999  # prospector can not parse >python3.5
+pyflakes:
+  disable:
+    - F999  # python >3.5 triggers this
     - E701  # type annotations trigger this.
     - F403  # pylint handles this.
     - F401  # pylint handles this.
+pylint:
+  run: false # we run pylint on travis


### PR DESCRIPTION
In #1413 I put the new exceptions in the wrong linting tool parent, so these errors were still shown. 

Funnily enough, the very very great tool codacy doesn't even show you what linting tool inside prospector caused these, it just gives you a "Prospector_F999" (don't know whether this is their fault or an error in prospector).

On the [interblag](https://xkcd.com/181/), [some people put F999 inside the pyflakes section](https://github.com/readthedocs/pydoc.io/blob/master/prospector.yml). Let's see if this helps...

(Or maybe I'm just stupid - can you find out which tool causes this error?)
![image](https://user-images.githubusercontent.com/13838962/74250453-e833f980-4cea-11ea-8736-f1c514c0b5e0.png)

Related to #1092
