### PR TITLE
Update to Django 3.0

### DIFF
--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -5,7 +5,7 @@ from django import forms
 from django.conf import settings
 from django.db.models import Q
 from django.forms.widgets import CheckboxSelectMultiple
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from evap.evaluation.forms import UserModelMultipleChoiceField, UserModelChoiceField
 from evap.evaluation.models import Course, Evaluation, Questionnaire, UserProfile
 from evap.evaluation.tools import date_to_datetime

--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -31,7 +31,7 @@ class EvaluationForm(forms.ModelForm):
         self.fields['name_en_field'].initial = self.instance.full_name_en
 
         self.fields['general_questionnaires'].queryset = Questionnaire.objects.general_questionnaires().filter(
-            Q(visibility=Questionnaire.EDITORS) | Q(contributions__evaluation=self.instance)).distinct()
+            Q(visibility=Questionnaire.Visibility.EDITORS) | Q(contributions__evaluation=self.instance)).distinct()
 
         self.fields['vote_start_datetime'].localize = True
         self.fields['vote_end_date'].localize = True
@@ -71,7 +71,7 @@ class EditorContributionForm(ContributionForm):
         existing_contributor_pk = self.instance.contributor.pk if self.instance.contributor else None
 
         self.fields['questionnaires'].queryset = Questionnaire.objects.contributor_questionnaires().filter(
-            Q(visibility=Questionnaire.EDITORS) | Q(contributions__evaluation=self.evaluation)).distinct()
+            Q(visibility=Questionnaire.Visibility.EDITORS) | Q(contributions__evaluation=self.evaluation)).distinct()
         self.fields['contributor'].queryset = UserProfile.objects.filter(
             (Q(is_active=True) & Q(is_proxy_user=False)) | Q(pk=existing_contributor_pk)
         )

--- a/evap/contributor/tests/test_forms.py
+++ b/evap/contributor/tests/test_forms.py
@@ -40,10 +40,10 @@ class ContributionFormsetTests(TestCase):
             Regression test for #593.
         """
         evaluation = baker.make(Evaluation)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR, visibility=Questionnaire.EDITORS)
-        questionnaire_managers_only = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR, visibility=Questionnaire.MANAGERS)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR, visibility=Questionnaire.Visibility.EDITORS)
+        questionnaire_managers_only = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR, visibility=Questionnaire.Visibility.MANAGERS)
         # one hidden questionnaire that should never be shown
-        baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR, visibility=Questionnaire.HIDDEN)
+        baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR, visibility=Questionnaire.Visibility.HIDDEN)
 
         # just the normal questionnaire should be shown.
         contribution1 = baker.make(Contribution, evaluation=evaluation, contributor=baker.make(UserProfile), questionnaires=[])
@@ -103,9 +103,9 @@ class ContributionFormsetWebTests(WebTest):
         evaluation = baker.make(Evaluation, pk=1, state="prepared")
         user1 = baker.make(UserProfile)
         user2 = baker.make(UserProfile)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
-        contribution1 = baker.make(Contribution, evaluation=evaluation, contributor=user1, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS, questionnaires=[questionnaire], order=1)
-        contribution2 = baker.make(Contribution, evaluation=evaluation, contributor=user2, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS, questionnaires=[questionnaire], order=2)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
+        contribution1 = baker.make(Contribution, evaluation=evaluation, contributor=user1, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS, questionnaires=[questionnaire], order=1)
+        contribution2 = baker.make(Contribution, evaluation=evaluation, contributor=user2, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS, questionnaires=[questionnaire], order=2)
 
         # almost everything is missing in this set of data,
         # so we're guaranteed to have some errors

--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -18,7 +18,7 @@ class TestContributorDirectDelegationView(WebTest):
 
         cls.editor = baker.make(UserProfile)
         cls.non_editor = baker.make(UserProfile, email="a@b.c")
-        baker.make(Contribution, evaluation=cls.evaluation, contributor=cls.editor, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=cls.evaluation, contributor=cls.editor, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
 
     def test_direct_delegation_request(self):
         data = {"delegate_to": self.non_editor.id}

--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -5,7 +5,7 @@ from django.db.models import Max, Q
 from django.forms.models import inlineformset_factory
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
 from evap.contributor.forms import EvaluationForm, DelegatesForm, EditorContributionForm, DelegateSelectionForm

--- a/evap/evaluation/auth.py
+++ b/evap/evaluation/auth.py
@@ -4,7 +4,6 @@ import unicodedata
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.views import redirect_to_login
-from django.utils.decorators import available_attrs
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
 from evap.evaluation.models import UserProfile
@@ -40,7 +39,7 @@ def user_passes_test(test_func):
     that takes the user object and returns True if the user passes.
     """
     def decorator(view_func):
-        @wraps(view_func, assigned=available_attrs(view_func))
+        @wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):
             if not request.user.is_authenticated:
                 return redirect_to_login(request.get_full_path())

--- a/evap/evaluation/forms.py
+++ b/evap/evaluation/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth import authenticate
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.debug import sensitive_variables
 
 from evap.evaluation.models import UserProfile

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -18,7 +18,7 @@ from django.template import Context, Template
 from django.template.base import TemplateSyntaxError
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
 from django_fsm import FSMField, transition
 from django_fsm.signals import post_transition

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -123,24 +123,21 @@ class Semester(models.Model):
 
 class QuestionnaireManager(Manager):
     def general_questionnaires(self):
-        return super().get_queryset().exclude(type=Questionnaire.CONTRIBUTOR)
+        return super().get_queryset().exclude(type=Questionnaire.Type.CONTRIBUTOR)
 
     def contributor_questionnaires(self):
-        return super().get_queryset().filter(type=Questionnaire.CONTRIBUTOR)
+        return super().get_queryset().filter(type=Questionnaire.Type.CONTRIBUTOR)
 
 
 class Questionnaire(models.Model):
     """A named collection of questions."""
 
-    TOP = 10
-    CONTRIBUTOR = 20
-    BOTTOM = 30
-    TYPE_CHOICES = (
-        (TOP, _('Top questionnaire')),
-        (CONTRIBUTOR, _('Contributor questionnaire')),
-        (BOTTOM, _('Bottom questionnaire')),
-    )
-    type = models.IntegerField(choices=TYPE_CHOICES, verbose_name=_('type'), default=TOP)
+    class Type(models.IntegerChoices):
+        TOP = 10, _('Top questionnaire')
+        CONTRIBUTOR = 20, _('Contributor questionnaire')
+        BOTTOM = 30, _('Bottom questionnaire')
+
+    type = models.IntegerField(choices=Type.choices, verbose_name=_('type'), default=Type.TOP)
 
     name_de = models.CharField(max_length=1024, unique=True, verbose_name=_("name (german)"))
     name_en = models.CharField(max_length=1024, unique=True, verbose_name=_("name (english)"))
@@ -160,15 +157,12 @@ class Questionnaire(models.Model):
 
     order = models.IntegerField(verbose_name=_("ordering index"), default=0)
 
-    HIDDEN = 0
-    MANAGERS = 1
-    EDITORS = 2
-    VISIBILITY_CHOICES = (
-        (HIDDEN, _("Don't show")),
-        (MANAGERS, _("Managers only")),
-        (EDITORS, _("Managers and editors")),
-    )
-    visibility = models.IntegerField(choices=VISIBILITY_CHOICES, verbose_name=_('visibility'), default=MANAGERS)
+    class Visibility(models.IntegerChoices):
+        HIDDEN = 0, _("Don't show")
+        MANAGERS = 1, _("Managers only")
+        EDITORS = 2, _("Managers and editors")
+
+    visibility = models.IntegerField(choices=Visibility.choices, verbose_name=_('visibility'), default=Visibility.MANAGERS)
 
     objects = QuestionnaireManager()
 
@@ -188,11 +182,11 @@ class Questionnaire(models.Model):
 
     @property
     def is_above_contributors(self):
-        return self.type == self.TOP
+        return self.type == self.Type.TOP
 
     @property
     def is_below_contributors(self):
-        return self.type == self.BOTTOM
+        return self.type == self.Type.BOTTOM
 
     @property
     def can_be_edited_by_manager(self):
@@ -316,14 +310,14 @@ class Course(models.Model):
         # We think it's better to use the imported constant here instead of using some workaround
         # pylint: disable=import-outside-toplevel
         from evap.grades.models import GradeDocument
-        return self.grade_documents.filter(type=GradeDocument.FINAL_GRADES)
+        return self.grade_documents.filter(type=GradeDocument.Type.FINAL_GRADES)
 
     @property
     def midterm_grade_documents(self):
         # We think it's better to use the imported constant here instead of using some workaround
         # pylint: disable=import-outside-toplevel
         from evap.grades.models import GradeDocument
-        return self.grade_documents.filter(type=GradeDocument.MIDTERM_GRADES)
+        return self.grade_documents.filter(type=GradeDocument.Type.MIDTERM_GRADES)
 
     @cached_property
     def responsibles_names(self):
@@ -604,7 +598,7 @@ class Evaluation(models.Model):
         if not self.can_publish_text_results:
             self.textanswer_set.delete()
         else:
-            self.textanswer_set.filter(state=TextAnswer.HIDDEN).delete()
+            self.textanswer_set.filter(state=TextAnswer.State.HIDDEN).delete()
             self.textanswer_set.update(original_answer=None)
 
     @transition(field=state, source='published', target='reviewed')
@@ -680,11 +674,11 @@ class Evaluation(models.Model):
 
     @property
     def unreviewed_textanswer_set(self):
-        return self.textanswer_set.filter(state=TextAnswer.NOT_REVIEWED)
+        return self.textanswer_set.filter(state=TextAnswer.State.NOT_REVIEWED)
 
     @property
     def reviewed_textanswer_set(self):
-        return self.textanswer_set.exclude(state=TextAnswer.NOT_REVIEWED)
+        return self.textanswer_set.exclude(state=TextAnswer.State.NOT_REVIEWED)
 
     @cached_property
     def num_reviewed_textanswers(self):
@@ -719,7 +713,7 @@ class Evaluation(models.Model):
                 logger.exception('An error occured when updating the state of evaluation "{}" (id {}).'.format(evaluation, evaluation.id))
 
         template = EmailTemplate.objects.get(name=EmailTemplate.EVALUATION_STARTED)
-        template.send_to_users_in_evaluations(evaluations_new_in_evaluation, [EmailTemplate.ALL_PARTICIPANTS], use_cc=False, request=None)
+        template.send_to_users_in_evaluations(evaluations_new_in_evaluation, [EmailTemplate.Recipients.ALL_PARTICIPANTS], use_cc=False, request=None)
 
         EmailTemplate.send_participant_publish_notifications(evaluation_results_evaluations)
         EmailTemplate.send_contributor_publish_notifications(evaluation_results_evaluations)
@@ -749,24 +743,19 @@ def log_state_transition(instance, name, source, target, **_kwargs):
 class Contribution(models.Model):
     """A contributor who is assigned to an evaluation and his questionnaires."""
 
