### PR TITLE
Course evaluation creation redesign

### DIFF
--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -132,15 +132,9 @@
             {% if request.user.is_manager %}
                 <div class="ml-auto">
                     {% if not semester.participations_are_archived %}
-                        <div class="btn-group" role="group">
-                            <button type="button" id="btnAdd" role="button" class="btn btn-sm btn-dark dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Create/Import' %}</button>
-                            <div class="dropdown-menu" aria-labelledby="btnAdd">
-                                <a class="dropdown-item" href="{% url 'staff:course_create' semester.id %}"><span class="fas fa-fw fa-chalkboard-teacher"></span> {% trans 'Create course' %}</a>
-                                <a class="dropdown-item" href="{% url 'staff:evaluation_create' semester.id %}"><span class="fas fa-fw fa-clipboard-check"></span> {% trans 'Create evaluation' %}</a>
-                                <a class="dropdown-item" href="{% url 'staff:single_result_create' semester.id %}"><span class="fas fa-fw fa-poll"></span> {% trans 'Create single result' %}</a>
-                                <a class="dropdown-item" href="{% url 'staff:semester_import' semester.id %}"><span class="fas fa-fw fa-file-import"></span> {% trans 'Import courses and evaluations' %}</a>
-                            </div>
-                        </div>
+                        <a class="btn btn-sm btn-light" href="{% url 'staff:semester_import' semester.id %}">
+                            {% trans 'Import' %}
+                        </a>
                     {% endif %}
                     <div class="btn-group ml-2" role="group">
                         <button type="button" id="btnExport" class="btn btn-sm btn-light dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Export' %}</button>
@@ -158,6 +152,24 @@
         </div>
         <div class="card-body tab-content">
             <div class="tab-pane show active" id="evaluations" role="tabpanel">
+                <div class="row align-items-center mb-3">
+                    <div class="col-9">
+                        <a class="btn btn-sm btn-dark" href="{% url 'staff:evaluation_create' semester.id %}">
+                            {% trans 'Create evaluation' %}
+                        </a>
+                        <a class="btn btn-sm btn-dark ml-2" href="{% url 'staff:single_result_create' semester.id %}">
+                            {% trans 'Create single result' %}
+                        </a>
+                    </div>
+                    <div class="col-3 input-group">
+                        <input type="search" name="search-evaluation" class="form-control" placeholder="{% trans 'Search...' %}" />
+                        <div class="input-group-append">
+                            <button class="btn btn-light text-secondary" type="button" data-reset="search-evaluation" data-toggle="tooltip" data-placement="top" title="{% trans 'Clear search filter' %}">
+                                <span class="fas fa-backspace"></span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
                 <div class="btn-switch mb-2" id="evaluation-filter-buttons">
                     <div class="btn-switch-label my-auto pr-0">{% trans 'Filter' %}</div>
                     <div>
@@ -221,14 +233,6 @@
                                 <span class="fas fa-chart-bar icon-green"></span>
                             </button>
                         </div>
-                    </div>
-                </div>
-                <div class="input-group ml-auto mb-3 w-25">
-                    <input type="search" name="search-evaluation" class="form-control" placeholder="{% trans 'Search...' %}" />
-                    <div class="input-group-append">
-                        <button class="btn btn-light text-secondary" type="button" data-reset="search-evaluation" data-toggle="tooltip" data-placement="top" title="{% trans 'Clear search filter' %}">
-                            <span class="fas fa-backspace"></span>
-                        </button>
                     </div>
                 </div>
                 <form id="evaluation_operation_form" method="GET" action="{% url 'staff:semester_evaluation_operation' semester.id %}">
@@ -315,12 +319,19 @@
                 </form>
             </div>
             <div class="tab-pane" id="courses" role="tabpanel">
