### PR TITLE
Tests: Use UserProfile instances in self.page.get and post. Minor styling.

### DIFF
--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -28,7 +28,11 @@ class TestContributorDirectDelegationView(WebTest):
 
     def test_direct_delegation_request(self):
         data = {"delegate_to": self.non_editor.id}
-        page = self.app.post('/contributor/evaluation/{}/direct_delegation'.format(self.evaluation.id), params=data, user=self.editor).follow()
+        page = self.app.post(
+            f'/contributor/evaluation/{self.evaluation.id}/direct_delegation',
+            params=data,
+            user=self.editor
+        ).follow()
 
         self.assertContains(
             page,
@@ -50,7 +54,11 @@ class TestContributorDirectDelegationView(WebTest):
         old_contribution_count = Contribution.objects.count()
 
         data = {"delegate_to": self.non_editor.id}
-        page = self.app.post('/contributor/evaluation/{}/direct_delegation'.format(self.evaluation.id), params=data, user=self.editor).follow()
+        page = self.app.post(
+            f'/contributor/evaluation/{self.evaluation.id}/direct_delegation',
+            params=data,
+            user=self.editor
+        ).follow()
 
         self.assertContains(
             page,
@@ -79,16 +87,18 @@ class TestContributorSettingsView(WebTest):
 
     @classmethod
     def setUpTestData(cls):
-        create_evaluation_with_responsible_and_editor()
+        result = create_evaluation_with_responsible_and_editor()
+        cls.responsible = result['responsible']
 
     def test_save_settings(self):
         user = baker.make(UserProfile)
-        page = self.app.get(self.url, user="responsible@institution.example.com", status=200)
+        page = self.app.get(self.url, user=self.responsible, status=200)
         form = page.forms["settings-form"]
         form["delegates"] = [user.pk]
         form.submit()
 
-        self.assertEqual(list(UserProfile.objects.get(email='responsible@institution.example.com').delegates.all()), [user])
+        self.responsible.refresh_from_db()
+        self.assertEqual(list(self.responsible.delegates.all()), [user])
 
 
 class TestContributorEvaluationView(WebTestWith200Check):
@@ -97,7 +107,9 @@ class TestContributorEvaluationView(WebTestWith200Check):
 
     @classmethod
     def setUpTestData(cls):
-        create_evaluation_with_responsible_and_editor(evaluation_id=TESTING_EVALUATION_ID)
+        result = create_evaluation_with_responsible_and_editor(evaluation_id=TESTING_EVALUATION_ID)
+        cls.responsible = result['responsible']
+        cls.editor = result['editor']
 
     def setUp(self):
         self.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)
@@ -105,13 +117,13 @@ class TestContributorEvaluationView(WebTestWith200Check):
     def test_wrong_state(self):
         self.evaluation.revert_to_new()
         self.evaluation.save()
-        self.app.get(self.url, user="responsible@institution.example.com", status=403)
+        self.app.get(self.url, user=self.responsible, status=403)
 
     def test_information_message(self):
         self.evaluation.editor_approve()
         self.evaluation.save()
 
-        page = self.app.get(self.url, user="editor@institution.example.com")
+        page = self.app.get(self.url, user=self.editor)
         self.assertContains(page, "You cannot edit this evaluation because it has already been approved")
         self.assertNotContains(page, "Please review the evaluation's details below, add all contributors and select suitable questionnaires. Once everything is okay, please approve the evaluation on the bottom of the page.")
 
@@ -122,7 +134,8 @@ class TestContributorEvaluationPreviewView(WebTestWith200Check):
 
     @classmethod
     def setUpTestData(cls):
-        create_evaluation_with_responsible_and_editor(evaluation_id=TESTING_EVALUATION_ID)
+        result = create_evaluation_with_responsible_and_editor(evaluation_id=TESTING_EVALUATION_ID)
+        cls.responsible = result['responsible']
 
     def setUp(self):
         self.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)
@@ -130,7 +143,7 @@ class TestContributorEvaluationPreviewView(WebTestWith200Check):
     def test_wrong_state(self):
         self.evaluation.revert_to_new()
         self.evaluation.save()
-        self.app.get(self.url, user="responsible@institution.example.com", status=403)
+        self.app.get(self.url, user=self.responsible, status=403)
 
 
 class TestContributorEvaluationEditView(WebTest):
@@ -138,7 +151,9 @@ class TestContributorEvaluationEditView(WebTest):
 
     @classmethod
     def setUpTestData(cls):
-        create_evaluation_with_responsible_and_editor(evaluation_id=TESTING_EVALUATION_ID)
+        result = create_evaluation_with_responsible_and_editor(evaluation_id=TESTING_EVALUATION_ID)
+        cls.responsible = result['responsible']
+        cls.editor = result['editor']
 
     def setUp(self):
         self.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)
@@ -166,14 +181,14 @@ class TestContributorEvaluationEditView(WebTest):
         self.evaluation.editor_approve()
         self.evaluation.save()
 
-        self.app.get(self.url, user="responsible@institution.example.com", status=403)
+        self.app.get(self.url, user=self.responsible, status=403)
 
     def test_contributor_evaluation_edit(self):
         """
             Tests whether the "save" button in the contributor's evaluation edit view does not
             change the evaluation's state, and that the "approve" button does that.
         """
-        page = self.app.get(self.url, user="responsible@institution.example.com", status=200)
+        page = self.app.get(self.url, user=self.responsible, status=200)
         form = page.forms["evaluation-form"]
         form["vote_start_datetime"] = "2098-01-01 11:43:12"
         form["vote_end_date"] = "2099-01-01"
@@ -221,7 +236,7 @@ class TestContributorEvaluationEditView(WebTest):
         """
             Asserts that the preview button either renders a preview or shows an error.
         """
-        page = self.app.get(self.url, user="responsible@institution.example.com")
+        page = self.app.get(self.url, user=self.responsible)
         form = page.forms["evaluation-form"]
         form["vote_start_datetime"] = "2099-01-01 11:43:12"
         form["vote_end_date"] = "2098-01-01"