-    OWN_TEXTANSWERS = 'OWN'
-    GENERAL_TEXTANSWERS = 'GENERAL'
-    TEXTANSWER_VISIBILITY_CHOICES = (
-        (OWN_TEXTANSWERS, _('Own')),
-        (GENERAL_TEXTANSWERS, _('Own and general')),
-    )
-    IS_CONTRIBUTOR = 'CONTRIBUTOR'
-    IS_EDITOR = 'EDITOR'
-    RESPONSIBILITY_CHOICES = (
-        (IS_CONTRIBUTOR, _('Contributor')),
-        (IS_EDITOR, _('Editor')),
-    )
+    class TextAnswerVisibility(models.TextChoices):
+        OWN_TEXTANSWERS = 'OWN', _('Own')
+        GENERAL_TEXTANSWERS = 'GENERAL', _('Own and general')
+
+    class Responsibility(models.TextChoices):
+        IS_CONTRIBUTOR = 'CONTRIBUTOR', _('Contributor')
+        IS_EDITOR = 'EDITOR', _('Editor')
 
     evaluation = models.ForeignKey(Evaluation, models.CASCADE, verbose_name=_("evaluation"), related_name='contributions')
     contributor = models.ForeignKey(settings.AUTH_USER_MODEL, models.PROTECT, verbose_name=_("contributor"), blank=True, null=True, related_name='contributions')
     questionnaires = models.ManyToManyField(Questionnaire, verbose_name=_("questionnaires"), blank=True, related_name="contributions")
     can_edit = models.BooleanField(verbose_name=_("can edit"), default=False)
-    textanswer_visibility = models.CharField(max_length=10, choices=TEXTANSWER_VISIBILITY_CHOICES, verbose_name=_('text answer visibility'), default=OWN_TEXTANSWERS)
+    textanswer_visibility = models.CharField(max_length=10, choices=TextAnswerVisibility.choices, verbose_name=_('text answer visibility'), default=TextAnswerVisibility.OWN_TEXTANSWERS)
     label = models.CharField(max_length=255, blank=True, null=True, verbose_name=_("label"))
 
     order = models.IntegerField(verbose_name=_("contribution order"), default=-1)
@@ -1086,17 +1075,13 @@ class TextAnswer(Answer):
     answer = models.TextField(verbose_name=_("answer"))
     original_answer = models.TextField(verbose_name=_("original answer"), blank=True, null=True)
 
-    HIDDEN = 'HI'
-    PUBLISHED = 'PU'
-    PRIVATE = 'PR'
-    NOT_REVIEWED = 'NR'
-    TEXTANSWER_STATES = (
-        (HIDDEN, _('hidden')),
-        (PUBLISHED, _('published')),
-        (PRIVATE, _('private')),
-        (NOT_REVIEWED, _('not reviewed')),
-    )
-    state = models.CharField(max_length=2, choices=TEXTANSWER_STATES, verbose_name=_('state of answer'), default=NOT_REVIEWED)
+    class State(models.TextChoices):
+        HIDDEN = 'HI', _('hidden')
+        PUBLISHED = 'PU', _('published')
+        PRIVATE = 'PR', _('private')
+        NOT_REVIEWED = 'NR', _('not reviewed')
+
+    state = models.CharField(max_length=2, choices=State.choices, verbose_name=_('state of answer'), default=State.NOT_REVIEWED)
 
     class Meta:
         # Prevent ordering by date for privacy reasons. Otherwise, entries
@@ -1107,35 +1092,35 @@ class TextAnswer(Answer):
 
     @property
     def is_hidden(self):
-        return self.state == self.HIDDEN
+        return self.state == self.State.HIDDEN
 
     @property
     def is_private(self):
-        return self.state == self.PRIVATE
+        return self.state == self.State.PRIVATE
 
     @property
     def is_published(self):
-        return self.state == self.PUBLISHED
+        return self.state == self.State.PUBLISHED
 
     @property
     def is_reviewed(self):
-        return self.state != self.NOT_REVIEWED
+        return self.state != self.State.NOT_REVIEWED
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         assert self.answer != self.original_answer
 
     def publish(self):
-        self.state = self.PUBLISHED
+        self.state = self.State.PUBLISHED
 
     def hide(self):
-        self.state = self.HIDDEN
+        self.state = self.State.HIDDEN
 
     def make_private(self):
-        self.state = self.PRIVATE
+        self.state = self.State.PRIVATE
 
     def unreview(self):
-        self.state = self.NOT_REVIEWED
+        self.state = self.State.NOT_REVIEWED
 
 
 class FaqSection(models.Model):
@@ -1444,34 +1429,27 @@ class EmailTemplate(models.Model):
     EVALUATION_STARTED = "Evaluation Started"
     DIRECT_DELEGATION = "Direct Delegation"
 
-    ALL_PARTICIPANTS = 'all_participants'
-    DUE_PARTICIPANTS = 'due_participants'
-    RESPONSIBLE = 'responsible'
-    EDITORS = 'editors'
-    CONTRIBUTORS = 'contributors'
-
-    EMAIL_RECIPIENTS = (
-        (ALL_PARTICIPANTS, _('all participants')),
-        (DUE_PARTICIPANTS, _('due participants')),
-        (RESPONSIBLE, _('responsible person')),
-        (EDITORS, _('all editors')),
-        (CONTRIBUTORS, _('all contributors'))
-    )
+    class Recipients(models.TextChoices):
+        ALL_PARTICIPANTS = 'all_participants', _('all participants')
+        DUE_PARTICIPANTS = 'due_participants', _('due participants')
+        RESPONSIBLE = 'responsible', _('responsible person')
+        EDITORS = 'editors', _('all editors')
+        CONTRIBUTORS = 'contributors', _('all contributors')
 
     @classmethod
     def recipient_list_for_evaluation(cls, evaluation, recipient_groups, filter_users_in_cc):
         recipients = set()
 
-        if cls.CONTRIBUTORS in recipient_groups or cls.EDITORS in recipient_groups or cls.RESPONSIBLE in recipient_groups:
+        if cls.Recipients.CONTRIBUTORS in recipient_groups or cls.Recipients.EDITORS in recipient_groups or cls.Recipients.RESPONSIBLE in recipient_groups:
             recipients.update(evaluation.course.responsibles.all())
-            if cls.CONTRIBUTORS in recipient_groups:
+            if cls.Recipients.CONTRIBUTORS in recipient_groups:
                 recipients.update(UserProfile.objects.filter(contributions__evaluation=evaluation))
-            elif cls.EDITORS in recipient_groups:
+            elif cls.Recipients.EDITORS in recipient_groups:
                 recipients.update(UserProfile.objects.filter(contributions__evaluation=evaluation, contributions__can_edit=True))
 
-        if cls.ALL_PARTICIPANTS in recipient_groups:
+        if cls.Recipients.ALL_PARTICIPANTS in recipient_groups:
             recipients.update(evaluation.participants.all())
-        elif cls.DUE_PARTICIPANTS in recipient_groups:
+        elif cls.Recipients.DUE_PARTICIPANTS in recipient_groups:
             recipients.update(evaluation.due_participants)
 
         if filter_users_in_cc:

--- a/evap/evaluation/templatetags/evaluation_filters.py
+++ b/evap/evaluation/templatetags/evaluation_filters.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 from django.forms import TypedChoiceField
 from django.template import Library
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from evap.evaluation.models import BASE_UNIPOLAR_CHOICES
 from evap.rewards.tools import can_reward_points_be_used_by

--- a/evap/evaluation/tests/test_auth.py
+++ b/evap/evaluation/tests/test_auth.py
@@ -18,8 +18,8 @@ class LoginTests(WebTest):
         cls.inactive_external_user = baker.make(UserProfile, email="inactive@extern.com", is_active=False)
         cls.inactive_external_user.ensure_valid_login_key()
         evaluation = baker.make(Evaluation, state='published')