-                <div class="input-group ml-auto mb-3 w-25">
-                    <input type="search" name="search-course" class="form-control" placeholder="{% trans 'Search...' %}" />
-                    <div class="input-group-append">
-                        <button class="btn btn-light text-secondary" type="button" data-reset="search-course" data-toggle="tooltip" data-placement="top" title="{% trans 'Clear search filter' %}">
-                            <span class="fas fa-backspace"></span>
-                        </button>
+                <div class="row align-items-center mb-3">
+                    <div class="col-9">
+                        <a class="btn btn-sm btn-dark" href="{% url 'staff:course_create' semester.id %}">
+                            {% trans 'Create course' %}
+                        </a>
+                    </div>
+                    <div class="col-3 input-group">
+                        <input type="search" name="search-course" class="form-control" placeholder="{% trans 'Search...' %}" />
+                        <div class="input-group-append">
+                            <button class="btn btn-light text-secondary" type="button" data-reset="search-course" data-toggle="tooltip" data-placement="top" title="{% trans 'Clear search filter' %}">
+                                <span class="fas fa-backspace"></span>
+                            </button>
+                        </div>
                     </div>
                 </div>
                 <table id="course-table" class="table table-striped table-narrow table-vertically-aligned">

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -336,37 +336,53 @@
                 </div>
                 <table id="course-table" class="table table-striped table-narrow table-vertically-aligned">
                     {% if courses %}
+                        <colgroup>
+                            <col />
+                            <col style="width: 14em" />
+                            <col style="width: 12em" />
+                            <col style="width: 9em" />
+                        </colgroup>
                         <thead>
                             <tr role="row">
-                                <th style="width: 40%" class="col-order" data-col="name">{% trans 'Course' %}</th>
-                                <th style="width: 40%" class="col-order" data-col="responsible">{% trans 'Responsible' %}</th>
-                                <th style="width: 12%" class="col-order" data-col="evaluation-count">{% trans '#Evaluations' %}</th>
-                                <th style="width: 8%"></th>
+                                <th class="col-order" data-col="name">{% trans 'Course' %}</th>
+                                <th class="col-order" data-col="responsible">{% trans 'Responsible' %}</th>
+                                <th class="col-order" data-col="evaluation-count">{% trans '#Evaluations' %}</th>
+                                <th></th>
                             </tr>
                         </thead>
                     {% endif %}
                     <tbody>
                         {% for course in courses %}
                             <tr id="course-row-{{ course.id }}">
-                                <td style="width: 40%" data-col="name" data-order="{{ course.name|lower }}">
+                                <td data-col="name" data-order="{{ course.name|lower }}">
                                     <div>
                                         <a href="{% url 'staff:course_edit' semester.id course.id %}">{{ course.name }}</a>
                                     </div>
                                     {% include 'course_badges.html' %}
                                 </td>
-                                <td style="width: 40%;" data-col="responsible" data-order="{{ course.responsibles.first.last_name|lower }}">
+                                <td data-col="responsible" data-order="{{ course.responsibles.first.last_name|lower }}">
                                     <div class="font-italic">
                                         {{ course.responsibles_names }}
                                     </div>
                                 </td>
-                                <td style="width: 10%;" data-col="evaluation-count" data-order="{{ course.evaluations.count }}">
+                                <td data-col="evaluation-count" data-order="{{ course.evaluations.count }}">
                                     {% if course.evaluations.count == 0 %}
                                         <span class="badge badge-warning">{% trans 'No evaluations' %}</span>
                                     {% else %}
                                         {{ course.evaluations.count }}
                                     {% endif %}
                                 </td>
-                                <td class="text-right" style="width: 10%;">
+                                <td class="icon-buttons">
+                                    <a class="btn btn-sm btn-dark" data-toggle="tooltip"
+                                        href="{% url 'staff:evaluation_create' semester.id course.id %}"
+                                        title="{% trans "Create evaluation for this course" %}">
+                                        <span class="fas fa-clipboard-check"></span>
+                                    </a>
+                                    <a class="btn btn-sm btn-dark" data-toggle="tooltip"
+                                        href="{% url 'staff:single_result_create' semester.id course.id %}"
+                                        title="{% trans "Create single result for this course" %}">
+                                        <span class="fas fa-poll"></span>
+                                    </a>
                                     {% if course.can_be_deleted_by_manager %}
                                         <button type="button" onclick="deleteCourseModalShow({{ course.id }}, '{{ course.name|escapejs }}');" class="btn btn-sm btn-outline-danger" data-toggle="tooltip" data-placement="top" title="{% trans 'Delete' %}">
                                             <span class="fas fa-trash" aria-hidden="true"></span>

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -244,10 +244,10 @@
                                 <col style="width: 1.25em" />
                                 <col style="width: 1.25em" />
                                 <col style="width: 1.25em" />