@@ -244,7 +259,7 @@ class TestContributorEvaluationEditView(WebTest):
         """
         self.evaluation.name_en = "Adam & Eve"
         self.evaluation.save()
-        page = self.app.get(self.url, user="responsible@institution.example.com", status=200)
+        page = self.app.get(self.url, user=self.responsible, status=200)
 
         self.assertIn("changeParticipantRequestModalLabel", page)
 
@@ -253,7 +268,7 @@ class TestContributorEvaluationEditView(WebTest):
         self.assertNotIn("Adam & Eve", page)
 
     def test_information_message(self):
-        page = self.app.get(self.url, user="editor@institution.example.com")
+        page = self.app.get(self.url, user=self.editor)
         self.assertNotContains(page, "You cannot edit this evaluation because it has already been approved")
         self.assertContains(page, "Please review the evaluation's details below, add all contributors and select suitable questionnaires. Once everything is okay, please approve the evaluation on the bottom of the page.")
 
@@ -265,7 +280,7 @@ class TestContributorEvaluationEditView(WebTest):
         self.assertEqual(self.evaluation.last_modified_user, None)
         last_modified_time_before = self.evaluation.last_modified_time
 
-        page = self.app.get(self.url, user="responsible@institution.example.com", status=200)
+        page = self.app.get(self.url, user=self.responsible, status=200)
         form = page.forms["evaluation-form"]
 
         # Change label of the first contribution
@@ -274,7 +289,7 @@ class TestContributorEvaluationEditView(WebTest):
 
         self.evaluation = Evaluation.objects.get(pk=self.evaluation.pk)
         self.assertEqual(self.evaluation.state, 'editor_approved')
-        self.assertEqual(self.evaluation.last_modified_user.email, 'responsible@institution.example.com')
+        self.assertEqual(self.evaluation.last_modified_user, self.responsible)
         self.assertGreater(self.evaluation.last_modified_time, last_modified_time_before)
 
     def test_last_modified_unchanged(self):
@@ -284,7 +299,7 @@ class TestContributorEvaluationEditView(WebTest):
         self.assertIsNone(self.evaluation.last_modified_user)
         last_modified_time_before = self.evaluation.last_modified_time
 
-        page = self.app.get(self.url, user="responsible@institution.example.com", status=200)
+        page = self.app.get(self.url, user=self.responsible, status=200)
         form = page.forms["evaluation-form"]
         form.submit(name="operation", value="approve")
 

--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -75,11 +75,11 @@ class TestContributorDirectDelegationView(WebTest):
 
 class TestContributorView(WebTestWith200Check):
     url = '/contributor/'
-    test_users = ['editor@institution.example.com', 'responsible@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
-        create_evaluation_with_responsible_and_editor()
+        users = create_evaluation_with_responsible_and_editor()
+        cls.test_users = [users['editor'], users['responsible']]
 
 
 class TestContributorSettingsView(WebTest):
@@ -102,14 +102,15 @@ class TestContributorSettingsView(WebTest):
 
 
 class TestContributorEvaluationView(WebTestWith200Check):
-    url = '/contributor/evaluation/%s' % TESTING_EVALUATION_ID
-    test_users = ['editor@institution.example.com', 'responsible@institution.example.com']
+    url = f'/contributor/evaluation/{TESTING_EVALUATION_ID}'
 
     @classmethod
     def setUpTestData(cls):
         result = create_evaluation_with_responsible_and_editor(evaluation_id=TESTING_EVALUATION_ID)
         cls.responsible = result['responsible']
         cls.editor = result['editor']
+
+        cls.test_users = [cls.editor, cls.responsible]
 
     def setUp(self):
         self.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)
@@ -129,13 +130,14 @@ class TestContributorEvaluationView(WebTestWith200Check):
 
 
 class TestContributorEvaluationPreviewView(WebTestWith200Check):
-    url = '/contributor/evaluation/%s/preview' % TESTING_EVALUATION_ID
-    test_users = ['editor@institution.example.com', 'responsible@institution.example.com']
+    url = f'/contributor/evaluation/{TESTING_EVALUATION_ID}/preview'
 
     @classmethod
     def setUpTestData(cls):
         result = create_evaluation_with_responsible_and_editor(evaluation_id=TESTING_EVALUATION_ID)
         cls.responsible = result['responsible']
+
+        cls.test_users = [result['editor'], result['responsible']]
 
     def setUp(self):
         self.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)

--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -31,7 +31,7 @@ class TestContributorDirectDelegationView(WebTest):
         page = self.app.post(
             f'/contributor/evaluation/{self.evaluation.id}/direct_delegation',
             params=data,
-            user=self.editor
+            user=self.editor,
         ).follow()
 
         self.assertContains(
@@ -57,7 +57,7 @@ class TestContributorDirectDelegationView(WebTest):
         page = self.app.post(
             f'/contributor/evaluation/{self.evaluation.id}/direct_delegation',
             params=data,
-            user=self.editor
+            user=self.editor,
         ).follow()
 
         self.assertContains(

--- a/evap/evaluation/tests/test_misc.py
+++ b/evap/evaluation/tests/test_misc.py
@@ -2,7 +2,6 @@ import os.path
 from io import StringIO
 
 from django.conf import settings
-from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -11,7 +10,7 @@ from django.urls import reverse
 from model_bakery import baker
 
 from evap.evaluation.models import Semester, UserProfile, CourseType, Degree
-from evap.evaluation.tests.tools import WebTest
+from evap.evaluation.tests.tools import WebTest, make_manager
 
 
 @override_settings(INSTITUTION_EMAIL_DOMAINS=["institution.com", "student.institution.com"])
@@ -19,8 +18,8 @@ class SampleXlsTests(WebTest):
 
     @classmethod
     def setUpTestData(cls):
+        cls.manager = make_manager()
         cls.semester = baker.make(Semester)
-        cls.user = baker.make(UserProfile, email="user@institution.example.com", groups=[Group.objects.get(name="Manager")])
         baker.make(CourseType, name_de="Vorlesung", name_en="Lecture", import_names=["Vorlesung"])
         baker.make(CourseType, name_de="Seminar", name_en="Seminar", import_names=["Seminar"])
         degree_bachelor = Degree.objects.get(name_de="Bachelor")
@@ -31,7 +30,7 @@ class SampleXlsTests(WebTest):
         degree_master.save()
 
     def test_sample_xls(self):
-        page = self.app.get(reverse("staff:semester_import", args=[self.semester.pk]), user=self.user)
+        page = self.app.get(reverse("staff:semester_import", args=[self.semester.pk]), user=self.manager)
 
         original_user_count = UserProfile.objects.count()
 
@@ -47,7 +46,7 @@ class SampleXlsTests(WebTest):
         self.assertEqual(UserProfile.objects.count(), original_user_count + 4)
 
     def test_sample_user_xls(self):
-        page = self.app.get("/staff/user/import", user=self.user)
+        page = self.app.get("/staff/user/import", user=self.manager)
 
         original_user_count = UserProfile.objects.count()
 

--- a/evap/evaluation/tests/test_misc.py
+++ b/evap/evaluation/tests/test_misc.py
@@ -20,7 +20,7 @@ class SampleXlsTests(WebTest):
     @classmethod
     def setUpTestData(cls):
         cls.semester = baker.make(Semester)
-        baker.make(UserProfile, email="user@institution.example.com", groups=[Group.objects.get(name="Manager")])
+        cls.user = baker.make(UserProfile, email="user@institution.example.com", groups=[Group.objects.get(name="Manager")])
         baker.make(CourseType, name_de="Vorlesung", name_en="Lecture", import_names=["Vorlesung"])
         baker.make(CourseType, name_de="Seminar", name_en="Seminar", import_names=["Seminar"])
         degree_bachelor = Degree.objects.get(name_de="Bachelor")
@@ -31,7 +31,7 @@ class SampleXlsTests(WebTest):
         degree_master.save()
 
     def test_sample_xls(self):
-        page = self.app.get(reverse("staff:semester_import", args=[self.semester.pk]), user="user@institution.example.com")
+        page = self.app.get(reverse("staff:semester_import", args=[self.semester.pk]), user=self.user)
 
         original_user_count = UserProfile.objects.count()
 
@@ -47,7 +47,7 @@ class SampleXlsTests(WebTest):
         self.assertEqual(UserProfile.objects.count(), original_user_count + 4)
 
     def test_sample_user_xls(self):
-        page = self.app.get("/staff/user/import", user="user@institution.example.com")
+        page = self.app.get("/staff/user/import", user=self.user)
 
         original_user_count = UserProfile.objects.count()
 

--- a/evap/evaluation/tests/test_views.py
+++ b/evap/evaluation/tests/test_views.py
@@ -54,7 +54,11 @@ class TestContactEmail(WebTest):
 
     def test_sends_mail(self):
         user = baker.make(UserProfile, email="user@institution.example.com")
-        self.app.post('/contact', params={'message': 'feedback message', 'title': 'some title', 'sender_email': 'unique@mail.de'}, user=user.email)
+        self.app.post(
+            '/contact',
+            params={'message': 'feedback message', 'title': 'some title', 'sender_email': 'unique@mail.de'},
+            user=user,
+        )
         self.assertEqual(len(mail.outbox), 1)
 
 
@@ -65,7 +69,7 @@ class TestChangeLanguageView(WebTest):
     def test_changes_language(self):
         user = baker.make(UserProfile, email='tester@institution.example.com', language='de')
 
-        self.app.post(self.url, params={'language': 'en'}, user='tester@institution.example.com')
+        self.app.post(self.url, params={'language': 'en'}, user=user)
 
         user.refresh_from_db()
         self.assertEqual(user.language, 'en')

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -99,5 +99,5 @@ def make_manager():
     return baker.make(
         UserProfile,
         email='manager@institution.example.com',
-        groups=[Group.objects.get(name='Manager')]
+        groups=[Group.objects.get(name='Manager')],
     )

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -87,4 +87,8 @@ def create_evaluation_with_responsible_and_editor(evaluation_id=None):
     )
     evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire, type=Questionnaire.Type.TOP)])
 
-    return evaluation
+    return {
+        'evaluation': evaluation,
+        'responsible': responsible,
+        'editor': editor,
+    }

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from django.contrib.auth.models import Group
 from django.http.request import QueryDict
 from django.utils import timezone
 
@@ -92,3 +93,11 @@ def create_evaluation_with_responsible_and_editor(evaluation_id=None):
         'responsible': responsible,
         'editor': editor,
     }
+
+
+def make_manager():
+    return baker.make(
+        UserProfile,
+        email='manager@institution.example.com',
+        groups=[Group.objects.get(name='Manager')]
+    )

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -17,7 +17,7 @@ class GradeUploadTest(WebTest):
         cls.grade_publisher = baker.make(
             UserProfile,
             email="grade_publisher@institution.example.com",
-            groups=[Group.objects.get(name="Grade publisher")]
+            groups=[Group.objects.get(name="Grade publisher")],
         )
         cls.student = baker.make(UserProfile, email="student@institution.example.com")
         cls.student2 = baker.make(UserProfile, email="student2@institution.example.com")
@@ -189,7 +189,7 @@ class GradeDocumentIndexTest(WebTest):
         cls.grade_publisher = baker.make(
             UserProfile,
             email="grade_publisher@institution.example.com",
-            groups=[Group.objects.get(name="Grade publisher")]
+            groups=[Group.objects.get(name="Grade publisher")],
         )
         cls.semester = baker.make(Semester, grade_documents_are_deleted=False)
         cls.archived_semester = baker.make(Semester, grade_documents_are_deleted=True)
@@ -208,7 +208,7 @@ class GradeSemesterViewTest(WebTest):
         cls.grade_publisher = baker.make(
             UserProfile,
             email="grade_publisher@institution.example.com",
-            groups=[Group.objects.get(name="Grade publisher")]
+            groups=[Group.objects.get(name="Grade publisher")],
         )
 
     def test_does_not_crash(self):
@@ -231,7 +231,7 @@ class GradeCourseViewTest(WebTest):
         cls.grade_publisher = baker.make(
             UserProfile,
             email="grade_publisher@institution.example.com",
-            groups=[Group.objects.get(name="Grade publisher")]
+            groups=[Group.objects.get(name="Grade publisher")],
         )
 
     def test_does_not_crash(self):

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -14,7 +14,11 @@ class GradeUploadTest(WebTest):
 
     @classmethod
     def setUpTestData(cls):
-        baker.make(UserProfile, email="grade_publisher@institution.example.com", groups=[Group.objects.get(name="Grade publisher")])
+        cls.grade_publisher = baker.make(
+            UserProfile,
+            email="grade_publisher@institution.example.com",
+            groups=[Group.objects.get(name="Grade publisher")]
+        )
         cls.student = baker.make(UserProfile, email="student@institution.example.com")
         cls.student2 = baker.make(UserProfile, email="student2@institution.example.com")
         cls.student3 = baker.make(UserProfile, email="student3@institution.example.com")
@@ -57,7 +61,7 @@ class GradeUploadTest(WebTest):
         response = self.app.post(
             "/grades/semester/{}/course/{}/upload{}".format(course.semester.id, course.id, final),
             params={"description_en": "Grades", "description_de": "Grades"},
-            user="grade_publisher@institution.example.com",
+            user=self.grade_publisher,
             content_type='multipart/form-data',
             upload_files=upload_files,
         ).follow()
@@ -69,7 +73,7 @@ class GradeUploadTest(WebTest):
         self.assertIn("Successfully", response)
         self.assertEqual(course.final_grade_documents.count(), 1)
         self.assertEqual(len(mail.outbox), expected_number_of_emails)
-        response = self.app.get("/grades/download/{}".format(course.final_grade_documents.first().id), user="student@institution.example.com")
+        response = self.app.get("/grades/download/{}".format(course.final_grade_documents.first().id), user=self.student)
         self.assertEqual(response.status_code, 200)
 
         # tear down
@@ -152,7 +156,7 @@ class GradeUploadTest(WebTest):
 
         self.assertFalse(evaluation.course.gets_no_grade_documents)
 
-        response = self.app.post("/grades/toggle_no_grades", params={"course_id": evaluation.course.id}, user="grade_publisher@institution.example.com")
+        response = self.app.post("/grades/toggle_no_grades", params={"course_id": evaluation.course.id}, user=self.grade_publisher)
         self.assertEqual(response.status_code, 200)
         evaluation = Evaluation.objects.get(id=evaluation.id)
         self.assertTrue(evaluation.course.gets_no_grade_documents)
@@ -160,7 +164,7 @@ class GradeUploadTest(WebTest):
         self.assertEqual(evaluation.state, "published")
         self.assertEqual(len(mail.outbox), evaluation.num_participants + evaluation.contributions.exclude(contributor=None).count())
 
-        response = self.app.post("/grades/toggle_no_grades", params={"course_id": evaluation.course.id}, user="grade_publisher@institution.example.com")
+        response = self.app.post("/grades/toggle_no_grades", params={"course_id": evaluation.course.id}, user=self.grade_publisher)
         self.assertEqual(response.status_code, 200)
         evaluation = Evaluation.objects.get(id=evaluation.id)
         self.assertFalse(evaluation.course.gets_no_grade_documents)
@@ -171,10 +175,10 @@ class GradeUploadTest(WebTest):
         self.assertGreater(self.course.midterm_grade_documents.count(), 0)
 
         url = "/grades/download/" + str(self.course.midterm_grade_documents.first().id)
-        self.app.get(url, user="student@institution.example.com", status=200)  # grades should be downloadable
+        self.app.get(url, user=self.student, status=200)  # grades should be downloadable
 
         self.semester.delete_grade_documents()
-        self.app.get(url, user="student@institution.example.com", status=404)  # grades should not be downloadable anymore
+        self.app.get(url, user=self.student, status=404)  # grades should not be downloadable anymore
 
 
 class GradeDocumentIndexTest(WebTest):
@@ -182,12 +186,16 @@ class GradeDocumentIndexTest(WebTest):
 
     @classmethod
     def setUpTestData(cls):
-        baker.make(UserProfile, email="grade_publisher@institution.example.com", groups=[Group.objects.get(name="Grade publisher")])
+        cls.grade_publisher = baker.make(
+            UserProfile,
+            email="grade_publisher@institution.example.com",
+            groups=[Group.objects.get(name="Grade publisher")]
+        )
         cls.semester = baker.make(Semester, grade_documents_are_deleted=False)
         cls.archived_semester = baker.make(Semester, grade_documents_are_deleted=True)
 
     def test_visible_semesters(self):
-        page = self.app.get(self.url, user="grade_publisher@institution.example.com", status=200)
+        page = self.app.get(self.url, user=self.grade_publisher, status=200)
         self.assertIn(self.semester.name, page)
         self.assertNotIn(self.archived_semester.name, page)
 
@@ -197,18 +205,22 @@ class GradeSemesterViewTest(WebTest):
 
     @classmethod
     def setUpTestData(cls):
-        baker.make(UserProfile, email="grade_publisher@institution.example.com", groups=[Group.objects.get(name="Grade publisher")])
+        cls.grade_publisher = baker.make(
+            UserProfile,
+            email="grade_publisher@institution.example.com",
+            groups=[Group.objects.get(name="Grade publisher")]
+        )
 
     def test_does_not_crash(self):
         semester = baker.make(Semester, pk=1, grade_documents_are_deleted=False)
         course = baker.make(Course, semester=semester)
         baker.make(Evaluation, course=course, state="prepared")
-        page = self.app.get(self.url, user="grade_publisher@institution.example.com", status=200)
+        page = self.app.get(self.url, user=self.grade_publisher, status=200)
         self.assertIn(course.name, page)
 
     def test_403_on_deleted(self):
         baker.make(Semester, pk=1, grade_documents_are_deleted=True)
-        self.app.get('/grades/semester/1', user="grade_publisher@institution.example.com", status=403)
+        self.app.get('/grades/semester/1', user=self.grade_publisher, status=403)
 
 
 class GradeCourseViewTest(WebTest):
@@ -216,14 +228,18 @@ class GradeCourseViewTest(WebTest):
 
     @classmethod
     def setUpTestData(cls):
-        baker.make(UserProfile, email="grade_publisher@institution.example.com", groups=[Group.objects.get(name="Grade publisher")])
+        cls.grade_publisher = baker.make(
+            UserProfile,
+            email="grade_publisher@institution.example.com",
+            groups=[Group.objects.get(name="Grade publisher")]
+        )
 
     def test_does_not_crash(self):
         semester = baker.make(Semester, pk=1, grade_documents_are_deleted=False)
         baker.make(Evaluation, course=baker.make(Course, pk=1, semester=semester), state="prepared")
-        self.app.get('/grades/semester/1/course/1', user="grade_publisher@institution.example.com", status=200)
+        self.app.get('/grades/semester/1/course/1', user=self.grade_publisher, status=200)
 
     def test_403_on_archived_semester(self):
         archived_semester = baker.make(Semester, pk=1, grade_documents_are_deleted=True)
         baker.make(Evaluation, course=baker.make(Course, pk=1, semester=archived_semester), state="prepared")
-        self.app.get('/grades/semester/1/course/1', user="grade_publisher@institution.example.com", status=403)
+        self.app.get('/grades/semester/1/course/1', user=self.grade_publisher, status=403)

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -134,7 +134,7 @@ class TestResultsViewContributionWarning(WebTest):
             state='published',
             course=baker.make(Course, semester=cls.semester),
             participants=[student1, student2],
-            voters=[student1, student2]
+            voters=[student1, student2],
         )
         questionnaire = baker.make(Questionnaire)
         cls.evaluation.general_contribution.questionnaires.set([questionnaire])
@@ -142,7 +142,7 @@ class TestResultsViewContributionWarning(WebTest):
             Contribution,
             evaluation=cls.evaluation,
             questionnaires=[questionnaire],
-            contributor=contributor
+            contributor=contributor,
         )
         cls.likert_question = baker.make(Question, type=Question.LIKERT, questionnaire=questionnaire, order=2)
         cls.url = '/results/semester/%s/evaluation/%s' % (cls.semester.id, cls.evaluation.id)
@@ -788,7 +788,7 @@ class TestTextAnswerExportView(WebTest):
         cls.reviewer = baker.make(
             UserProfile,
             email="reviewer@institution.example.com",
-            groups=[Group.objects.get(name="Reviewer")]
+            groups=[Group.objects.get(name="Reviewer")],
         )
         evaluation = baker.make(Evaluation)
         cls.url = f"/results/evaluation/{evaluation.id}/text_answers_export"

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -164,7 +164,6 @@ class TestResultsViewContributionWarning(WebTest):
 
 class TestResultsSemesterEvaluationDetailView(WebTestWith200Check):
     url = '/results/semester/2/evaluation/21'
-    test_users = ['manager@institution.example.com', 'contributor@institution.example.com', 'responsible@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
@@ -173,6 +172,8 @@ class TestResultsSemesterEvaluationDetailView(WebTestWith200Check):
 
         contributor = baker.make(UserProfile, email='contributor@institution.example.com')
         responsible = baker.make(UserProfile, email='responsible@institution.example.com')
+
+        cls.test_users = [cls.manager, contributor, responsible]
 
         # Normal evaluation with responsible and contributor.
         cls.evaluation = baker.make(Evaluation, id=21, state='published', course=baker.make(Course, semester=cls.semester))

--- a/evap/rewards/tests/test_tools.py
+++ b/evap/rewards/tests/test_tools.py
@@ -27,7 +27,7 @@ class TestGrantRewardPoints(WebTest):
         cls.evaluation.general_contribution.questionnaires.set([questionnaire])
 
     def setUp(self):
-        response = self.app.get(reverse("student:vote", args=[self.evaluation.pk]), user="student@institution.example.com")
+        response = self.app.get(reverse("student:vote", args=[self.evaluation.pk]), user=self.student)
 
         self.form = response.forms["student-vote-form"]
         for key in self.form.fields.keys():

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -79,11 +79,11 @@ class TestIndexView(WebTest):
 
 class TestEventsView(WebTestWith200Check):
     url = reverse('rewards:reward_point_redemption_events')
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
-        make_manager()
+        cls.test_users = [make_manager()]
+
         baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
         baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
 
@@ -134,11 +134,11 @@ class TestEventEditView(WebTest):
 
 class TestExportView(WebTestWith200Check):
     url = '/rewards/reward_point_redemption_event/1/export'
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
-        make_manager()
+        cls.test_users = [make_manager()]
+
         event = baker.make(RewardPointRedemptionEvent, pk=1, redeem_end_date=date.today() + timedelta(days=1))
         baker.make(RewardPointRedemption, value=1, event=event)
 

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -1,13 +1,12 @@
 from datetime import date, timedelta
 
-from django.contrib.auth.models import Group
 from django.urls import reverse
 
 from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import UserProfile, Evaluation, Semester
-from evap.evaluation.tests.tools import WebTestWith200Check
+from evap.evaluation.tests.tools import WebTestWith200Check, make_manager
 from evap.rewards.models import RewardPointRedemptionEvent, RewardPointGranting, RewardPointRedemption, SemesterActivation
 from evap.rewards.tools import reward_points_of_user, is_semester_activated
 
@@ -18,11 +17,7 @@ class TestEventDeleteView(WebTest):
 
     @classmethod
     def setUpTestData(cls):
-        cls.manager = baker.make(
-            UserProfile,
-            email='manager@institution.example.com',
-            groups=[Group.objects.get(name='Manager')]
-        )
+        cls.manager = make_manager()
 
     def test_deletion_success(self):
         event = baker.make(RewardPointRedemptionEvent)
@@ -88,7 +83,7 @@ class TestEventsView(WebTestWith200Check):
 
     @classmethod
     def setUpTestData(cls):
-        baker.make(UserProfile, email='manager@institution.example.com', groups=[Group.objects.get(name='Manager')])
+        make_manager()
         baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
         baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
 
@@ -99,11 +94,7 @@ class TestEventCreateView(WebTest):
 
     @classmethod
     def setUpTestData(cls):
-        cls.manager = baker.make(
-            UserProfile,
-            email='manager@institution.example.com',
-            groups=[Group.objects.get(name='Manager')]
-        )
+        cls.manager = make_manager()
 
     def test_create_redemption_event(self):
         """ submits a newly created redemption event and checks that the event has been created """
@@ -126,11 +117,7 @@ class TestEventEditView(WebTest):
 
     @classmethod
     def setUpTestData(cls):
-        cls.manager = baker.make(
-            UserProfile,
-            email='manager@institution.example.com',
-            groups=[Group.objects.get(name='Manager')]
-        )
+        cls.manager = make_manager()
         cls.event = baker.make(RewardPointRedemptionEvent, pk=1, name='old name')
 
     def test_edit_redemption_event(self):
@@ -151,7 +138,7 @@ class TestExportView(WebTestWith200Check):
 
     @classmethod
     def setUpTestData(cls):
-        baker.make(UserProfile, email='manager@institution.example.com', groups=[Group.objects.get(name='Manager')])
+        make_manager()
         event = baker.make(RewardPointRedemptionEvent, pk=1, redeem_end_date=date.today() + timedelta(days=1))
         baker.make(RewardPointRedemption, value=1, event=event)
 
@@ -162,11 +149,7 @@ class TestSemesterActivationView(WebTest):
 
     @classmethod
     def setUpTestData(cls):
-        cls.manager = baker.make(
-            UserProfile,
-            email='manager@institution.example.com',
-            groups=[Group.objects.get(name='Manager')]
-        )
+        cls.manager = make_manager()
         cls.semester = baker.make(Semester, pk=1)
 
     def test_activate(self):

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -69,7 +69,7 @@ class EvaluationEmailFormTests(TestCase):
         """
             Tests the EvaluationEmailForm with one valid and one invalid input dataset.
         """
-        evaluation = create_evaluation_with_responsible_and_editor()
+        evaluation = create_evaluation_with_responsible_and_editor()['evaluation']
         data = {"body": "wat", "subject": "some subject", "recipients": [EmailTemplate.Recipients.DUE_PARTICIPANTS]}
         form = EvaluationEmailForm(evaluation=evaluation, data=data)
         self.assertTrue(form.is_valid())

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -104,7 +104,7 @@ class TestUserIndexView(WebTest):
             state="published",
             course__semester=semester,
             _participant_count=1,
-            _voter_count=1
+            _voter_count=1,
         )
         baker.make(UserProfile, _quantity=num_users, evaluations_participating_in=[evaluation])
 
@@ -432,13 +432,13 @@ class TestSemesterView(WebTest):
             Evaluation,
             name_de="Evaluation 1",
             name_en="Evaluation 1",
-            course=baker.make(Course, name_de="A", name_en="B", semester=cls.semester)
+            course=baker.make(Course, name_de="A", name_en="B", semester=cls.semester),
         )
         cls.evaluation2 = baker.make(
             Evaluation,
             name_de="Evaluation 2",
             name_en="Evaluation 2",
-            course=baker.make(Course, name_de="B", name_en="A", semester=cls.semester)
+            course=baker.make(Course, name_de="B", name_en="A", semester=cls.semester),
         )
 
     def test_view_list_sorting(self):
@@ -461,7 +461,7 @@ class TestSemesterView(WebTest):
         reviewer = baker.make(
             UserProfile,
             email='reviewer@institution.example.com',
-            groups=[Group.objects.get(name='Reviewer')]
+            groups=[Group.objects.get(name='Reviewer')],
         )
         baker.make(Semester, pk=2, results_are_archived=True)
 
@@ -587,7 +587,7 @@ class TestSemesterDeleteView(WebTest):
             Evaluation,
             course=baker.make(Course, semester=semester),
             state='in_evaluation',
-            voters=[baker.make(UserProfile)]
+            voters=[baker.make(UserProfile)],
         )
         self.assertFalse(semester.can_be_deleted_by_manager)
 
@@ -739,7 +739,7 @@ class TestSendReminderView(WebTest):
         baker.make(
             Evaluation,
             course=baker.make(Course, semester=cls.semester, responsibles=[responsible]),
-            state='prepared'
+            state='prepared',
         )
 
     def test_form(self):
@@ -995,7 +995,7 @@ class TestSemesterParticipationDataExportView(WebTest):
             voters=[cls.student_user],
             name_de="Veranstaltung 1",
             name_en="Evaluation 1",
-            is_rewarded=True
+            is_rewarded=True,
         )
         cls.evaluation2 = baker.make(
             Evaluation,
@@ -1003,7 +1003,7 @@ class TestSemesterParticipationDataExportView(WebTest):
             participants=[cls.student_user, cls.student_user2],
             name_de="Veranstaltung 2",
             name_en="Evaluation 2",
-            is_rewarded=False
+            is_rewarded=False,
         )
         baker.make(
             Contribution,
@@ -1045,7 +1045,7 @@ class TestLoginKeyExportView(WebTest):
             pk=1,
             course__semester=semester,
             participants=[cls.external_user, cls.internal_user],
-            voters=[cls.external_user, cls.internal_user]
+            voters=[cls.external_user, cls.internal_user],
         )
 
     def test_login_key_export_works_as_expected(self):
@@ -1470,7 +1470,7 @@ class TestCourseEditView(WebTest):
             responsibles=[responsible],
             pk=1,
             last_modified_user=cls.manager,
-            last_modified_time=datetime.datetime(2000, 1, 1, 0, 0)
+            last_modified_time=datetime.datetime(2000, 1, 1, 0, 0),
         )
 
     def setUp(self):
@@ -1541,7 +1541,7 @@ class TestEvaluationEditView(WebTest):
             pk=1,
             last_modified_user=cls.manager,
             vote_start_datetime=datetime.datetime(2099, 1, 1, 0, 0),
-            vote_end_date=datetime.date(2099, 12, 31)
+            vote_end_date=datetime.date(2099, 12, 31),
         )
         baker.make(Questionnaire, questions=[baker.make(Question)])
         cls.evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
@@ -2001,7 +2001,7 @@ class TestEvaluationTextAnswerView(WebTest):
             Contribution,
             evaluation=cls.evaluation,
             contributor=baker.make(UserProfile),
-            questionnaires=[questionnaire]
+            questionnaires=[questionnaire],
         )
         cls.answer = 'should show up'
         baker.make(TextAnswer, contribution=contribution, question=question, answer=cls.answer)
@@ -2053,13 +2053,13 @@ class TestEvaluationTextAnswerEditView(WebTest):
             Contribution,
             evaluation=cls.evaluation,
             contributor=baker.make(UserProfile),
-            questionnaires=[questionnaire]
+            questionnaires=[questionnaire],
         )
         cls.text_answer = baker.make(
             TextAnswer,
             contribution=contribution,
             question=question,
-            answer='test answer text'
+            answer='test answer text',
         )
 
         cls.url = f'/staff/semester/1/evaluation/1/textanswer/{cls.text_answer.id}/edit'
@@ -2285,7 +2285,7 @@ class TestQuestionnaireDeletionView(WebTest):
             "/staff/questionnaire/delete",
             params={"questionnaire_id": self.q1.pk},
             user=self.manager,
-            expect_errors=True
+            expect_errors=True,
         )
         self.assertEqual(response.status_code, 400)
         self.assertTrue(Questionnaire.objects.filter(pk=self.q1.pk).exists())
@@ -2294,7 +2294,7 @@ class TestQuestionnaireDeletionView(WebTest):
         response = self.app.post(
             "/staff/questionnaire/delete",
             params={"questionnaire_id": self.q2.pk},
-            user=self.manager
+            user=self.manager,
         )
         self.assertEqual(response.status_code, 200)
         self.assertFalse(Questionnaire.objects.filter(pk=self.q2.pk).exists())
@@ -2400,7 +2400,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
             Evaluation,
             participants=[cls.student1, cls.student2],
             voters=[cls.student1],
-            state="in_evaluation"
+            state="in_evaluation",
         )
         top_general_questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.TOP)
         baker.make(Question, questionnaire=top_general_questionnaire, type=Question.LIKERT)
@@ -2412,7 +2412,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
             self.url,
             params={"id": textanswer.id, "action": action, "evaluation_id": self.evaluation.pk},
             user=self.manager,
-            expect_errors=expect_errors
+            expect_errors=expect_errors,
         )
         if expect_errors:
             self.assertEqual(response.status_code, 403)
@@ -2533,11 +2533,11 @@ class TestSemesterQuestionnaireAssignment(WebTest):
         cls.questionnaire_responsible = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
         cls.evaluation_1 = baker.make(
             Evaluation,
-            course=baker.make(Course, semester=cls.semester, type=cls.course_type_1, responsibles=[cls.responsible])
+            course=baker.make(Course, semester=cls.semester, type=cls.course_type_1, responsibles=[cls.responsible]),
         )
         cls.evaluation_2 = baker.make(
             Evaluation,
-            course=baker.make(Course, semester=cls.semester, type=cls.course_type_2, responsibles=[cls.responsible])
+            course=baker.make(Course, semester=cls.semester, type=cls.course_type_2, responsibles=[cls.responsible]),
         )
         baker.make(
             Contribution,

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -57,30 +57,28 @@ class TestDownloadSampleXlsView(WebTest):
 
 
 class TestStaffIndexView(WebTestWith200Check):
-    test_users = ['manager@institution.example.com']
     url = '/staff/'
 
     @classmethod
     def setUpTestData(cls):
-        make_manager()
+        cls.test_users = [make_manager()]
 
 
 class TestStaffFAQView(WebTestWith200Check):
     url = '/staff/faq/'
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
-        make_manager()
+        cls.test_users = [make_manager()]
 
 
 class TestStaffFAQEditView(WebTestWith200Check):
     url = '/staff/faq/1'
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
-        make_manager()
+        cls.test_users = [make_manager()]
+
         section = baker.make(FaqSection, pk=1)
         baker.make(FaqQuestion, section=section)
 
@@ -174,21 +172,21 @@ class TestUserEditView(WebTest):
 
 class TestUserMergeSelectionView(WebTestWith200Check):
     url = "/staff/user/merge"
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
-        make_manager()
+        cls.test_users = [make_manager()]
+
         baker.make(UserProfile)
 
 
 class TestUserMergeView(WebTestWith200Check):
     url = "/staff/user/3/merge/4"
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
-        make_manager()
+        cls.test_users = [make_manager()]
+
         baker.make(UserProfile, pk=3)
         baker.make(UserProfile, pk=4)
 
@@ -681,13 +679,14 @@ class TestSemesterAssignView(WebTest):
 
 class TestSemesterPreparationReminderView(WebTestWith200Check):
     url = '/staff/semester/1/preparation_reminder'
-    test_users = ['manager@institution.example.com']
     csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
         cls.manager = make_manager()
         cls.semester = baker.make(Semester, pk=1)
+
+        cls.test_users = [cls.manager]
 
     def test_preparation_reminder(self):
         user = baker.make(UserProfile, email='user_to_find@institution.example.com')
@@ -942,13 +941,14 @@ class TestSemesterExportView(WebTest):
 
 class TestSemesterRawDataExportView(WebTestWith200Check):
     url = '/staff/semester/1/raw_export'
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
         cls.manager = make_manager()
         cls.semester = baker.make(Semester, pk=1)
         cls.course_type = baker.make(CourseType, name_en="Type")
+
+        cls.test_users = [cls.manager]
 
     def test_view_downloads_csv_file(self):
         student_user = baker.make(UserProfile, email='student@institution.example.com')
@@ -1724,13 +1724,12 @@ class TestEvaluationEditView(WebTest):
 
 class TestSingleResultEditView(WebTestWith200Check):
     url = '/staff/semester/1/evaluation/1/edit'
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
-        make_manager()
-        semester = baker.make(Semester, pk=1)
+        cls.test_users = [make_manager()]
 
+        semester = baker.make(Semester, pk=1)
         responsible = baker.make(UserProfile)
         evaluation = baker.make(Evaluation, course=baker.make(Course, semester=semester, responsibles=[responsible]), pk=1)
         contribution = baker.make(
@@ -1752,11 +1751,11 @@ class TestSingleResultEditView(WebTestWith200Check):
 
 class TestEvaluationPreviewView(WebTestWith200Check):
     url = '/staff/semester/1/evaluation/1/preview'
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
-        make_manager()
+        cls.test_users = [make_manager()]
+
         semester = baker.make(Semester, pk=1)
         evaluation = baker.make(Evaluation, course=baker.make(Course, semester=semester), pk=1)
         evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
@@ -2186,11 +2185,12 @@ class TestQuestionnaireIndexView(WebTest):
 
 class TestQuestionnaireEditView(WebTestWith200Check):
     url = '/staff/questionnaire/2/edit'
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
         cls.manager = make_manager()
+        cls.test_users = [cls.manager]
+
         evaluation = baker.make(Evaluation, state='in_evaluation')
         cls.questionnaire = baker.make(Questionnaire, id=2)
         baker.make(Contribution, questionnaires=[cls.questionnaire], evaluation=evaluation)
@@ -2225,11 +2225,11 @@ class TestQuestionnaireEditView(WebTestWith200Check):
 
 class TestQuestionnaireViewView(WebTestWith200Check):
     url = '/staff/questionnaire/2'
-    test_users = ['manager@institution.example.com']
 
     @classmethod
     def setUpTestData(cls):
-        make_manager()
+        cls.test_users = [make_manager()]
+
         questionnaire = baker.make(Questionnaire, id=2)
         baker.make(Question, questionnaire=questionnaire, type=Question.TEXT)
         baker.make(Question, questionnaire=questionnaire, type=Question.GRADE)

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -11,13 +11,15 @@ from evap.student.views import SUCCESS_MAGIC_STRING
 
 
 class TestStudentIndexView(WebTestWith200Check):
-    test_users = ['student@institution.example.com']
     url = '/student/'
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         # View is only visible to users participating in at least one evaluation.
         user = baker.make(UserProfile, email='student@institution.example.com')
         baker.make(Evaluation, participants=[user])
+
+        cls.test_users = [user]
 
 
 @override_settings(INSTITUTION_EMAIL_DOMAINS=["example.com"])

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -59,7 +59,7 @@ class TestVoteView(WebTest):
         cls.evaluation.general_contribution.questionnaires.set([cls.top_general_questionnaire, cls.bottom_general_questionnaire])
 
     def test_question_ordering(self):
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
 
         top_heading_index = page.body.decode().index(self.top_heading_question.text)
         top_text_index = page.body.decode().index(self.top_text_question.text)
@@ -123,7 +123,7 @@ class TestVoteView(WebTest):
             Submits a student vote, verifies that an error message is displayed if not all rating questions about
             contributors have been answered and that all given answers stay selected/filled.
         """
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
         form = page.forms["student-vote-form"]
         self.fill_form(form, fill_contributors_complete=False)
         response = form.submit()
