### PR TITLE
Show participations and votes on user merge

### DIFF
--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -141,15 +141,15 @@
                     <tr{% if 'courses_responsible_for' in errors %} class="table-danger"{% endif %}>
                         <td><strong>{% trans 'Courses responsible for' %}</strong></td>
                         {% regroup main_user.get_sorted_courses_responsible_for by semester as course_list %}
-                        <td{% if course_list|length > 0 %} class="info"{% endif %}>
+                        <td{% if course_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=course_list %}
                         </td>
                         {% regroup other_user.get_sorted_courses_responsible_for by semester as course_list %}
-                        <td{% if course_list|length > 0 %} class="info"{% endif %}>
+                        <td{% if course_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=course_list %}
                         </td>
                         {% regroup merged_user.courses_responsible_for by semester as course_list %}
-                        <td{% if course_list|length > 0 %} class="success"{% endif %}>
+                        <td{% if course_list|length > 0 %} class="table-success"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=course_list %}
                         </td>
                     </tr>
@@ -157,15 +157,15 @@
                     <tr{% if 'contributions' in errors %} class="table-danger"{% endif %}>
                         <td><strong>{% trans 'Contributions' %}</strong></td>
                         {% regroup main_user.get_sorted_contributions by evaluation.course.semester as contribution_list %}
-                        <td{% if contribution_list|length > 0 %} class="info"{% endif %}>
+                        <td{% if contribution_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=contribution_list %}
                         </td>
                         {% regroup other_user.get_sorted_contributions by evaluation.course.semester as contribution_list %}
-                        <td{% if contribution_list|length > 0 %} class="info"{% endif %}>
+                        <td{% if contribution_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=contribution_list %}
                         </td>
                         {% regroup merged_user.contributions by evaluation.course.semester as contribution_list %}
-                        <td{% if contribution_list|length > 0 %} class="success"{% endif %}>
+                        <td{% if contribution_list|length > 0 %} class="table-success"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=contribution_list %}
                         </td>
                     </tr>
@@ -173,15 +173,15 @@
                     <tr{% if 'evaluations_participating_in' in errors %} class="table-danger"{% endif %}>
                         <td><strong>{% trans 'Participated in' %}</strong></td>
                         {% regroup main_user.get_sorted_evaluations_participating_in by course.semester as participation_list %}
-                        <td{% if participation_list|length > 0 %} class="info"{% endif %}>
+                        <td{% if participation_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=participation_list %}
                         </td>
                         {% regroup other_user.get_sorted_evaluations_participating_in by course.semester as participation_list %}
-                        <td{% if participation_list|length > 0 %} class="info"{% endif %}>
+                        <td{% if participation_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=participation_list %}
                         </td>
-                        {% regroup merged_user.get_sorted_evaluations_participating_in by course.semester as participation_list %}
-                        <td{% if participation_list|length > 0 %} class="success"{% endif %}>
+                        {% regroup merged_user.evaluations_participating_in by course.semester as participation_list %}
+                        <td{% if participation_list|length > 0 %} class="table-success"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=participation_list %}
                         </td>
                     </tr>
@@ -189,15 +189,15 @@
                     <tr{% if 'evaluations_voted_for' in errors %} class="table-danger"{% endif %}>
                         <td><strong>{% trans 'Voted for' %}</strong></td>
                         {% regroup main_user.get_sorted_evaluations_voted_for by course.semester as voting_list %}
-                        <td{% if voting_list|length > 0 %} class="info"{% endif %}>
+                        <td{% if voting_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=voting_list %}
                         </td>
                         {% regroup other_user.get_sorted_evaluations_voted_for by course.semester as voting_list %}
-                        <td{% if voting_list|length > 0 %} class="info"{% endif %}>
+                        <td{% if voting_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=voting_list %}
                         </td>
-                        {% regroup merged_user.get_sorted_evaluations_voted_for by course.semester as voting_list %}
-                        <td{% if voting_list|length > 0 %} class="success"{% endif %}>
+                        {% regroup merged_user.evaluations_voted_for by course.semester as voting_list %}
+                        <td{% if voting_list|length > 0 %} class="table-success"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=voting_list %}
                         </td>
                     </tr>

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -185,10 +185,27 @@ class TestUserMergeView(WebTestWith200Check):
 
     @classmethod
     def setUpTestData(cls):
-        cls.test_users = [make_manager()]
+        cls.manager = make_manager()
+        cls.test_users = [cls.manager]
 
-        baker.make(UserProfile, pk=3)
-        baker.make(UserProfile, pk=4)
+        cls.main_user = baker.make(UserProfile, pk=3)
+        cls.other_user = baker.make(UserProfile, pk=4)
+
+    def test_shows_evaluations_participating_in(self):
+        evaluation = baker.make(Evaluation, name_en="The journey of unit-testing", participants=[self.main_user])
+
+        page = self.app.get(self.url, user=self.manager)
+        self.assertContains(page, evaluation.name_en, count=2,
+                            msg_prefix="The evaluation name should be displayed twice: "
+                                       "in the column of the participant and in the column of the merged data")
+
+    def test_shows_evaluations_voted_for(self):
+        evaluation = baker.make(Evaluation, name_en="Voting theory", voters=[self.main_user])
+
+        page = self.app.get(self.url, user=self.manager)
+        self.assertContains(page, evaluation.name_en, count=2,
+                            msg_prefix="The evaluation name should be displayed twice: "
+                                       "in the column of the voter and in the column of the merged data")
 
 
 class TestUserBulkUpdateView(WebTest):


### PR DESCRIPTION
Resolves #1480 

This was properly introduced in 8a2eaf6dd6961a1f56711f5896b0014da1fa2b88, where the lines were changed to have a consistent ordering.
But, I think it is unnecessary to explicitely sort here, as the `merged_user` is a `dict` which `courses_responsible_for`, `contributions`, `evaluations_participating_in`, `evaluations_voted_for` are sorted according to the semester: https://github.com/e-valuation/EvaP/blob/56c307a7347861ed3bbfd4327be28fca152bc4c8/evap/staff/tools.py#L238-L241

To check that the regression is caught, run:
```
git checkout master
git checkout user-merge-missing-participation evap/staff/tests/test_views.py
./manage.py test
```

But I might overlook something, pinging @karyon for this case :)