### PR TITLE
Don't update Userprofile on OpenID login

### DIFF
--- a/evap/evaluation/auth.py
+++ b/evap/evaluation/auth.py
@@ -175,14 +175,6 @@ class OpenIDAuthenticationBackend(OIDCAuthenticationBackend):
         )
         return user
 
-    @staticmethod
-    def update_user(user, claims):
-        user.email = claims.get('email')
-        user.first_name = claims.get('given_name', '')
-        user.last_name = claims.get('family_name', '')
-        user.save()
-        return user
-
 
 def generate_username_from_email(email):
     return unicodedata.normalize('NFKC', email).split('@')[0].lower()


### PR DESCRIPTION
Automatically updating on login leads to unwanted name changes (e.g., `ä` becomes `ae`), because the identity service uses a different internal name representation.