-        baker.make(Contribution, evaluation=evaluation, contributor=cls.external_user, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
-        baker.make(Contribution, evaluation=evaluation, contributor=cls.inactive_external_user, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=evaluation, contributor=cls.external_user, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=evaluation, contributor=cls.inactive_external_user, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
 
     @override_settings(PAGE_URL='https://example.com')
     def test_login_url_generation(self):

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -58,8 +58,8 @@ class TestAnonymizeCommand(TestCase):
             name_en="History of Unicode 😄",
         )
 
-        cls.contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
-        cls.general_questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        cls.contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
+        cls.general_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
 
         cls.contributor_questions = baker.make(Question, _quantity=10,
                 questionnaire=cls.contributor_questionnaire, type=cycle(iter(CHOICES.keys())))

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -23,13 +23,13 @@ class TestEvaluations(WebTest):
 
         with patch('evap.evaluation.models.EmailTemplate') as mock:
             mock.EVALUATION_STARTED = EmailTemplate.EVALUATION_STARTED
-            mock.ALL_PARTICIPANTS = EmailTemplate.ALL_PARTICIPANTS
+            mock.Recipients.ALL_PARTICIPANTS = EmailTemplate.Recipients.ALL_PARTICIPANTS
             mock.objects.get.return_value = mock
             Evaluation.update_evaluations()
 
         self.assertEqual(mock.objects.get.call_args_list[0][1]['name'], EmailTemplate.EVALUATION_STARTED)
         mock.send_to_users_in_evaluations.assert_called_once_with(
-            [evaluation], [EmailTemplate.ALL_PARTICIPANTS], use_cc=False, request=None
+            [evaluation], [EmailTemplate.Recipients.ALL_PARTICIPANTS], use_cc=False, request=None
         )
 
         evaluation = Evaluation.objects.get(pk=evaluation.pk)
@@ -136,7 +136,7 @@ class TestEvaluations(WebTest):
 
         editor_contribution = baker.make(
                 Contribution, evaluation=evaluation, contributor=baker.make(UserProfile),
-                can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+                can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         evaluation = Evaluation.objects.get()
         self.assertFalse(evaluation.general_contribution_has_questionnaires)
         self.assertFalse(evaluation.all_contributions_have_questionnaires)
@@ -165,7 +165,7 @@ class TestEvaluations(WebTest):
         responsible = baker.make(UserProfile)
         evaluation = baker.make(Evaluation, is_single_result=True)
         contribution = baker.make(Contribution,
-            evaluation=evaluation, contributor=responsible, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS,
+            evaluation=evaluation, contributor=responsible, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             questionnaires=[Questionnaire.single_result_questionnaire()]
         )
         baker.make(RatingAnswerCounter, answer=1, count=1, question=Questionnaire.single_result_questionnaire().questions.first(), contribution=contribution)
@@ -189,7 +189,7 @@ class TestEvaluations(WebTest):
         responsible = baker.make(UserProfile)
         single_result = baker.make(Evaluation, is_single_result=True, _participant_count=5, _voter_count=5)
         contribution = baker.make(Contribution,
-            evaluation=single_result, contributor=responsible, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS,
+            evaluation=single_result, contributor=responsible, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             questionnaires=[Questionnaire.single_result_questionnaire()]
         )
         baker.make(RatingAnswerCounter, answer=1, count=1, question=Questionnaire.single_result_questionnaire().questions.first(), contribution=contribution)
@@ -202,7 +202,7 @@ class TestEvaluations(WebTest):
         student2 = baker.make(UserProfile)
         evaluation = baker.make(Evaluation, participants=[student1, student2], voters=[student1], state="in_evaluation")
         evaluation.save()
-        top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         baker.make(Question, questionnaire=top_general_questionnaire, type=Question.LIKERT)
         evaluation.general_contribution.questionnaires.set([top_general_questionnaire])
 
@@ -216,7 +216,7 @@ class TestEvaluations(WebTest):
     def test_textanswers_get_deleted_if_they_cannot_be_published(self):
         student = baker.make(UserProfile)
         evaluation = baker.make(Evaluation, state='reviewed', participants=[student], voters=[student], can_publish_text_results=False)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         question = baker.make(Question, type=Question.TEXT, questionnaire=questionnaire)
         evaluation.general_contribution.questionnaires.set([questionnaire])
         baker.make(TextAnswer, question=question, contribution=evaluation.general_contribution)
@@ -229,7 +229,7 @@ class TestEvaluations(WebTest):
         student = baker.make(UserProfile)
         student2 = baker.make(UserProfile)
         evaluation = baker.make(Evaluation, state='reviewed', participants=[student, student2], voters=[student, student2], can_publish_text_results=True)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         question = baker.make(Question, type=Question.TEXT, questionnaire=questionnaire)
         evaluation.general_contribution.questionnaires.set([questionnaire])
         baker.make(TextAnswer, question=question, contribution=evaluation.general_contribution)
@@ -242,12 +242,12 @@ class TestEvaluations(WebTest):
         student = baker.make(UserProfile)
         student2 = baker.make(UserProfile)
         evaluation = baker.make(Evaluation, state='reviewed', participants=[student, student2], voters=[student, student2], can_publish_text_results=True)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         question = baker.make(Question, type=Question.TEXT, questionnaire=questionnaire)
         evaluation.general_contribution.questionnaires.set([questionnaire])
-        baker.make(TextAnswer, question=question, contribution=evaluation.general_contribution, answer="hidden", state=TextAnswer.HIDDEN)
-        baker.make(TextAnswer, question=question, contribution=evaluation.general_contribution, answer="published", state=TextAnswer.PUBLISHED)
-        baker.make(TextAnswer, question=question, contribution=evaluation.general_contribution, answer="private", state=TextAnswer.PRIVATE)
+        baker.make(TextAnswer, question=question, contribution=evaluation.general_contribution, answer="hidden", state=TextAnswer.State.HIDDEN)
+        baker.make(TextAnswer, question=question, contribution=evaluation.general_contribution, answer="published", state=TextAnswer.State.PUBLISHED)
+        baker.make(TextAnswer, question=question, contribution=evaluation.general_contribution, answer="private", state=TextAnswer.State.PRIVATE)
 
         self.assertEqual(evaluation.textanswer_set.count(), 3)
         evaluation.publish()
@@ -258,10 +258,10 @@ class TestEvaluations(WebTest):
         student = baker.make(UserProfile)
         student2 = baker.make(UserProfile)
         evaluation = baker.make(Evaluation, state='reviewed', participants=[student, student2], voters=[student, student2], can_publish_text_results=True)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         question = baker.make(Question, type=Question.TEXT, questionnaire=questionnaire)
         evaluation.general_contribution.questionnaires.set([questionnaire])
-        baker.make(TextAnswer, question=question, contribution=evaluation.general_contribution, answer="published answer", original_answer="original answer", state=TextAnswer.PUBLISHED)
+        baker.make(TextAnswer, question=question, contribution=evaluation.general_contribution, answer="published answer", original_answer="original answer", state=TextAnswer.State.PUBLISHED)
 
         self.assertEqual(evaluation.textanswer_set.count(), 1)
         self.assertFalse(TextAnswer.objects.get().original_answer is None)
@@ -482,7 +482,7 @@ class ParticipationArchivingTests(TestCase):
     def test_archiving_participations_doesnt_change_single_results_participant_count(self):
         responsible = baker.make(UserProfile)
         evaluation = baker.make(Evaluation, state="published", is_single_result=True, _participant_count=5, _voter_count=5)
-        contribution = baker.make(Contribution, evaluation=evaluation, contributor=responsible, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        contribution = baker.make(Contribution, evaluation=evaluation, contributor=responsible, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         contribution.questionnaires.add(Questionnaire.single_result_questionnaire())
 
         evaluation.course.semester.archive_participations()
@@ -499,7 +499,7 @@ class TestLoginUrlEmail(TestCase):
         cls.user.ensure_valid_login_key()
 
         cls.evaluation = baker.make(Evaluation)
-        baker.make(Contribution, evaluation=cls.evaluation, contributor=cls.user, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=cls.evaluation, contributor=cls.user, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
 
         cls.template = baker.make(EmailTemplate, body="{{ login_url }}")
 
@@ -508,7 +508,7 @@ class TestLoginUrlEmail(TestCase):
     @override_settings(PAGE_URL="https://example.com")
     def test_no_login_url_when_delegates_in_cc(self):
         self.user.delegates.add(self.other_user)
-        self.template.send_to_users_in_evaluations([self.evaluation], EmailTemplate.CONTRIBUTORS, use_cc=True, request=None)
+        self.template.send_to_users_in_evaluations([self.evaluation], EmailTemplate.Recipients.CONTRIBUTORS, use_cc=True, request=None)
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(mail.outbox[0].body, "")  # message does not contain the login url
         self.assertEqual(mail.outbox[1].body, self.user.login_url)  # separate email with login url was sent
@@ -517,7 +517,7 @@ class TestLoginUrlEmail(TestCase):
 
     def test_no_login_url_when_cc_users_in_cc(self):
         self.user.cc_users.add(self.other_user)
-        self.template.send_to_users_in_evaluations([self.evaluation], [EmailTemplate.CONTRIBUTORS], use_cc=True, request=None)
+        self.template.send_to_users_in_evaluations([self.evaluation], [EmailTemplate.Recipients.CONTRIBUTORS], use_cc=True, request=None)
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(mail.outbox[0].body, "")  # message does not contain the login url
         self.assertEqual(mail.outbox[1].body, self.user.login_url)  # separate email with login url was sent
@@ -526,14 +526,14 @@ class TestLoginUrlEmail(TestCase):
 
     def test_login_url_when_nobody_in_cc(self):
         # message is not sent to others in cc
-        self.template.send_to_users_in_evaluations([self.evaluation], [EmailTemplate.CONTRIBUTORS], use_cc=True, request=None)
+        self.template.send_to_users_in_evaluations([self.evaluation], [EmailTemplate.Recipients.CONTRIBUTORS], use_cc=True, request=None)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].body, self.user.login_url)  # message does contain the login url
 
     def test_login_url_when_use_cc_is_false(self):
         # message is not sent to others in cc
         self.user.delegates.add(self.other_user)
-        self.template.send_to_users_in_evaluations([self.evaluation], [EmailTemplate.CONTRIBUTORS], use_cc=False, request=None)
+        self.template.send_to_users_in_evaluations([self.evaluation], [EmailTemplate.Recipients.CONTRIBUTORS], use_cc=False, request=None)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].body, self.user.login_url)  # message does contain the login url
 
@@ -636,19 +636,19 @@ class TestEmailRecipientList(TestCase):
         recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [], filter_users_in_cc=False)
         self.assertCountEqual(recipient_list, [])
 
-        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.RESPONSIBLE], filter_users_in_cc=False)
+        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.Recipients.RESPONSIBLE], filter_users_in_cc=False)
         self.assertCountEqual(recipient_list, [responsible])
 
-        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.EDITORS], filter_users_in_cc=False)
+        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.Recipients.EDITORS], filter_users_in_cc=False)
         self.assertCountEqual(recipient_list, [responsible, editor])
 
-        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.CONTRIBUTORS], filter_users_in_cc=False)
+        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.Recipients.CONTRIBUTORS], filter_users_in_cc=False)
         self.assertCountEqual(recipient_list, [responsible, editor, contributor])
 
-        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.ALL_PARTICIPANTS], filter_users_in_cc=False)
+        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.Recipients.ALL_PARTICIPANTS], filter_users_in_cc=False)
         self.assertCountEqual(recipient_list, [participant1, participant2])
 
-        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.DUE_PARTICIPANTS], filter_users_in_cc=False)
+        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.Recipients.DUE_PARTICIPANTS], filter_users_in_cc=False)
         self.assertCountEqual(recipient_list, [participant2])
 
     def test_recipient_list_filtering(self):
@@ -661,21 +661,21 @@ class TestEmailRecipientList(TestCase):
         baker.make(Contribution, evaluation=evaluation, contributor=contributor2)
 
         # no-one should get filtered.
-        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.CONTRIBUTORS], filter_users_in_cc=False)
+        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.Recipients.CONTRIBUTORS], filter_users_in_cc=False)
         self.assertCountEqual(recipient_list, [contributor1, contributor2])
 
         # contributor1 is in cc of contributor2 and gets filtered.
-        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.CONTRIBUTORS], filter_users_in_cc=True)
+        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.Recipients.CONTRIBUTORS], filter_users_in_cc=True)
         self.assertCountEqual(recipient_list, [contributor2])
 
         contributor3 = baker.make(UserProfile, delegates=[contributor2])
         baker.make(Contribution, evaluation=evaluation, contributor=contributor3)
 
         # again, no-one should get filtered.
-        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.CONTRIBUTORS], filter_users_in_cc=False)
+        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.Recipients.CONTRIBUTORS], filter_users_in_cc=False)
         self.assertCountEqual(recipient_list, [contributor1, contributor2, contributor3])
 
         # contributor1 is in cc of contributor2 and gets filtered.
         # contributor2 is in cc of contributor3 but is not filtered since contributor1 wouldn't get an email at all then.
-        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.CONTRIBUTORS], filter_users_in_cc=True)
+        recipient_list = EmailTemplate.recipient_list_for_evaluation(evaluation, [EmailTemplate.Recipients.CONTRIBUTORS], filter_users_in_cc=True)
         self.assertCountEqual(recipient_list, [contributor2, contributor3])

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -78,7 +78,7 @@ def create_evaluation_with_responsible_and_editor(evaluation_id=None):
         evaluation_params['id'] = evaluation_id
 
     evaluation = baker.make(Evaluation, **evaluation_params)
-    baker.make(Contribution, evaluation=evaluation, contributor=editor, can_edit=True, questionnaires=[baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)])
-    evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire, type=Questionnaire.TOP)])
+    baker.make(Contribution, evaluation=evaluation, contributor=editor, can_edit=True, questionnaires=[baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)])
+    evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire, type=Questionnaire.Type.TOP)])
 
     return evaluation

--- a/evap/evaluation/views.py
+++ b/evap/evaluation/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.mail import EmailMessage
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect, render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.i18n import set_language

--- a/evap/grades/forms.py
+++ b/evap/grades/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.core.exceptions import ValidationError
 
 from evap.grades.models import GradeDocument

--- a/evap/grades/models.py
+++ b/evap/grades/models.py
@@ -2,7 +2,7 @@ import os
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.db.models.signals import pre_delete, pre_save
 from django.dispatch.dispatcher import receiver
 

--- a/evap/grades/models.py
+++ b/evap/grades/models.py
@@ -18,13 +18,11 @@ class GradeDocument(models.Model):
     course = models.ForeignKey(Course, models.PROTECT, related_name='grade_documents', verbose_name=_("course"))
     file = models.FileField(upload_to=helper_upload_path, verbose_name=_("File"))  # upload_to="grades/{}/".format(course.id),
 
-    MIDTERM_GRADES = 'MID'
-    FINAL_GRADES = 'FIN'
-    GRADE_DOCUMENT_TYPES = (
-        (MIDTERM_GRADES, _('midterm grades')),
-        (FINAL_GRADES, _('final grades')),
-    )
-    type = models.CharField(max_length=3, choices=GRADE_DOCUMENT_TYPES, verbose_name=_('grade type'), default=MIDTERM_GRADES)
+    class Type(models.TextChoices):
+        MIDTERM_GRADES = 'MID', _('midterm grades')
+        FINAL_GRADES = 'FIN', _('final grades')
+
+    type = models.CharField(max_length=3, choices=Type.choices, verbose_name=_('grade type'), default=Type.MIDTERM_GRADES)
 
     description_de = models.CharField(max_length=255, verbose_name=_("description (german)"))
     description_en = models.CharField(max_length=255, verbose_name=_("description (english)"))

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -32,8 +32,8 @@ class GradeUploadTest(WebTest):
         )
 
         contribution = baker.make(Contribution, evaluation=cls.evaluation, contributor=editor, can_edit=True,
-                                  textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
-        contribution.questionnaires.set([baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)])
+                                  textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
+        contribution.questionnaires.set([baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)])
 
         cls.evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
 