@@ -146,13 +146,13 @@ class TestVoteView(WebTest):
         self.assertEqual(form[question_id(self.contribution2, self.contributor_questionnaire, self.contributor_text_question)].value, "some more text")
 
     def test_answer(self):
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
         form = page.forms["student-vote-form"]
         self.fill_form(form)
         response = form.submit()
         self.assertEqual(SUCCESS_MAGIC_STRING, response.body.decode())
 
-        page = self.app.get(self.url, user=self.voting_user2.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user2, status=200)
         form = page.forms["student-vote-form"]
         self.fill_form(form)
         response = form.submit()
@@ -197,12 +197,12 @@ class TestVoteView(WebTest):
         self.assertEqual(list(answers), ["some bottom text"] * 2)
 
     def test_user_cannot_vote_multiple_times(self):
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
         form = page.forms["student-vote-form"]
         self.fill_form(form)
         form.submit()
 
-        self.app.get(self.url, user=self.voting_user1.email, status=403)
+        self.app.get(self.url, user=self.voting_user1, status=403)
 
     def test_user_cannot_vote_for_themselves(self):
         response = self.app.get(self.url, user=self.contributor1, status=200)
@@ -215,39 +215,39 @@ class TestVoteView(WebTest):
             "Regular students should see the questionnaire about a contributor")
 
     def test_user_logged_out(self):
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
         form = page.forms["student-vote-form"]
         self.fill_form(form)