-                                <col style="" />
+                                <col />
                                 <col style="width: 12.25em" />
                                 <col style="width: 12em" />
-                                <col style="width: 9em" />
+                                <col style="width: 10.5em" />
                             </colgroup>
                             <thead>
                                 <tr>

--- a/evap/staff/templates/staff_semester_view_evaluation.html
+++ b/evap/staff/templates/staff_semester_view_evaluation.html
@@ -182,8 +182,13 @@
         </a>
     </td>
 {% endif %}
-<td>
+<td class="icon-buttons">
     {% if not info_only %}
+        {% if not evaluation.is_single_result %}
+            <a href="{% url 'staff:evaluation_copy' semester.id evaluation.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" title="{% trans "Copy" %}">
+                <span class="far fa-copy"></span>
+            </a>
+        {% endif %}
         {% if request.user.is_manager %}
             <a href="{% url 'staff:evaluation_email' semester.id evaluation.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Send email' %}">
                 <span class="fas fa-envelope" aria-hidden="true"></span>

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -19,6 +19,7 @@ from evap.evaluation.models import (Contribution, Course, CourseType, Degree, Em
 from evap.evaluation.tests.tools import FuzzyInt, let_user_vote_for_evaluation, WebTestWith200Check
 from evap.rewards.models import SemesterActivation, RewardPointGranting
 from evap.staff.tools import generate_import_filename, ImportType
+from evap.staff.forms import ContributionCopyForm, ContributionCopyFormSet, EvaluationCopyForm
 from evap.staff.views import get_evaluations_with_prefetched_data
 
 
@@ -1283,7 +1284,7 @@ class TestSingleResultCreateView(WebTest):
         cls.course = baker.make(Course, semester=baker.make(Semester, pk=1))
 
     def test_course_is_prefilled(self):
-        response = self.app.get(f'{self.url}/{self.course.pk}', user='manager', status=200)
+        response = self.app.get(f'{self.url}/{self.course.pk}', user=self.manager_user, status=200)
         form = response.context['form']
         self.assertEqual(form['course'].initial, self.course.pk)
 
@@ -1320,7 +1321,7 @@ class TestEvaluationCreateView(WebTest):
         cls.q2 = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
 
     def test_course_is_prefilled(self):
-        response = self.app.get(f'{self.url}/{self.course.pk}', user='manager', status=200)
+        response = self.app.get(f'{self.url}/{self.course.pk}', user=self.manager_user, status=200)
         form = response.context['evaluation_form']
         self.assertEqual(form['course'].initial, self.course.pk)
 
@@ -1356,6 +1357,50 @@ class TestEvaluationCreateView(WebTest):
 
         form.submit()
         self.assertEqual(Evaluation.objects.get().name_de, "lfo9e7bmxp1xi")
+
+
+class TestEvaluationCopyView(WebTest):
+    url = '/staff/semester/1/evaluation/1/copy'
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.manager = baker.make(UserProfile, email='manager@institution.example.com', groups=[Group.objects.get(name='Manager')])
+        cls.semester = baker.make(Semester, pk=1)
+        cls.course = baker.make(Course, semester=cls.semester)
+        cls.evaluation = baker.make(
+            Evaluation,
+            pk=1,
+            course=cls.course,
+            name_de="Das Original",
+            name_en="The Original",
+        )
+        cls.general_questionnaires = baker.make(Questionnaire, _quantity=5)
+        cls.evaluation.general_contribution.questionnaires.set(cls.general_questionnaires)
+        for __ in range(3):
+            baker.make(
+                Contribution,
+                evaluation=cls.evaluation,
+                contributor=baker.make(UserProfile),
+            )
+
+    def test_copy_forms_are_used(self):
+        response = self.app.get(self.url, user=self.manager, status=200)
+        self.assertIsInstance(response.context['evaluation_form'], EvaluationCopyForm)
+        self.assertIsInstance(response.context['formset'], ContributionCopyFormSet)
+        self.assertTrue(issubclass(response.context['formset'].form, ContributionCopyForm))
+
+    def test_evaluation_copy(self):
+        response = self.app.get(self.url, user=self.manager, status=200)
+        form = response.forms['evaluation-form']
+        form['name_de'] = "Eine Kopie"
+        form['name_en'] = "A Copy"
+        form.submit()
+
+        # As we checked previously that the respective copy forms were used,
+        # we don’t have to check for individual attributes, as those are checked in the respective form tests
+        self.assertEqual(Evaluation.objects.count(), 2)
+        copied_evaluation = Evaluation.objects.exclude(pk=self.evaluation.pk).get()
+        self.assertEqual(copied_evaluation.contributions.count(), 4)
 
 
 class TestCourseEditView(WebTest):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1282,6 +1282,11 @@ class TestSingleResultCreateView(WebTest):
         cls.manager_user = baker.make(UserProfile, email='manager@institution.example.com', groups=[Group.objects.get(name='Manager')])
         cls.course = baker.make(Course, semester=baker.make(Semester, pk=1))
 
+    def test_course_is_prefilled(self):
+        response = self.app.get(f'{self.url}/{self.course.pk}', user='manager', status=200)
+        form = response.context['form']
+        self.assertEqual(form['course'].initial, self.course.pk)
+
     def test_single_result_create(self):
         """
             Tests the single result creation view with one valid and one invalid input dataset.
@@ -1313,6 +1318,11 @@ class TestEvaluationCreateView(WebTest):
         cls.course = baker.make(Course, semester=baker.make(Semester, pk=1))
         cls.q1 = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         cls.q2 = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
+
+    def test_course_is_prefilled(self):
+        response = self.app.get(f'{self.url}/{self.course.pk}', user='manager', status=200)
+        form = response.context['evaluation_form']
+        self.assertEqual(form['course'].initial, self.course.pk)
 
     def test_evaluation_create(self):
         """

--- a/evap/staff/urls.py
+++ b/evap/staff/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path("semester/<int:semester_id>/evaluation/create", views.evaluation_create, name="evaluation_create"),
     path("semester/<int:semester_id>/evaluation/create/<int:course_id>", views.evaluation_create, name="evaluation_create"),
     path("semester/<int:semester_id>/evaluation/<int:evaluation_id>/edit", views.evaluation_edit, name="evaluation_edit"),
+    path("semester/<int:semester_id>/evaluation/<int:evaluation_id>/copy", views.evaluation_copy, name="evaluation_copy"),
     path("semester/<int:semester_id>/evaluation/<int:evaluation_id>/email", views.evaluation_email, name="evaluation_email"),
     path("semester/<int:semester_id>/evaluation/<int:evaluation_id>/preview", views.evaluation_preview, name="evaluation_preview"),
     path("semester/<int:semester_id>/evaluation/<int:evaluation_id>/person_management", views.evaluation_person_management, name="evaluation_person_management"),


### PR DESCRIPTION
Resolves #1405 

Some background about copying models:
Not only the evaluation object must be copied, also the related contribution objects should be copyable.
The current approach uses the form fields to build `initial` data from the original objects (some fields needed manual cleaning though).
Passing the original object as-is to the form and setting `pk = None` just before saving will result in possible locked forms. Setting `pk = None` before displaying it will still result in saving some unwanted attributes (like state).
For contributions, I first wanted to pass `initial = [initial_contribution_data(contribution) for contribution in evaluation.contributions.all()]` to the `InlineContributionFormset`. This behaves very quirky, one has to set `queryset = Contribution.objects.none()` `extra = evaluation.contributions.count()` – but this messes up ordering.
If you want to learn more about the details, you can look into my resolved self-review