@@ -135,9 +135,9 @@ class GradeUploadTest(WebTest):
             voters=[self.student, self.student2]
         )
         contribution = Contribution(evaluation=evaluation, contributor=UserProfile.objects.get(username="editor"),
-                                    can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+                                    can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         contribution.save()
-        contribution.questionnaires.set([baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)])
+        contribution.questionnaires.set([baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)])
 
         evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
 

--- a/evap/grades/views.py
+++ b/evap/grades/views.py
@@ -2,11 +2,11 @@ from django.shortcuts import get_object_or_404, render, redirect
 from django.core.exceptions import PermissionDenied
 from django.contrib import messages
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.http import HttpResponse
 from django.views.decorators.http import require_POST, require_GET
 
-from sendfile import sendfile
+from django_sendfile import sendfile
 
 from evap.evaluation.auth import grade_publisher_required, grade_downloader_required, grade_publisher_or_manager_required
 from evap.evaluation.models import Course, Semester, EmailTemplate

--- a/evap/grades/views.py
+++ b/evap/grades/views.py
@@ -83,11 +83,11 @@ def upload_grades(request, semester_id, course_id):
 
     grade_document = GradeDocument(course=course)
     if final_grades:
-        grade_document.type = GradeDocument.FINAL_GRADES
+        grade_document.type = GradeDocument.Type.FINAL_GRADES
         grade_document.description_en = settings.DEFAULT_FINAL_GRADES_DESCRIPTION_EN
         grade_document.description_de = settings.DEFAULT_FINAL_GRADES_DESCRIPTION_DE
     else:
-        grade_document.type = GradeDocument.MIDTERM_GRADES
+        grade_document.type = GradeDocument.Type.MIDTERM_GRADES
         grade_document.description_en = settings.DEFAULT_MIDTERM_GRADES_DESCRIPTION_EN
         grade_document.description_de = settings.DEFAULT_MIDTERM_GRADES_DESCRIPTION_DE
 

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from django.db.models import Q
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import xlwt
 

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -161,7 +161,7 @@ class ExcelExporter():
                 self.write_empty_cell_with_borders()
 
             for questionnaire in used_questionnaires:
-                if contributor and questionnaire.type == Questionnaire.CONTRIBUTOR:
+                if contributor and questionnaire.type == Questionnaire.Type.CONTRIBUTOR:
                     writen(self, "{} ({})".format(questionnaire.name, contributor.full_name), "bold")
                 else:
                     writen(self, questionnaire.name, "bold")

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -37,10 +37,10 @@ class TestExporters(TestCase):
             _voter_count=2
         )
 
-        questionnaire_1 = baker.make(Questionnaire, order=1, type=Questionnaire.TOP)
-        questionnaire_2 = baker.make(Questionnaire, order=4, type=Questionnaire.TOP)
-        questionnaire_3 = baker.make(Questionnaire, order=1, type=Questionnaire.BOTTOM)
-        questionnaire_4 = baker.make(Questionnaire, order=4, type=Questionnaire.BOTTOM)
+        questionnaire_1 = baker.make(Questionnaire, order=1, type=Questionnaire.Type.TOP)
+        questionnaire_2 = baker.make(Questionnaire, order=4, type=Questionnaire.Type.TOP)
+        questionnaire_3 = baker.make(Questionnaire, order=1, type=Questionnaire.Type.BOTTOM)
+        questionnaire_4 = baker.make(Questionnaire, order=4, type=Questionnaire.Type.BOTTOM)
 
         question_1 = baker.make(Question, type=Question.LIKERT, questionnaire=questionnaire_1)
         question_2 = baker.make(Question, type=Question.LIKERT, questionnaire=questionnaire_2)
@@ -220,8 +220,8 @@ class TestExporters(TestCase):
         contribution = baker.make(Contribution, evaluation=evaluation_2, contributor=contributor)
         other_contribution = baker.make(Contribution, evaluation=evaluation_2, contributor=other_contributor)
 
-        general_questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
-        contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
+        general_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
+        contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
         general_question = baker.make(Question, type=Question.LIKERT, questionnaire=general_questionnaire)
         contributor_question = baker.make(Question, type=Question.LIKERT, questionnaire=contributor_questionnaire)
 

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -216,7 +216,7 @@ class TestCalculateAverageDistribution(TestCase):
     def test_get_single_result_rating_result(self):
         single_result_evaluation = baker.make(Evaluation, state='published', is_single_result=True)
         questionnaire = Questionnaire.objects.get(name_en=Questionnaire.SINGLE_RESULT_QUESTIONNAIRE_NAME)