-        page = self.app.get(reverse("django-auth-logout"), user=self.voting_user1.email, status=302)
+        page = self.app.get(reverse("django-auth-logout"), user=self.voting_user1, status=302)
         response = form.submit()
         self.assertEqual(response.status_code, 302)
         self.assertNotIn(SUCCESS_MAGIC_STRING, response)
 
     def test_midterm_evaluation_warning(self):
         evaluation_warning = "The results of this evaluation will be published while the course is still running."
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
         self.assertNotIn(evaluation_warning, page)
 
         self.evaluation.is_midterm_evaluation = True
         self.evaluation.save()
 
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
         self.assertIn(evaluation_warning, page)
 
     @override_settings(SMALL_COURSE_SIZE=5)
     def test_small_evaluation_size_warning_shown(self):
         small_evaluation_size_warning = "Only a small number of people can take part in this evaluation."
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
         self.assertIn(small_evaluation_size_warning, page)
 
     @override_settings(SMALL_COURSE_SIZE=2)
     def test_small_evaluation_size_warning_not_shown(self):
         small_evaluation_size_warning = "Only a small number of people can take part in this evaluation."
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
         self.assertNotIn(small_evaluation_size_warning, page)
 
     def helper_test_answer_publish_confirmation(self, form_element):
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
         form = page.forms["student-vote-form"]
         self.fill_form(form)
         if form_element:
@@ -270,7 +270,7 @@ class TestVoteView(WebTest):
         self.helper_test_answer_publish_confirmation(None)
 
     def test_textanswer_visibility_is_shown(self):
-        page = self.app.get(self.url, user=self.voting_user1.email, status=200)
+        page = self.app.get(self.url, user=self.voting_user1, status=200)
         self.assertRegex(
             page.body.decode(),
             r"can be seen by:<br />\s*{}".format(self.contributor1.full_name.replace('(', '\\(').replace(')', '\\)'))


### PR DESCRIPTION
Fixes #1475.

I found it intriguing how often we had that same `baker.make` call for creating a manager. I considered making a baker recipe to shorten these calls, but I wasn't quite happy with how they work, so I decided to go for a helper function. I'm open for suggestions here, though.

Also, I came along a lot of very long lines (like >160 chars) during this, so I chopped some of them down. I think it significantly improved readability at these places, but I'm also open for suggestions here. Our tests kind of suffer from the fact that we often have to work through very verbose hierarchies to express ourselves.