-        contribution = baker.make(Contribution, contributor=baker.make(UserProfile), evaluation=single_result_evaluation, questionnaires=[questionnaire], can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        contribution = baker.make(Contribution, contributor=baker.make(UserProfile), evaluation=single_result_evaluation, questionnaires=[questionnaire], can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         baker.make(RatingAnswerCounter, question=questionnaire.questions.first(), contribution=contribution, answer=1, count=1)
         baker.make(RatingAnswerCounter, question=questionnaire.questions.first(), contribution=contribution, answer=4, count=1)
         distribution = calculate_average_distribution(single_result_evaluation)
@@ -332,18 +332,18 @@ class TestTextAnswerVisibilityInfo(TestCase):
         cls.general_contribution = cls.evaluation.general_contribution
         cls.general_contribution.questionnaires.set([cls.questionnaire])
         cls.responsible1_contribution = baker.make(Contribution, contributor=cls.responsible1, evaluation=cls.evaluation,
-            questionnaires=[cls.questionnaire], can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+            questionnaires=[cls.questionnaire], can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         cls.responsible2_contribution = baker.make(Contribution, contributor=cls.responsible2, evaluation=cls.evaluation,
-            questionnaires=[cls.questionnaire], can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+            questionnaires=[cls.questionnaire], can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         cls.contributor_own_contribution = baker.make(Contribution, contributor=cls.contributor_own, evaluation=cls.evaluation,
-            questionnaires=[cls.questionnaire], textanswer_visibility=Contribution.OWN_TEXTANSWERS)
+            questionnaires=[cls.questionnaire], textanswer_visibility=Contribution.TextAnswerVisibility.OWN_TEXTANSWERS)
         cls.contributor_general_contribution = baker.make(Contribution, contributor=cls.contributor_general, evaluation=cls.evaluation,
-            questionnaires=[cls.questionnaire], textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
-        cls.general_contribution_textanswer = baker.make(TextAnswer, question=cls.question, contribution=cls.general_contribution, state=TextAnswer.PUBLISHED)
-        cls.responsible1_textanswer = baker.make(TextAnswer, question=cls.question, contribution=cls.responsible1_contribution, state=TextAnswer.PUBLISHED)
-        cls.responsible2_textanswer = baker.make(TextAnswer, question=cls.question, contribution=cls.responsible2_contribution, state=TextAnswer.PUBLISHED)
-        cls.contributor_own_textanswer = baker.make(TextAnswer, question=cls.question, contribution=cls.contributor_own_contribution, state=TextAnswer.PUBLISHED)
-        cls.contributor_general_textanswer = baker.make(TextAnswer, question=cls.question, contribution=cls.contributor_general_contribution, state=TextAnswer.PUBLISHED)
+            questionnaires=[cls.questionnaire], textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
+        cls.general_contribution_textanswer = baker.make(TextAnswer, question=cls.question, contribution=cls.general_contribution, state=TextAnswer.State.PUBLISHED)
+        cls.responsible1_textanswer = baker.make(TextAnswer, question=cls.question, contribution=cls.responsible1_contribution, state=TextAnswer.State.PUBLISHED)
+        cls.responsible2_textanswer = baker.make(TextAnswer, question=cls.question, contribution=cls.responsible2_contribution, state=TextAnswer.State.PUBLISHED)
+        cls.contributor_own_textanswer = baker.make(TextAnswer, question=cls.question, contribution=cls.contributor_own_contribution, state=TextAnswer.State.PUBLISHED)
+        cls.contributor_general_textanswer = baker.make(TextAnswer, question=cls.question, contribution=cls.contributor_general_contribution, state=TextAnswer.State.PUBLISHED)
 
     def test_text_answer_visible_to_non_contributing_responsible(self):
         self.assertIn(self.responsible_without_contribution, textanswers_visible_to(self.general_contribution_textanswer.contribution)[0])

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -163,13 +163,13 @@ class TestResultsSemesterEvaluationDetailView(WebTestWith200Check):
         # Normal evaluation with responsible and contributor.
         cls.evaluation = baker.make(Evaluation, id=21, state='published', course=baker.make(Course, semester=cls.semester))
 
-        baker.make(Contribution, evaluation=cls.evaluation, contributor=responsible, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=cls.evaluation, contributor=responsible, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         cls.contribution = baker.make(Contribution, evaluation=cls.evaluation, contributor=contributor, can_edit=True)
 
     def test_questionnaire_ordering(self):
-        top_questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
-        contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
-        bottom_questionnaire = baker.make(Questionnaire, type=Questionnaire.BOTTOM)
+        top_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
+        contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
+        bottom_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.BOTTOM)
 
         top_heading_question = baker.make(Question, type=Question.HEADING, questionnaire=top_questionnaire, order=0)
         top_likert_question = baker.make(Question, type=Question.LIKERT, questionnaire=top_questionnaire, order=1)
@@ -317,7 +317,7 @@ class TestResultsSemesterEvaluationDetailViewPrivateEvaluation(WebTest):
         course = baker.make(Course, semester=semester, degrees=[degree], is_private=True, responsibles=[responsible, responsible_contributor])
         private_evaluation = baker.make(Evaluation, course=course, state='published', participants=[student, student_external, test1, test2], voters=[test1, test2])
         private_evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
-        baker.make(Contribution, evaluation=private_evaluation, contributor=responsible_contributor, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=private_evaluation, contributor=responsible_contributor, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         baker.make(Contribution, evaluation=private_evaluation, contributor=contributor, can_edit=True)
 
         url = '/results/'
@@ -516,11 +516,11 @@ class TestResultsOtherContributorsListOnExportView(WebTest):
         baker.make(Question, questionnaire=questionnaire, type=Question.LIKERT)
         cls.evaluation.general_contribution.questionnaires.set([questionnaire])
 
-        baker.make(Contribution, evaluation=cls.evaluation, contributor=responsible, questionnaires=[questionnaire], can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=cls.evaluation, contributor=responsible, questionnaires=[questionnaire], can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         cls.other_contributor_1 = baker.make(UserProfile, username='other contributor 1')
-        baker.make(Contribution, evaluation=cls.evaluation, contributor=cls.other_contributor_1, questionnaires=[questionnaire], textanswer_visibility=Contribution.OWN_TEXTANSWERS)
+        baker.make(Contribution, evaluation=cls.evaluation, contributor=cls.other_contributor_1, questionnaires=[questionnaire], textanswer_visibility=Contribution.TextAnswerVisibility.OWN_TEXTANSWERS)
         cls.other_contributor_2 = baker.make(UserProfile, username='other contributor 2')
-        baker.make(Contribution, evaluation=cls.evaluation, contributor=cls.other_contributor_2, questionnaires=[questionnaire], textanswer_visibility=Contribution.OWN_TEXTANSWERS)
+        baker.make(Contribution, evaluation=cls.evaluation, contributor=cls.other_contributor_2, questionnaires=[questionnaire], textanswer_visibility=Contribution.TextAnswerVisibility.OWN_TEXTANSWERS)
 
     def test_contributor_list(self):
         url = '/results/semester/{}/evaluation/{}?view=export'.format(self.semester.id, self.evaluation.id)
@@ -668,7 +668,7 @@ class TestArchivedResults(WebTest):
         course = baker.make(Course, semester=cls.semester, degrees=[baker.make(Degree)], responsibles=[responsible])
         cls.evaluation = baker.make(Evaluation, course=course, state='published', participants=[student, student_external], voters=[student, student_external])
         cls.evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
-        cls.contribution = baker.make(Contribution, evaluation=cls.evaluation, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS, contributor=responsible)
+        cls.contribution = baker.make(Contribution, evaluation=cls.evaluation, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS, contributor=responsible)
         cls.contribution = baker.make(Contribution, evaluation=cls.evaluation, contributor=contributor)
 
     @patch('evap.results.templatetags.results_templatetags.get_grade_color', new=lambda x: (0, 0, 0))

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -150,7 +150,7 @@ def _collect_results_impl(evaluation):
                         answer_counters = None
                     results.append(RatingResult(question, answer_counters))
                 elif question.is_text_question and evaluation.can_publish_text_results:
-                    answers = TextAnswer.objects.filter(contribution=contribution, question=question, state__in=[TextAnswer.PRIVATE, TextAnswer.PUBLISHED])
+                    answers = TextAnswer.objects.filter(contribution=contribution, question=question, state__in=[TextAnswer.State.PRIVATE, TextAnswer.State.PUBLISHED])
                     results.append(TextResult(question=question, answers=answers, answers_visible_to=textanswers_visible_to(contribution)))
                 elif question.is_heading_question:
                     results.append(HeadingResult(question=question))
@@ -291,7 +291,7 @@ def get_grade_color(grade):
 def textanswers_visible_to(contribution):
     if contribution.is_general:
         contributors = UserProfile.objects.filter(
-            Q(contributions__evaluation=contribution.evaluation, contributions__textanswer_visibility=Contribution.GENERAL_TEXTANSWERS) |
+            Q(contributions__evaluation=contribution.evaluation, contributions__textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS) |
             Q(courses_responsible_for__in=[contribution.evaluation.course])
         ).distinct().order_by('last_name', 'first_name')
     else:
@@ -303,7 +303,7 @@ def textanswers_visible_to(contribution):
 
 def can_textanswer_be_seen_by(user, represented_users, textanswer, view):
     # pylint: disable=too-many-return-statements
-    assert textanswer.state in [TextAnswer.PRIVATE, TextAnswer.PUBLISHED]
+    assert textanswer.state in [TextAnswer.State.PRIVATE, TextAnswer.State.PUBLISHED]
     contributor = textanswer.contribution.contributor
 
     if view == 'public':
@@ -329,7 +329,7 @@ def can_textanswer_be_seen_by(user, represented_users, textanswer, view):
         # users can see text answers from general contributions if one of their represented users has text answer
         # visibility GENERAL_TEXTANSWERS for the evaluation
         if textanswer.contribution.is_general and textanswer.contribution.evaluation.contributions.filter(
-                contributor__in=represented_users, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS).exists():
+                contributor__in=represented_users, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS).exists():
             return True
         # the people responsible for a course can see all general text answers for all its evaluations
         if textanswer.contribution.is_general and any(user in represented_users for user in textanswer.contribution.evaluation.course.responsibles.all()):

--- a/evap/rewards/exporters.py
+++ b/evap/rewards/exporters.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import xlwt
 

--- a/evap/rewards/models.py
+++ b/evap/rewards/models.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.dispatch import Signal
 from django.db import models
 

--- a/evap/rewards/tools.py
+++ b/evap/rewards/tools.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.db import models, transaction
 from django.db.models import Sum
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
 from django.dispatch import receiver
 from django.contrib.auth.decorators import login_required

--- a/evap/rewards/views.py
+++ b/evap/rewards/views.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.translation import get_language
 from django.http import HttpResponse
 from django.views.decorators.http import require_POST

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -336,8 +336,8 @@ COMPRESS_CACHEABLE_PRECOMPILERS = ('text/x-scss',)
 MEDIA_ROOT = os.path.join(BASE_DIR, "upload")
 
 # the backend used for downloading attachments
-# see https://github.com/johnsensible/django-sendfile for further information
-SENDFILE_BACKEND = 'sendfile.backends.simple'
+# see https://github.com/moggers87/django-sendfile2 for further information
+SENDFILE_BACKEND = 'django_sendfile.backends.simple'
 
 
 ### Slogans

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -8,7 +8,7 @@ from django.forms.models import BaseInlineFormSet
 from django.forms.widgets import CheckboxSelectMultiple
 from django.http.request import QueryDict
 from django.utils.text import normalize_newlines
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from evap.evaluation.forms import UserModelChoiceField, UserModelMultipleChoiceField
 from evap.evaluation.models import (Contribution, Course, CourseType, Degree, EmailTemplate, Evaluation, FaqQuestion,
                                     FaqSection, Question, Questionnaire, RatingAnswerCounter, Semester, TextAnswer,

--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -112,7 +112,7 @@ class EvaluationData(CommonEqualityMixin):
             course=course,
         )
         evaluation.save()
-        evaluation.contributions.create(contributor=responsible_dbobj, evaluation=evaluation, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        evaluation.contributions.create(contributor=responsible_dbobj, evaluation=evaluation, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
 
 
 class ExcelImporter():

--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -4,7 +4,7 @@ import xlrd
 from django.conf import settings
 from django.db import transaction
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy, ugettext as _
+from django.utils.translation import gettext_lazy, gettext as _
 from django.core.exceptions import ValidationError
 
 from evap.evaluation.models import Contribution, Course, CourseType, Degree, Evaluation, UserProfile
@@ -581,11 +581,11 @@ class PersonImporter:
 
 # Dictionary to translate internal keys to UI strings.
 WARNING_DESCRIPTIONS = {
-    ExcelImporter.W_NAME: ugettext_lazy("Name mismatches"),
-    ExcelImporter.W_INACTIVE: ugettext_lazy("Inactive users"),
-    ExcelImporter.W_DUPL: ugettext_lazy("Possible duplicates"),
-    ExcelImporter.W_IGNORED: ugettext_lazy("Ignored duplicates"),
-    ExcelImporter.W_GENERAL: ugettext_lazy("General warnings"),
-    EnrollmentImporter.W_DEGREE: ugettext_lazy("Degree mismatches"),
-    EnrollmentImporter.W_MANY: ugettext_lazy("Unusually high number of enrollments")
+    ExcelImporter.W_NAME: gettext_lazy("Name mismatches"),
+    ExcelImporter.W_INACTIVE: gettext_lazy("Inactive users"),
+    ExcelImporter.W_DUPL: gettext_lazy("Possible duplicates"),
+    ExcelImporter.W_IGNORED: gettext_lazy("Ignored duplicates"),
+    ExcelImporter.W_GENERAL: gettext_lazy("General warnings"),
+    EnrollmentImporter.W_DEGREE: gettext_lazy("Degree mismatches"),
+    EnrollmentImporter.W_MANY: gettext_lazy("Unusually high number of enrollments")
 }

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -14,7 +14,7 @@ from evap.contributor.forms import EvaluationForm as ContributorEvaluationForm
 
 class QuestionnaireFormTest(TestCase):
     def test_force_highest_order(self):
-        baker.make(Questionnaire, order=45, type=Questionnaire.TOP)
+        baker.make(Questionnaire, order=45, type=Questionnaire.Type.TOP)
 
         question = baker.make(Question)
 
@@ -27,7 +27,7 @@ class QuestionnaireFormTest(TestCase):
             'public_name_de': 'A german display name',
             'questions-0-id': question.id,
             'order': 0,
-            'type': Questionnaire.TOP,
+            'type': Questionnaire.Type.TOP,
             'visibility': 2,
         }
 
@@ -37,9 +37,9 @@ class QuestionnaireFormTest(TestCase):
         self.assertEqual(questionnaire.order, 46)
 
     def test_automatic_order_correction_on_type_change(self):
-        baker.make(Questionnaire, order=72, type=Questionnaire.BOTTOM)
+        baker.make(Questionnaire, order=72, type=Questionnaire.Type.BOTTOM)
 
-        questionnaire = baker.make(Questionnaire, order=7, type=Questionnaire.TOP)
+        questionnaire = baker.make(Questionnaire, order=7, type=Questionnaire.Type.TOP)
         question = baker.make(Question)
 
         data = {
@@ -51,7 +51,7 @@ class QuestionnaireFormTest(TestCase):
             'public_name_de': questionnaire.public_name_de,
             'questions-0-id': question.id,
             'order': questionnaire.order,
-            'type': Questionnaire.BOTTOM,
+            'type': Questionnaire.Type.BOTTOM,
             'visibility': 2,
         }
 
@@ -67,7 +67,7 @@ class EvaluationEmailFormTests(TestCase):
             Tests the EvaluationEmailForm with one valid and one invalid input dataset.
         """
         evaluation = create_evaluation_with_responsible_and_editor()
-        data = {"body": "wat", "subject": "some subject", "recipients": [EmailTemplate.DUE_PARTICIPANTS]}
+        data = {"body": "wat", "subject": "some subject", "recipients": [EmailTemplate.Recipients.DUE_PARTICIPANTS]}
         form = EvaluationEmailForm(evaluation=evaluation, data=data)
         self.assertTrue(form.is_valid())
         form.send(None)
@@ -179,7 +179,7 @@ class ContributionFormsetTests(TestCase):
         user1 = baker.make(UserProfile)
         user2 = baker.make(UserProfile)
         baker.make(UserProfile)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
 
         ContributionFormset = inlineformset_factory(Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0)
 
@@ -190,8 +190,8 @@ class ContributionFormsetTests(TestCase):
             'contributions-0-evaluation': evaluation.pk,
             'contributions-0-questionnaires': questionnaire.pk,
             'contributions-0-order': 0,
-            'contributions-0-responsibility': Contribution.IS_EDITOR,
-            'contributions-0-textanswer_visibility': Contribution.GENERAL_TEXTANSWERS,
+            'contributions-0-responsibility': Contribution.Responsibility.IS_EDITOR,
+            'contributions-0-textanswer_visibility': Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
         })
         # no contributor
         self.assertFalse(ContributionFormset(instance=evaluation, form_kwargs={'evaluation': evaluation}, data=data.copy()).is_valid())
@@ -204,11 +204,11 @@ class ContributionFormsetTests(TestCase):
         data['contributions-1-evaluation'] = evaluation.pk
         data['contributions-1-questionnaires'] = questionnaire.pk
         data['contributions-1-order'] = 1
-        data['contributions-1-textanswer_visibility'] = Contribution.GENERAL_TEXTANSWERS
+        data['contributions-1-textanswer_visibility'] = Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS
         self.assertFalse(ContributionFormset(instance=evaluation, form_kwargs={'evaluation': evaluation}, data=data).is_valid())
         # two contributors
         data['contributions-1-contributor'] = user2.pk
-        data['contributions-1-responsibility'] = Contribution.IS_EDITOR
+        data['contributions-1-responsibility'] = Contribution.Responsibility.IS_EDITOR
         self.assertTrue(ContributionFormset(instance=evaluation, form_kwargs={'evaluation': evaluation}, data=data).is_valid())
 
     def test_dont_validate_deleted_contributions(self):
@@ -220,7 +220,7 @@ class ContributionFormsetTests(TestCase):
         user1 = baker.make(UserProfile)
         user2 = baker.make(UserProfile)
         baker.make(UserProfile)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
 
         contribution_formset = inlineformset_factory(Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0)
 
@@ -233,20 +233,20 @@ class ContributionFormsetTests(TestCase):
             'contributions-0-evaluation': evaluation.pk,
             'contributions-0-questionnaires': "",
             'contributions-0-order': 0,
-            'contributions-0-responsibility': Contribution.IS_EDITOR,
-            'contributions-0-textanswer_visibility': Contribution.GENERAL_TEXTANSWERS,
+            'contributions-0-responsibility': Contribution.Responsibility.IS_EDITOR,
+            'contributions-0-textanswer_visibility': Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             'contributions-0-contributor': user1.pk,
             'contributions-1-evaluation': evaluation.pk,
             'contributions-1-questionnaires': questionnaire.pk,
             'contributions-1-order': 0,
-            'contributions-1-responsibility': Contribution.IS_EDITOR,
-            'contributions-1-textanswer_visibility': Contribution.GENERAL_TEXTANSWERS,
+            'contributions-1-responsibility': Contribution.Responsibility.IS_EDITOR,
+            'contributions-1-textanswer_visibility': Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             'contributions-1-contributor': user2.pk,
             'contributions-2-evaluation': evaluation.pk,
             'contributions-2-questionnaires': "",
             'contributions-2-order': 1,
             'contributions-2-responsibility': "CONTRIBUTOR",
-            'contributions-2-textanswer_visibility': Contribution.OWN_TEXTANSWERS,
+            'contributions-2-textanswer_visibility': Contribution.TextAnswerVisibility.OWN_TEXTANSWERS,
             'contributions-2-contributor': user2.pk,
         })
 
@@ -270,7 +270,7 @@ class ContributionFormsetTests(TestCase):
         """
         evaluation = baker.make(Evaluation)
         user1 = baker.make(UserProfile)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
 
         contribution_formset = inlineformset_factory(Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0)
 
@@ -281,14 +281,14 @@ class ContributionFormsetTests(TestCase):
             'contributions-0-evaluation': evaluation.pk,
             'contributions-0-questionnaires': questionnaire.pk,
             'contributions-0-order': 0,
-            'contributions-0-responsibility': Contribution.IS_EDITOR,
-            'contributions-0-textanswer_visibility': Contribution.GENERAL_TEXTANSWERS,
+            'contributions-0-responsibility': Contribution.Responsibility.IS_EDITOR,
+            'contributions-0-textanswer_visibility': Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             'contributions-0-contributor': user1.pk,
             'contributions-1-evaluation': evaluation.pk,
             'contributions-1-questionnaires': "",
             'contributions-1-order': -1,
             'contributions-1-responsibility': "CONTRIBUTOR",
-            'contributions-1-textanswer_visibility': Contribution.OWN_TEXTANSWERS,
+            'contributions-1-textanswer_visibility': Contribution.TextAnswerVisibility.OWN_TEXTANSWERS,
             'contributions-1-contributor': "",
         })
 
@@ -300,7 +300,7 @@ class ContributionFormsetTests(TestCase):
 
         # delete first, change data in extra formset
         data['contributions-0-DELETE'] = 'on'
-        data['contributions-1-responsibility'] = Contribution.IS_EDITOR
+        data['contributions-1-responsibility'] = Contribution.Responsibility.IS_EDITOR
         formset = contribution_formset(instance=evaluation, form_kwargs={'evaluation': evaluation}, data=data)
         formset.is_valid()
 
@@ -312,9 +312,9 @@ class ContributionFormsetTests(TestCase):
         """
         evaluation = baker.make(Evaluation)
         user1 = baker.make(UserProfile)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
         contribution1 = baker.make(Contribution, evaluation=evaluation, contributor=user1, can_edit=True,
-                                   textanswer_visibility=Contribution.GENERAL_TEXTANSWERS, questionnaires=[questionnaire])
+                                   textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS, questionnaires=[questionnaire])
 
         contribution_formset = inlineformset_factory(Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0)
 
@@ -326,16 +326,16 @@ class ContributionFormsetTests(TestCase):
             'contributions-0-evaluation': evaluation.pk,
             'contributions-0-questionnaires': questionnaire.pk,
             'contributions-0-order': 0,
-            'contributions-0-responsibility': Contribution.IS_EDITOR,
-            'contributions-0-textanswer_visibility': Contribution.GENERAL_TEXTANSWERS,
+            'contributions-0-responsibility': Contribution.Responsibility.IS_EDITOR,
+            'contributions-0-textanswer_visibility': Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             'contributions-0-contributor': user1.pk,
             'contributions-0-DELETE': 'on',
             'contributions-1-evaluation': evaluation.pk,
             'contributions-1-questionnaires': questionnaire.pk,
             'contributions-1-order': 0,
             'contributions-1-id': '',
-            'contributions-1-responsibility': Contribution.IS_EDITOR,
-            'contributions-1-textanswer_visibility': Contribution.GENERAL_TEXTANSWERS,
+            'contributions-1-responsibility': Contribution.Responsibility.IS_EDITOR,
+            'contributions-1-textanswer_visibility': Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             'contributions-1-contributor': user1.pk,
         })
 
@@ -366,9 +366,9 @@ class ContributionFormsetTests(TestCase):
             Regression test for #593.
         """
         evaluation = baker.make(Evaluation)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR, visibility=Questionnaire.EDITORS)
-        questionnaire_hidden = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR, visibility=Questionnaire.HIDDEN)
-        questionnaire_managers_only = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR, visibility=Questionnaire.MANAGERS)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR, visibility=Questionnaire.Visibility.EDITORS)
+        questionnaire_hidden = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR, visibility=Questionnaire.Visibility.HIDDEN)
+        questionnaire_managers_only = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR, visibility=Questionnaire.Visibility.MANAGERS)
 
         # The normal and managers_only questionnaire should be shown.
         contribution1 = baker.make(Contribution, evaluation=evaluation, contributor=baker.make(UserProfile), questionnaires=[])
@@ -407,8 +407,8 @@ class ContributionFormset775RegressionTests(TestCase):
         cls.user1 = baker.make(UserProfile)
         cls.user2 = baker.make(UserProfile)
         baker.make(UserProfile)
-        cls.questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
-        cls.contribution1 = baker.make(Contribution, contributor=cls.user1, evaluation=cls.evaluation, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        cls.questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
+        cls.contribution1 = baker.make(Contribution, contributor=cls.user1, evaluation=cls.evaluation, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         cls.contribution2 = baker.make(Contribution, contributor=cls.user2, evaluation=cls.evaluation)
 
         cls.contribution_formset = inlineformset_factory(Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0)
@@ -422,15 +422,15 @@ class ContributionFormset775RegressionTests(TestCase):
             'contributions-0-evaluation': self.evaluation.pk,
             'contributions-0-questionnaires': self.questionnaire.pk,
             'contributions-0-order': 0,
-            'contributions-0-responsibility': Contribution.IS_EDITOR,
-            'contributions-0-textanswer_visibility': Contribution.GENERAL_TEXTANSWERS,
+            'contributions-0-responsibility': Contribution.Responsibility.IS_EDITOR,
+            'contributions-0-textanswer_visibility': Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             'contributions-0-contributor': self.user1.pk,
             'contributions-1-id': str(self.contribution2.pk),
             'contributions-1-evaluation': self.evaluation.pk,
             'contributions-1-questionnaires': self.questionnaire.pk,
             'contributions-1-order': 0,
             'contributions-1-responsibility': "CONTRIBUTOR",
-            'contributions-1-textanswer_visibility': Contribution.OWN_TEXTANSWERS,
+            'contributions-1-textanswer_visibility': Contribution.TextAnswerVisibility.OWN_TEXTANSWERS,
             'contributions-1-contributor': self.user2.pk,
         })
 
@@ -464,7 +464,7 @@ class ContributionFormset775RegressionTests(TestCase):
         self.data['contributions-2-id'] = ""
         self.data['contributions-2-order'] = -1
         self.data['contributions-2-responsibility'] = "CONTRIBUTOR"
-        self.data['contributions-2-textanswer_visibility'] = Contribution.OWN_TEXTANSWERS
+        self.data['contributions-2-textanswer_visibility'] = Contribution.TextAnswerVisibility.OWN_TEXTANSWERS
         formset = self.contribution_formset(instance=self.evaluation, form_kwargs={'evaluation': self.evaluation}, data=self.data)
         self.assertTrue(formset.is_valid())
 
@@ -479,7 +479,7 @@ class ContributionFormset775RegressionTests(TestCase):
         self.data['contributions-1-id'] = ""
         self.data['contributions-1-order'] = -1
         self.data['contributions-1-responsibility'] = "CONTRIBUTOR"
-        self.data['contributions-1-textanswer_visibility'] = Contribution.OWN_TEXTANSWERS
+        self.data['contributions-1-textanswer_visibility'] = Contribution.TextAnswerVisibility.OWN_TEXTANSWERS
 
         formset = self.contribution_formset(instance=self.evaluation, form_kwargs={'evaluation': self.evaluation}, data=self.data)
         self.assertTrue(formset.is_valid())
@@ -490,7 +490,7 @@ class ContributionFormset775RegressionTests(TestCase):
         self.data['contributions-0-contributor'] = self.user2.pk
         self.data['contributions-1-contributor'] = self.user1.pk
 
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
+        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
         self.data.appendlist('contributions-0-questionnaires', questionnaire.pk)
         formset = self.contribution_formset(instance=self.evaluation, form_kwargs={'evaluation': self.evaluation}, data=self.data)
         formset.save()

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -659,7 +659,7 @@ class TestSemesterImportView(WebTest):
         form["excel_file"] = (self.filename_invalid,)
 
         reply = form.submit(name="operation", value="test")
-        self.assertContains(reply, 'Sheet &quot;MA Belegungen&quot;, row 3: The users&#39;s data (email: bastius.quid@external.example.com) differs from it&#39;s data in a previous row.')
+        self.assertContains(reply, 'Sheet &quot;MA Belegungen&quot;, row 3: The users&#x27;s data (email: bastius.quid@external.example.com) differs from it&#x27;s data in a previous row.')
         self.assertContains(reply, 'Sheet &quot;MA Belegungen&quot;, row 7: Email address is missing.')
         self.assertContains(reply, 'Sheet &quot;MA Belegungen&quot;, row 10: Email address is missing.')
         self.assertContains(reply, 'Errors occurred while parsing the input data. No data was imported.')

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -505,13 +505,13 @@ class TestSemesterAssignView(WebTest):
         cls.semester = baker.make(Semester, pk=1)
         lecture_type = baker.make(CourseType, name_de="Vorlesung", name_en="Lecture")
         seminar_type = baker.make(CourseType, name_de="Seminar", name_en="Seminar")
-        cls.questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        cls.questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         evaluation1 = baker.make(Evaluation, course=baker.make(Course, semester=cls.semester, type=seminar_type))
         baker.make(Contribution, contributor=baker.make(UserProfile), evaluation=evaluation1,
-                   can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+                   can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         evaluation2 = baker.make(Evaluation, course=baker.make(Course, semester=cls.semester, type=lecture_type))
         baker.make(Contribution, contributor=baker.make(UserProfile), evaluation=evaluation2,
-                   can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+                   can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
 
     def test_assign_questionnaires(self):
         page = self.app.get(self.url, user="manager")
@@ -538,7 +538,7 @@ class TestSemesterPreparationReminderView(WebTestWith200Check):
     def test_preparation_reminder(self):
         user = baker.make(UserProfile, username='user_to_find')
         evaluation = baker.make(Evaluation, course=baker.make(Course, semester=self.semester, responsibles=[user]), state='prepared', name_en='name_to_find', name_de='name_to_find')
-        baker.make(Contribution, evaluation=evaluation, contributor=user, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=evaluation, contributor=user, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
 
         response = self.app.get(self.url, user='manager')
         self.assertContains(response, 'user_to_find')
@@ -572,7 +572,7 @@ class TestSendReminderView(WebTest):
         cls.semester = baker.make(Semester, pk=1)
         responsible = baker.make(UserProfile, pk=3, email='a.b@example.com')
         evaluation = baker.make(Evaluation, course=baker.make(Course, semester=cls.semester, responsibles=[responsible]), state='prepared')
-        baker.make(Contribution, evaluation=evaluation, contributor=responsible, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=evaluation, contributor=responsible, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
 
     def test_form(self):
         page = self.app.get(self.url, user='manager')
@@ -811,8 +811,8 @@ class TestSemesterParticipationDataExportView(WebTest):
             voters=[cls.student_user], name_de="Veranstaltung 1", name_en="Evaluation 1", is_rewarded=True)
         cls.evaluation2 = baker.make(Evaluation, course=baker.make(Course, type=cls.course_type, semester=cls.semester), participants=[cls.student_user, cls.student_user2],
             name_de="Veranstaltung 2", name_en="Evaluation 2", is_rewarded=False)
-        baker.make(Contribution, evaluation=cls.evaluation1, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
-        baker.make(Contribution, evaluation=cls.evaluation2, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=cls.evaluation1, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=cls.evaluation2, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         baker.make(RewardPointGranting, semester=cls.semester, user_profile=cls.student_user, value=23)
         baker.make(RewardPointGranting, semester=cls.semester, user_profile=cls.student_user, value=42)
 
@@ -1154,8 +1154,8 @@ class TestEvaluationCreateView(WebTest):
     def setUpTestData(cls):
         cls.manager_user = baker.make(UserProfile, username='manager', groups=[Group.objects.get(name='Manager')])
         cls.course = baker.make(Course, semester=baker.make(Semester, pk=1))
-        cls.q1 = baker.make(Questionnaire, type=Questionnaire.TOP)
-        cls.q2 = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
+        cls.q1 = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
+        cls.q2 = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
 
     def test_evaluation_create(self):
         """
@@ -1177,8 +1177,8 @@ class TestEvaluationCreateView(WebTest):
         form['contributions-0-contributor'] = self.manager_user.pk
         form['contributions-0-questionnaires'] = [self.q2.pk]
         form['contributions-0-order'] = 0
-        form['contributions-0-responsibility'] = Contribution.IS_EDITOR
-        form['contributions-0-textanswer_visibility'] = Contribution.GENERAL_TEXTANSWERS
+        form['contributions-0-responsibility'] = Contribution.Responsibility.IS_EDITOR
+        form['contributions-0-textanswer_visibility'] = Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS
 
         form.submit()
         self.assertFalse(Evaluation.objects.exists())
@@ -1268,7 +1268,7 @@ class TestEvaluationEditView(WebTest):
             vote_start_datetime=datetime.datetime(2099, 1, 1, 0, 0), vote_end_date=datetime.date(2099, 12, 31))
         baker.make(Questionnaire, questions=[baker.make(Question)])
         cls.evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
-        baker.make(Contribution, evaluation=cls.evaluation, contributor=responsible, order=0, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, evaluation=cls.evaluation, contributor=responsible, order=0, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
         baker.make(Contribution, evaluation=cls.evaluation, contributor=cls.editor, order=1, can_edit=True)
 
     def setUp(self):
@@ -1279,7 +1279,7 @@ class TestEvaluationEditView(WebTest):
 
         # remove editor rights
         form = page.forms["evaluation-form"]
-        form['contributions-1-responsibility'] = Contribution.IS_CONTRIBUTOR
+        form['contributions-1-responsibility'] = Contribution.Responsibility.IS_CONTRIBUTOR
         form.submit("operation", value="save")
         self.assertFalse(self.evaluation.contributions.get(contributor=self.editor).can_edit)
 
@@ -1444,7 +1444,7 @@ class TestSingleResultEditView(WebTestWith200Check):
         responsible = baker.make(UserProfile)
         evaluation = baker.make(Evaluation, course=baker.make(Course, semester=semester, responsibles=[responsible]), pk=1)
         contribution = baker.make(Contribution, evaluation=evaluation, contributor=responsible, can_edit=True,
-                                  textanswer_visibility=Contribution.GENERAL_TEXTANSWERS, questionnaires=[Questionnaire.single_result_questionnaire()])
+                                  textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS, questionnaires=[Questionnaire.single_result_questionnaire()])
 
         question = Questionnaire.single_result_questionnaire().questions.get()
         baker.make(RatingAnswerCounter, question=question, contribution=contribution, answer=1, count=5)
@@ -1688,7 +1688,7 @@ class TestEvaluationTextAnswerView(WebTest):
         student1 = baker.make(UserProfile)
         cls.student2 = baker.make(UserProfile)
         cls.evaluation = baker.make(Evaluation, pk=1, course=baker.make(Course, semester=semester), participants=[student1, cls.student2], voters=[student1], state="in_evaluation")
-        top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         baker.make(Question, questionnaire=top_general_questionnaire, type=Question.LIKERT)
         cls.evaluation.general_contribution.questionnaires.set([top_general_questionnaire])
         questionnaire = baker.make(Questionnaire)
@@ -1728,7 +1728,7 @@ class TestEvaluationTextAnswerEditView(WebTest):
         student1 = baker.make(UserProfile)
         cls.student2 = baker.make(UserProfile)
         cls.evaluation = baker.make(Evaluation, pk=1, course=baker.make(Course, semester=semester), participants=[student1, cls.student2], voters=[student1], state="in_evaluation")
-        top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         baker.make(Question, questionnaire=top_general_questionnaire, type=Question.LIKERT)
         cls.evaluation.general_contribution.questionnaires.set([top_general_questionnaire])
         questionnaire = baker.make(Questionnaire)
@@ -1813,7 +1813,7 @@ class TestQuestionnaireCreateView(WebTest):
         questionnaire_form['questions-0-text_en'] = "Question 1"
         questionnaire_form['questions-0-type'] = Question.TEXT
         questionnaire_form['order'] = 0
-        questionnaire_form['type'] = Questionnaire.TOP
+        questionnaire_form['type'] = Questionnaire.Type.TOP
         questionnaire_form.submit().follow()
 
         # retrieve new questionnaire
@@ -1842,9 +1842,9 @@ class TestQuestionnaireIndexView(WebTest):
     @classmethod
     def setUpTestData(cls):
         baker.make(UserProfile, username='manager', groups=[Group.objects.get(name='Manager')])
-        cls.contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
-        cls.top_questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
-        cls.bottom_questionnaire = baker.make(Questionnaire, type=Questionnaire.BOTTOM)
+        cls.contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
+        cls.top_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
+        cls.bottom_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.BOTTOM)
 
     def test_ordering(self):
         content = self.app.get(self.url, user="manager").body.decode()
@@ -1870,7 +1870,7 @@ class TestQuestionnaireEditView(WebTestWith200Check):
 
     def test_allowed_type_changes_on_used_questionnaire(self):
         # top to bottom
-        self.questionnaire.type = Questionnaire.TOP
+        self.questionnaire.type = Questionnaire.Type.TOP
         self.questionnaire.save()
 
         page = self.app.get(self.url, user='manager')
@@ -1878,7 +1878,7 @@ class TestQuestionnaireEditView(WebTestWith200Check):
         self.assertEqual(form['type'].options, [('10', True, 'Top questionnaire'), ('30', False, 'Bottom questionnaire')])
 
         # bottom to top
-        self.questionnaire.type = Questionnaire.BOTTOM
+        self.questionnaire.type = Questionnaire.Type.BOTTOM
         self.questionnaire.save()
 
         page = self.app.get(self.url, user='manager')
@@ -1886,7 +1886,7 @@ class TestQuestionnaireEditView(WebTestWith200Check):
         self.assertEqual(form['type'].options, [('10', False, 'Top questionnaire'), ('30', True, 'Bottom questionnaire')])
 
         # contributor has no other possible type
-        self.questionnaire.type = Questionnaire.CONTRIBUTOR
+        self.questionnaire.type = Questionnaire.Type.CONTRIBUTOR
         self.questionnaire.save()
 
         page = self.app.get(self.url, user='manager')
@@ -2040,7 +2040,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         cls.student1 = baker.make(UserProfile)
         cls.student2 = baker.make(UserProfile)
         cls.evaluation = baker.make(Evaluation, participants=[cls.student1, cls.student2], voters=[cls.student1], state="in_evaluation")
-        top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
+        top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         baker.make(Question, questionnaire=top_general_questionnaire, type=Question.LIKERT)
         cls.evaluation.general_contribution.questionnaires.set([top_general_questionnaire])
 
@@ -2056,15 +2056,15 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
 
     def test_review_actions(self):
         # in an evaluation with only one voter reviewing should fail
-        self.helper(TextAnswer.NOT_REVIEWED, TextAnswer.PUBLISHED, "publish", expect_errors=True)
+        self.helper(TextAnswer.State.NOT_REVIEWED, TextAnswer.State.PUBLISHED, "publish", expect_errors=True)
 
         let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
 
         # now reviewing should work
-        self.helper(TextAnswer.NOT_REVIEWED, TextAnswer.PUBLISHED, "publish")
-        self.helper(TextAnswer.NOT_REVIEWED, TextAnswer.HIDDEN, "hide")
-        self.helper(TextAnswer.NOT_REVIEWED, TextAnswer.PRIVATE, "make_private")
-        self.helper(TextAnswer.PUBLISHED, TextAnswer.NOT_REVIEWED, "unreview")
+        self.helper(TextAnswer.State.NOT_REVIEWED, TextAnswer.State.PUBLISHED, "publish")
+        self.helper(TextAnswer.State.NOT_REVIEWED, TextAnswer.State.HIDDEN, "hide")
+        self.helper(TextAnswer.State.NOT_REVIEWED, TextAnswer.State.PRIVATE, "make_private")
+        self.helper(TextAnswer.State.PUBLISHED, TextAnswer.State.NOT_REVIEWED, "unreview")
 
 
 class ParticipationArchivingTests(WebTest):
@@ -2142,13 +2142,13 @@ class TestSemesterQuestionnaireAssignment(WebTest):
         cls.course_type_1 = baker.make(CourseType)
         cls.course_type_2 = baker.make(CourseType)
         cls.responsible = baker.make(UserProfile)
-        cls.questionnaire_1 = baker.make(Questionnaire, type=Questionnaire.TOP)
-        cls.questionnaire_2 = baker.make(Questionnaire, type=Questionnaire.TOP)
-        cls.questionnaire_responsible = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
+        cls.questionnaire_1 = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
+        cls.questionnaire_2 = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
+        cls.questionnaire_responsible = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
         cls.evaluation_1 = baker.make(Evaluation, course=baker.make(Course, semester=cls.semester, type=cls.course_type_1, responsibles=[cls.responsible]))
         cls.evaluation_2 = baker.make(Evaluation, course=baker.make(Course, semester=cls.semester, type=cls.course_type_2, responsibles=[cls.responsible]))
-        baker.make(Contribution, contributor=cls.responsible, evaluation=cls.evaluation_1, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
-        baker.make(Contribution, contributor=cls.responsible, evaluation=cls.evaluation_2, can_edit=True, textanswer_visibility=Contribution.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, contributor=cls.responsible, evaluation=cls.evaluation_1, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
+        baker.make(Contribution, contributor=cls.responsible, evaluation=cls.evaluation_2, can_edit=True, textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS)
 
     def test_questionnaire_assignment(self):
         page = self.app.get(self.url, user="manager", status=200)

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -9,7 +9,7 @@ from django.db import transaction
 from django.db.models import Count
 from django.conf import settings
 from django.utils.html import format_html, format_html_join
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from evap.evaluation.models import Contribution, Course, Evaluation, TextAnswer, UserProfile
 from evap.grades.models import GradeDocument

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -188,6 +188,6 @@ def find_next_unreviewed_evaluation(semester, excluded):
     return semester.evaluations.exclude(pk__in=excluded) \
         .exclude(state='published') \
         .exclude(can_publish_text_results=False) \
-        .filter(contributions__textanswer_set__state=TextAnswer.NOT_REVIEWED) \
+        .filter(contributions__textanswer_set__state=TextAnswer.State.NOT_REVIEWED) \
         .annotate(num_unreviewed_textanswers=Count("contributions__textanswer_set")) \
         .order_by('vote_end_date', '-num_unreviewed_textanswers').first()

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -16,8 +16,8 @@ from django.forms.models import inlineformset_factory, modelformset_factory
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _, ugettext_lazy
-from django.utils.translation import get_language, ungettext, ngettext
+from django.utils.translation import gettext as _, gettext_lazy
+from django.utils.translation import get_language, ngettext
 from django.views.decorators.http import require_POST
 from evap.contributor.views import export_contributor_results
 from evap.evaluation.auth import reviewer_required, manager_required
@@ -173,7 +173,7 @@ class EvaluationOperation:
 
 
 class RevertToNewOperation(EvaluationOperation):
-    confirmation_message = ugettext_lazy("Do you want to revert the following evaluations to preparation?")
+    confirmation_message = gettext_lazy("Do you want to revert the following evaluations to preparation?")
 
     @staticmethod
     def applicable_to(evaluation):
@@ -181,7 +181,7 @@ class RevertToNewOperation(EvaluationOperation):
 
     @staticmethod
     def warning_for_inapplicables(amount):
-        return ungettext("{} evaluation can not be reverted, because it already started. It was removed from the selection.",
+        return ngettext("{} evaluation can not be reverted, because it already started. It was removed from the selection.",
             "{} evaluations can not be reverted, because they already started. They were removed from the selection.", amount).format(amount)
 
     @staticmethod
@@ -192,13 +192,13 @@ class RevertToNewOperation(EvaluationOperation):
         for evaluation in evaluations:
             evaluation.revert_to_new()
             evaluation.save()
-        messages.success(request, ungettext("Successfully reverted {} evaluation to in preparation.",
+        messages.success(request, ngettext("Successfully reverted {} evaluation to in preparation.",
             "Successfully reverted {} evaluations to in preparation.", len(evaluations)).format(len(evaluations)))
 
 
 class MoveToPreparedOperation(EvaluationOperation):
     email_template_name = EmailTemplate.EDITOR_REVIEW_NOTICE
-    confirmation_message = ugettext_lazy("Do you want to send the following evaluations to editor review?")
+    confirmation_message = gettext_lazy("Do you want to send the following evaluations to editor review?")
 
     @staticmethod
     def applicable_to(evaluation):
@@ -206,7 +206,7 @@ class MoveToPreparedOperation(EvaluationOperation):
 
     @staticmethod
     def warning_for_inapplicables(amount):
-        return ungettext("{} evaluation can not be reverted, because it already started. It was removed from the selection.",
+        return ngettext("{} evaluation can not be reverted, because it already started. It was removed from the selection.",
             "{} evaluations can not be reverted, because they already started. They were removed from the selection.", amount).format(amount)
 
     @staticmethod
@@ -217,7 +217,7 @@ class MoveToPreparedOperation(EvaluationOperation):
         for evaluation in evaluations:
             evaluation.ready_for_editors()
             evaluation.save()
-        messages.success(request, ungettext("Successfully enabled {} evaluation for editor review.",
+        messages.success(request, ngettext("Successfully enabled {} evaluation for editor review.",
             "Successfully enabled {} evaluations for editor review.", len(evaluations)).format(len(evaluations)))
         if email_template:
             evaluations_by_responsible = {}
@@ -236,7 +236,7 @@ class MoveToPreparedOperation(EvaluationOperation):
 
 class StartEvaluationOperation(EvaluationOperation):
     email_template_name = EmailTemplate.EVALUATION_STARTED
-    confirmation_message = ugettext_lazy("Do you want to immediately start the following evaluations?")
+    confirmation_message = gettext_lazy("Do you want to immediately start the following evaluations?")
 
     @staticmethod
     def applicable_to(evaluation):
@@ -244,7 +244,7 @@ class StartEvaluationOperation(EvaluationOperation):
 
     @staticmethod
     def warning_for_inapplicables(amount):
-        return ungettext("{} evaluation can not be started, because it was not approved, was already evaluated or its evaluation end date lies in the past. It was removed from the selection.",
+        return ngettext("{} evaluation can not be started, because it was not approved, was already evaluated or its evaluation end date lies in the past. It was removed from the selection.",
             "{} evaluations can not be started, because they were not approved, were already evaluated or their evaluation end dates lie in the past. They were removed from the selection.", amount).format(amount)
 
     @staticmethod
@@ -256,14 +256,14 @@ class StartEvaluationOperation(EvaluationOperation):
             evaluation.vote_start_datetime = datetime.now()
             evaluation.evaluation_begin()
             evaluation.save()
-        messages.success(request, ungettext("Successfully started {} evaluation.",
+        messages.success(request, ngettext("Successfully started {} evaluation.",
             "Successfully started {} evaluations.", len(evaluations)).format(len(evaluations)))
         if email_template:
             email_template.send_to_users_in_evaluations(evaluations, [EmailTemplate.ALL_PARTICIPANTS], use_cc=False, request=request)
 
 
 class RevertToReviewedOperation(EvaluationOperation):
-    confirmation_message = ugettext_lazy("Do you want to unpublish the following evaluations?")
+    confirmation_message = gettext_lazy("Do you want to unpublish the following evaluations?")
 
     @staticmethod
     def applicable_to(evaluation):
@@ -271,7 +271,7 @@ class RevertToReviewedOperation(EvaluationOperation):
 
     @staticmethod
     def warning_for_inapplicables(amount):
-        return ungettext("{} evaluation can not be unpublished, because it's results have not been published. It was removed from the selection.",
+        return ngettext("{} evaluation can not be unpublished, because it's results have not been published. It was removed from the selection.",
             "{} evaluations can not be unpublished because their results have not been published. They were removed from the selection.", amount).format(amount)
 
     @staticmethod
@@ -282,14 +282,14 @@ class RevertToReviewedOperation(EvaluationOperation):
         for evaluation in evaluations:
             evaluation.unpublish()
             evaluation.save()
-        messages.success(request, ungettext("Successfully unpublished {} evaluation.",
+        messages.success(request, ngettext("Successfully unpublished {} evaluation.",
             "Successfully unpublished {} evaluations.", len(evaluations)).format(len(evaluations)))
 
 
 class PublishOperation(EvaluationOperation):
     email_template_contributor_name = EmailTemplate.PUBLISHING_NOTICE_CONTRIBUTOR
     email_template_participant_name = EmailTemplate.PUBLISHING_NOTICE_PARTICIPANT
-    confirmation_message = ugettext_lazy("Do you want to publish the following evaluations?")
+    confirmation_message = gettext_lazy("Do you want to publish the following evaluations?")
 
     @staticmethod
     def applicable_to(evaluation):
@@ -297,7 +297,7 @@ class PublishOperation(EvaluationOperation):
 
     @staticmethod
     def warning_for_inapplicables(amount):
-        return ungettext("{} evaluation can not be published, because it's not finished or not all of its text answers have been reviewed. It was removed from the selection.",
+        return ngettext("{} evaluation can not be published, because it's not finished or not all of its text answers have been reviewed. It was removed from the selection.",
            "{} evaluations can not be published, because they are not finished or not all of their text answers have been reviewed. They were removed from the selection.", amount).format(amount)
 
     @staticmethod
@@ -307,7 +307,7 @@ class PublishOperation(EvaluationOperation):
         for evaluation in evaluations:
             evaluation.publish()
             evaluation.save()
-        messages.success(request, ungettext("Successfully published {} evaluation.",
+        messages.success(request, ngettext("Successfully published {} evaluation.",
             "Successfully published {} evaluations.", len(evaluations)).format(len(evaluations)))
 
         if email_template_contributor:

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -33,9 +33,9 @@ class TestVoteView(WebTest):
 
         cls.evaluation = baker.make(Evaluation, pk=1, participants=[cls.voting_user1, cls.voting_user2, cls.contributor1], state="in_evaluation")
 
-        cls.top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.TOP)
-        cls.bottom_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.BOTTOM)
-        cls.contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.CONTRIBUTOR)
+        cls.top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
+        cls.bottom_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.BOTTOM)
+        cls.contributor_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
 
         cls.contributor_heading_question = baker.make(Question, questionnaire=cls.contributor_questionnaire, order=0, type=Question.HEADING)
         cls.contributor_text_question = baker.make(Question, questionnaire=cls.contributor_questionnaire, order=1, type=Question.TEXT)

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from evap.evaluation.auth import participant_required
 from evap.evaluation.models import Evaluation, Course, NO_ANSWER, Semester

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@
 coverage
 django-debug-toolbar>=1.6
 pylint==2.4.4
-pylint-django==2.0.13
+pylint-django==2.0.14

--- a/requirements-travis.txt
+++ b/requirements-travis.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 coveralls
 pylint==2.4.4
-pylint-django==2.0.13
+pylint-django==2.0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
-django >= 2.2, < 2.3
+django >= 3.0, <3.1
 xlrd == 1.2.0
 xlwt == 1.3.0
 xlutils == 2.0.0
-psycopg2-binary == 2.7.5
-redis == 3.0.1
-django-redis == 4.10.0
-django-fsm == 2.6.1
+psycopg2-binary == 2.8.4
+redis == 3.4.1
+django-redis == 4.11.0
+django-fsm == 2.7.0
 django-webtest == 1.9.7
-WebTest == 2.0.30
-model-bakery == 1.0.2
-django-extensions == 2.1.9
-django-sendfile == 0.3.11
-django-compressor == 2.3
-mozilla-django-oidc == 1.2.2
+WebTest == 2.0.34
+model-bakery == 1.1.0
+django-extensions == 2.2.9
+django-sendfile2 == 0.5.1
+django-compressor == 2.4
+mozilla-django-oidc == 1.2.3


### PR DESCRIPTION
This fixes #1387.

I couldn't resist the urge to update the project to Django 3.0.
In particular:

- I updated all dependencies. Note that I replaced `django-sendfile` with `django-sendfile2`, because the former project is unmaintained and threw some warnings. The latter seems to be actively maintained.
- I updated Django to 3.0.
- I fixed the warnings, which mainly meant using `gettext` instead of `ugettext`.
- I made use of the new [enumerations for model field choices](https://docs.djangoproject.com/en/3.0/releases/3.0/#enumerations-for-model-field-choices) wherever possible. I quite like it, since the enums are now more descriptive, e.g., `TextAnswer.State.HIDDEN` instead of `TextAnswer.HIDDEN`.