### PR TITLE
Introduce staff mode

### DIFF
--- a/evap/evaluation/auth.py
+++ b/evap/evaluation/auth.py
@@ -66,6 +66,15 @@ def internal_required(view_func):
     return user_passes_test(check_user)(view_func)
 
 
+def staff_permission_required(view_func):
+    """
+    Decorator for views that checks that the user is logged in and staff (regardless of staff mode!)
+    """
+    def check_user(user):
+        return user.has_staff_permission
+    return user_passes_test(check_user)(view_func)
+
+
 def manager_required(view_func):
     """
     Decorator for views that checks that the user is logged in and a manager

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1360,6 +1360,11 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
     def is_staff(self):
         return self.is_manager or self.is_reviewer
 
+    # Required for staff mode to work, since several other cached properties (including is_staff) are overwritten
+    @property
+    def has_staff_permission(self):
+        return self.groups.filter(name='Manager').exists() or self.groups.filter(name='Reviewer').exists()
+
     @cached_property
     def is_manager(self):
         return self.groups.filter(name='Manager').exists()
@@ -1394,11 +1399,11 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
             return False
         return True
 
-    @property
+    @cached_property
     def is_participant(self):
         return self.evaluations_participating_in.exists()
 
-    @property
+    @cached_property
     def is_student(self):
         """
             A UserProfile is not considered to be a student anymore if the
@@ -1415,23 +1420,23 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
 
         return last_semester_participated.created_at >= last_semester_contributed.created_at
 
-    @property
+    @cached_property
     def is_contributor(self):
         return self.contributions.exists()
 
-    @property
+    @cached_property
     def is_editor(self):
         return self.contributions.filter(role=Contribution.Role.EDITOR).exists() or self.is_responsible
 
-    @property
+    @cached_property
     def is_responsible(self):
         return self.courses_responsible_for.exists()
 
-    @property
+    @cached_property
     def is_delegate(self):
         return self.represented_users.exists()
 
-    @property
+    @cached_property
     def is_editor_or_delegate(self):
         return self.is_editor or self.is_delegate
 

--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -21,39 +21,14 @@
                 {% if user|can_reward_points_be_used_by %}
                     <li class="nav-item"><a class="nav-link" href="{% url 'rewards:index' %}">{% trans 'Rewards' %}</a></li>
                 {% endif %}
-                {% if user.is_grade_publisher and not user.is_manager %}
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="{% url 'grades:index' %}" id="navbarPublishDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Publish grades' %}</a>
-                        <div class="dropdown-menu" aria-labelledby="navbarPublishDropdownMenuLink">
-                            <a class="dropdown-item" href="{% url 'grades:index' %}">{% trans 'Semesters' %}</a>
-                            {% for semester in grade_document_semesters %}
-                                <a class="dropdown-item dropdown-item-indent" href="{% url 'grades:semester_view' semester.id %}">{{ semester.name }}</a>
-                            {% endfor %}
-                        </div>
-                    </li>
-                {% endif %}
-                {% if not user.is_external %}
-                    <li class="nav-item"><a class="nav-link" href="{% url 'results:index' %}">{% trans 'Results' %}</a></li>
-                {% endif %}
                 {% if user.is_manager %}
+                    <li class="nav-item"><a class="nav-link" href="{% url 'staff:index' %}">{% trans 'Overview' %}</a></li>
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="{% url 'staff:index' %}" id="navbarStaffDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Manage' %}</a>
-                        <div class="dropdown-menu" aria-labelledby="navbarStaffDropdownMenuLink">
-                            <a class="dropdown-item" href="{% url 'staff:index' %}">{% trans 'Overview' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:index' %}">{% trans 'Semesters' %}</a>
+                        <a class="nav-link dropdown-toggle" href="#" id="navbarSemestersDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Semesters' %}</a>
+                        <div class="dropdown-menu" aria-labelledby="navbarSemestersDropdownMenuLink">
                             {% for semester in result_semesters %}
-                                <a class="dropdown-item dropdown-item-indent" href="{% url 'staff:semester_view' semester.id %}">{{ semester.name }}</a>
+                                <a class="dropdown-item" href="{% url 'staff:semester_view' semester.id %}">{{ semester.name }}</a>
                             {% endfor %}
-                            {% if user.is_grade_publisher %}
-                                <a class="dropdown-item" href="{% url 'grades:index' %}">{% trans 'Publish grades' %}</a>
-                            {% endif %}
-                            <a class="dropdown-item" href="{% url 'staff:questionnaire_index' %}">{% trans 'Questionnaires' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:user_index' %}">{% trans 'Users' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:degree_index' %}">{% trans 'Degrees' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:course_type_index' %}">{% trans 'Course types' %}</a>
-                            <a class="dropdown-item" href="{% url 'rewards:reward_point_redemption_events' %}">{% trans 'Reward point redemption events' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:index' %}">{% trans 'Templates' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:faq_index' %}">{% trans 'FAQ' %}</a>
                         </div>
                     </li>
                 {% elif user.is_reviewer %}
@@ -65,6 +40,58 @@
                             {% endfor %}
                         </div>
                     </li>
+                {% endif %}
+                {% if not user.is_external %}
+                    <li class="nav-item"><a class="nav-link" href="{% url 'results:index' %}">{% trans 'Results' %}</a></li>
+                {% endif %}
+                {%  if user.is_manager %}
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="navbarUsersDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Users' %}</a>
+                        <div class="dropdown-menu" aria-labelledby="navbarUsersDropdownMenuLink">
+                            <a class="dropdown-item" href="{% url 'staff:user_index' %}">{% trans 'User list' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:user_create' %}">{% trans 'Create' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:user_import' %}">{% trans 'Import' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:user_merge_selection' %}">{% trans 'Merge' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:user_bulk_update' %}">{% trans 'Update' %}</a>
+                        </div>
+                    </li>
+                    <li class="nav-item"><a class="nav-link" href="{% url 'staff:questionnaire_index' %}">{% trans 'Questionnaires' %}</a></li>
+                {% endif %}
+                {% if user.is_grade_publisher %}
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="{% url 'grades:index' %}" id="navbarPublishDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Publish grades' %}</a>
+                        <div class="dropdown-menu" aria-labelledby="navbarPublishDropdownMenuLink">
+                            <a class="dropdown-item" href="{% url 'grades:index' %}">{% trans 'Semesters' %}</a>
+                            {% for semester in grade_document_semesters %}
+                                <a class="dropdown-item dropdown-item-indent" href="{% url 'grades:semester_view' semester.id %}">{{ semester.name }}</a>
+                            {% endfor %}
+                        </div>
+                    </li>
+                {% endif %}
+                {% if user.is_manager %}
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="navbarStaffDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'More' %}</a>
+                        <div class="dropdown-menu" aria-labelledby="navbarStaffDropdownMenuLink">
+                            <a class="dropdown-item" href="{% url 'staff:course_type_index' %}">{% trans 'Course types' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:degree_index' %}">{% trans 'Degrees' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:index' %}">{% trans 'Email templates' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:faq_index' %}">{% trans 'FAQ' %}</a>
+                            <a class="dropdown-item" href="{% url 'rewards:reward_point_redemption_events' %}">{% trans 'Reward point redemption events' %}</a>
+                        </div>
+                    </li>
+                {% endif %}
+                {% if user.has_staff_permission %}
+                    {% if user.is_staff %}
+                        <form class="form-inline" method="post" action="{% url 'staff:exit_staff_mode' %}">
+                            {% csrf_token %}
+                            <button type="submit" class="ml-2 btn btn-sm btn-navbar btn-outline-secondary">{% trans 'Exit Staff Mode' %}</button>
+                        </form>
+                    {% else %}
+                        <form class="form-inline" method="post" action="{% url 'staff:enter_staff_mode' %}">
+                            {% csrf_token %}
+                            <button type="submit" class="ml-2 btn btn-sm btn-navbar btn-outline-secondary">{% trans 'Enter Staff Mode' %}</button>
+                        </form>
+                    {% endif %}
                 {% endif %}
             {% endif %}
         </ul>

--- a/evap/evaluation/tests/test_misc.py
+++ b/evap/evaluation/tests/test_misc.py
@@ -10,12 +10,12 @@ from django.urls import reverse
 from model_bakery import baker
 
 from evap.evaluation.models import Semester, UserProfile, CourseType, Degree
-from evap.evaluation.tests.tools import WebTest, make_manager
+from evap.evaluation.tests.tools import make_manager
+from evap.staff.tests.utils import WebTestStaffMode
 
 
 @override_settings(INSTITUTION_EMAIL_DOMAINS=["institution.com", "student.institution.com"])
-class SampleXlsTests(WebTest):
-
+class SampleXlsTests(WebTestStaffMode):
     @classmethod
     def setUpTestData(cls):
         cls.manager = make_manager()

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -426,11 +426,15 @@ class TestUserProfile(TestCase):
         semester_contributed_to.created_at = date.today() - timedelta(days=1)
         semester_contributed_to.save()
 
+        # invalidate cached_property
+        del user.is_student
         self.assertTrue(user.is_student)
 
         semester_participated_in.created_at = date.today() - timedelta(days=2)
         semester_participated_in.save()
 
+        # invalidate cached_property
+        del user.is_student
         self.assertFalse(user.is_student)
 
     def test_can_be_deleted_by_manager(self):

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -20,6 +20,7 @@ from evap.evaluation.tests.tools import let_user_vote_for_evaluation, make_manag
 from evap.results.exporters import TextAnswerExporter
 from evap.results.tools import cache_results
 from evap.results.views import get_evaluations_with_prefetched_data
+from evap.staff.tests.utils import helper_exit_staff_mode, run_in_staff_mode, WebTestStaffMode
 
 
 class TestResultsView(WebTest):
@@ -167,7 +168,7 @@ class TestResultsViewContributionWarning(WebTest):
         self.assertIn("Only a few participants answered these questions.", page)
 
 
-class TestResultsSemesterEvaluationDetailView(WebTest):
+class TestResultsSemesterEvaluationDetailView(WebTestStaffMode):
     url = '/results/semester/2/evaluation/21'
 
     @classmethod
@@ -262,6 +263,7 @@ class TestResultsSemesterEvaluationDetailView(WebTest):
         self.assertEqual(page_without_get_parameter.body, page_with_random_get_parameter.body)
 
     def test_wrong_state(self):
+        helper_exit_staff_mode(self)
         evaluation = baker.make(Evaluation, state='reviewed', course=baker.make(Course, semester=self.semester))
         cache_results(evaluation)
         url = '/results/semester/%s/evaluation/%s' % (self.semester.id, evaluation.id)
@@ -338,7 +340,8 @@ class TestResultsSemesterEvaluationDetailViewFewVoters(WebTest):
         self.evaluation.publish()
         self.evaluation.save()
         self.assertEqual(self.evaluation.voters.count(), 1)
-        self.helper_test_answer_visibility_one_voter("manager@institution.example.com")
+        with run_in_staff_mode(self):
+            self.helper_test_answer_visibility_one_voter("manager@institution.example.com")
         self.evaluation = Evaluation.objects.get(id=self.evaluation.id)
         self.helper_test_answer_visibility_one_voter("responsible@institution.example.com")
         self.helper_test_answer_visibility_one_voter("student@institution.example.com", expect_page_not_visible=True)
@@ -352,7 +355,8 @@ class TestResultsSemesterEvaluationDetailViewFewVoters(WebTest):
         self.evaluation.save()
         self.assertEqual(self.evaluation.voters.count(), 2)
 
-        self.helper_test_answer_visibility_two_voters("manager@institution.example.com")
+        with run_in_staff_mode(self):
+            self.helper_test_answer_visibility_two_voters("manager@institution.example.com")
         self.helper_test_answer_visibility_two_voters("responsible@institution.example.com")
         self.helper_test_answer_visibility_two_voters("student@institution.example.com")
 
@@ -396,7 +400,8 @@ class TestResultsSemesterEvaluationDetailViewPrivateEvaluation(WebTest):
         self.assertIn(private_evaluation.full_name, self.app.get(url, user=responsible))
         self.assertIn(private_evaluation.full_name, self.app.get(url, user=editor))
         self.assertIn(private_evaluation.full_name, self.app.get(url, user=contributor))
-        self.assertIn(private_evaluation.full_name, self.app.get(url, user=manager))
+        with run_in_staff_mode(self):
+            self.assertIn(private_evaluation.full_name, self.app.get(url, user=manager))
         self.app.get(url, user=student_external, status=403)  # external users can't see results semester view
 
         url = '/results/semester/%s/evaluation/%s' % (semester.id, private_evaluation.id)
@@ -405,11 +410,12 @@ class TestResultsSemesterEvaluationDetailViewPrivateEvaluation(WebTest):
         self.app.get(url, user=responsible, status=200)
         self.app.get(url, user=editor, status=200)
         self.app.get(url, user=contributor, status=200)
-        self.app.get(url, user=manager, status=200)
+        with run_in_staff_mode(self):
+            self.app.get(url, user=manager, status=200)
         self.app.get(url, user=student_external, status=200)  # this external user participates in the evaluation and can see the results
 
 
-class TestResultsTextanswerVisibilityForManager(WebTest):
+class TestResultsTextanswerVisibilityForManager(WebTestStaffMode):
     fixtures = ['minimal_test_data_results']
 
     @classmethod
@@ -712,21 +718,22 @@ class TestResultsTextanswerVisibilityForExportView(WebTest):
         self.assertNotIn(".responsible_contributor_orig_notreviewed.", page)
 
     def test_textanswer_visibility_for_manager(self):
-        contributor_id = UserProfile.objects.get(email="responsible@institution.example.com").id
-        page = self.app.get("/results/semester/1/evaluation/1?view=export&contributor_id={}".format(contributor_id), user="manager@institution.example.com")
+        with run_in_staff_mode(self):
+            contributor_id = UserProfile.objects.get(email="responsible@institution.example.com").id
+            page = self.app.get("/results/semester/1/evaluation/1?view=export&contributor_id={}".format(contributor_id), user="manager@institution.example.com")
 
-        self.assertIn(".general_orig_published.", page)
-        self.assertNotIn(".general_orig_hidden.", page)
-        self.assertNotIn(".general_orig_published_changed.", page)
-        self.assertIn(".general_changed_published.", page)
-        self.assertNotIn(".contributor_orig_published.", page)
-        self.assertNotIn(".contributor_orig_private.", page)
-        self.assertNotIn(".responsible_contributor_orig_published.", page)
-        self.assertNotIn(".responsible_contributor_orig_hidden.", page)
-        self.assertNotIn(".responsible_contributor_orig_published_changed.", page)
-        self.assertNotIn(".responsible_contributor_changed_published.", page)
-        self.assertNotIn(".responsible_contributor_orig_private.", page)
-        self.assertNotIn(".responsible_contributor_orig_notreviewed.", page)
+            self.assertIn(".general_orig_published.", page)
+            self.assertNotIn(".general_orig_hidden.", page)
+            self.assertNotIn(".general_orig_published_changed.", page)
+            self.assertIn(".general_changed_published.", page)
+            self.assertNotIn(".contributor_orig_published.", page)
+            self.assertNotIn(".contributor_orig_private.", page)
+            self.assertNotIn(".responsible_contributor_orig_published.", page)
+            self.assertNotIn(".responsible_contributor_orig_hidden.", page)
+            self.assertNotIn(".responsible_contributor_orig_published_changed.", page)
+            self.assertNotIn(".responsible_contributor_changed_published.", page)
+            self.assertNotIn(".responsible_contributor_orig_private.", page)
+            self.assertNotIn(".responsible_contributor_orig_notreviewed.", page)
 
     def test_textanswer_visibility_for_manager_contributor(self):
         manager_group = Group.objects.get(name="Manager")
@@ -804,7 +811,8 @@ class TestArchivedResults(WebTest):
         self.app.get(url, user=self.student, status=403)
         self.app.get(url, user=self.responsible, status=200)
         self.app.get(url, user=self.contributor, status=200)
-        self.app.get(url, user=self.manager, status=200)
+        with run_in_staff_mode(self):
+            self.app.get(url, user=self.manager, status=200)
         self.app.get(url, user=self.reviewer, status=403)
         self.app.get(url, user=self.student_external, status=403)
 
@@ -828,9 +836,10 @@ class TestTextAnswerExportView(WebTest):
             res.write(b"1337")
 
         with patch.object(TextAnswerExporter, "export", mock):
-            response = self.app.get(self.url, user=self.reviewer, status=200)
-            self.assertEqual(response.headers["Content-Type"], "application/vnd.ms-excel")
-            self.assertEqual(response.content, b"1337")
+            with run_in_staff_mode(self):
+                response = self.app.get(self.url, user=self.reviewer, status=200)
+                self.assertEqual(response.headers["Content-Type"], "application/vnd.ms-excel")
+                self.assertEqual(response.content, b"1337")
 
     @patch("evap.results.exporters.TextAnswerExporter.export")
     def test_permission_denied(self, export_method):
@@ -840,9 +849,11 @@ class TestTextAnswerExportView(WebTest):
         self.app.get(self.url, user=student, status=403)
         export_method.assert_not_called()
 
-        self.app.get(self.url, user=self.reviewer, status=200)
-        export_method.assert_called_once()
+        with run_in_staff_mode(self):
+            self.app.get(self.url, user=self.reviewer, status=200)
+            export_method.assert_called_once()
 
         export_method.reset_mock()
-        self.app.get(self.url, user=manager, status=200)
-        export_method.assert_called_once()
+        with run_in_staff_mode(self):
+            self.app.get(self.url, user=manager, status=200)
+            export_method.assert_called_once()

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -6,12 +6,13 @@ from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import UserProfile, Evaluation, Semester
-from evap.evaluation.tests.tools import WebTestWith200Check, make_manager
+from evap.evaluation.tests.tools import make_manager
 from evap.rewards.models import RewardPointRedemptionEvent, RewardPointGranting, RewardPointRedemption, SemesterActivation
 from evap.rewards.tools import reward_points_of_user, is_semester_activated
+from evap.staff.tests.utils import WebTestStaffMode, WebTestStaffModeWith200Check
 
 
-class TestEventDeleteView(WebTest):
+class TestEventDeleteView(WebTestStaffMode):
     url = reverse('rewards:reward_point_redemption_event_delete')
     csrf_checks = False
 
@@ -77,7 +78,7 @@ class TestIndexView(WebTest):
         self.assertEqual(5, reward_points_of_user(self.student))
 
 
-class TestEventsView(WebTestWith200Check):
+class TestEventsView(WebTestStaffModeWith200Check):
     url = reverse('rewards:reward_point_redemption_events')
 
     @classmethod
@@ -88,7 +89,7 @@ class TestEventsView(WebTestWith200Check):
         baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
 
 
-class TestEventCreateView(WebTest):
+class TestEventCreateView(WebTestStaffMode):
     url = reverse('rewards:reward_point_redemption_event_create')
     csrf_checks = False
 
@@ -111,7 +112,7 @@ class TestEventCreateView(WebTest):
         self.assertEqual(RewardPointRedemptionEvent.objects.count(), 1)
 
 
-class TestEventEditView(WebTest):
+class TestEventEditView(WebTestStaffMode):
     url = reverse('rewards:reward_point_redemption_event_edit', args=[1])
     csrf_checks = False
 
@@ -132,7 +133,7 @@ class TestEventEditView(WebTest):
         self.assertEqual(RewardPointRedemptionEvent.objects.get(pk=self.event.pk).name, 'new name')
 
 
-class TestExportView(WebTestWith200Check):
+class TestExportView(WebTestStaffModeWith200Check):
     url = '/rewards/reward_point_redemption_event/1/export'
 
     @classmethod
@@ -143,7 +144,7 @@ class TestExportView(WebTestWith200Check):
         baker.make(RewardPointRedemption, value=1, event=event)
 
 
-class TestSemesterActivationView(WebTest):
+class TestSemesterActivationView(WebTestStaffMode):
     url = '/rewards/reward_semester_activation/1/'
     csrf_checks = False
 

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -223,6 +223,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'mozilla_django_oidc.middleware.SessionRefresh',
     'evap.middleware.RequireLoginMiddleware',
+    'evap.staff.staff_mode.staff_mode_middleware',
 ]
 
 TEMPLATES = [
@@ -271,6 +272,8 @@ SESSION_CACHE_ALIAS = "sessions"
 SESSION_SAVE_EVERY_REQUEST = True
 SESSION_COOKIE_AGE = 60 * 60 * 24 * 365  # one year
 
+STAFF_MODE_TIMEOUT = 60 * 60  # one hour
+STAFF_MODE_INFO_TIMEOUT = 3 * 60 * 60  # three hours
 
 ### Internationalization
 

--- a/evap/staff/staff_mode.py
+++ b/evap/staff/staff_mode.py
@@ -1,0 +1,69 @@
+import time
+
+from django.contrib import messages
+from django.utils.translation import ugettext as _
+
+from evap.settings import STAFF_MODE_TIMEOUT, STAFF_MODE_INFO_TIMEOUT
+from evap.staff.tools import delete_navbar_cache_for_users
+
+
+def staff_mode_middleware(get_response):
+    """
+    Middleware handling the staff mode.
+
+    If too much time has passed, the staff mode will be exited.
+    Otherwise, the last request time will be updated.
+    """
+
+    def middleware(request):
+        if is_in_staff_mode(request):
+            current_time = time.time()
+            if current_time <= request.session.get('staff_mode_start_time', 0) + STAFF_MODE_TIMEOUT:
+                # just refresh time
+                update_staff_mode(request)
+            else:
+                exit_staff_mode(request)
+                # only show info message if not too much time has passed
+                if current_time <= request.session.get('staff_mode_start_time', 0) + STAFF_MODE_TIMEOUT + STAFF_MODE_INFO_TIMEOUT:
+                    messages.info(request, _("Your staff mode timed out."))
+
+        if is_in_staff_mode(request):
+            request.user.is_participant = False
+            request.user.is_student = False
+            request.user.is_editor = False
+            request.user.is_contributor = False
+            request.user.is_delegate = False
+            request.user.is_responsible = False
+            request.user.is_responsible_or_contributor_or_delegate = False
+        else:
+            request.user.is_staff = False
+            request.user.is_manager = False
+            request.user.is_reviewer = False
+
+        response = get_response(request)
+        return response
+
+    return middleware
+
+
+def is_in_staff_mode(request):
+    return 'staff_mode_start_time' in request.session
+
+
+def update_staff_mode(request):
+    assert request.user.has_staff_permission
+
+    request.session['staff_mode_start_time'] = time.time()
+    request.session.modified = True
+
+
+def enter_staff_mode(request):
+    update_staff_mode(request)
+    delete_navbar_cache_for_users([request.user])
+
+
+def exit_staff_mode(request):
+    if is_in_staff_mode(request):
+        del request.session['staff_mode_start_time']
+        request.session.modified = True
+        delete_navbar_cache_for_users([request.user])

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -16,24 +16,16 @@ import xlrd
 from evap.evaluation.models import (Contribution, Course, CourseType, Degree, EmailTemplate, Evaluation, FaqSection,
                                     FaqQuestion, Question, Questionnaire, RatingAnswerCounter, Semester, TextAnswer,
                                     UserProfile)
-from evap.evaluation.tests.tools import FuzzyInt, let_user_vote_for_evaluation, WebTestWith200Check, make_manager
+from evap.evaluation.tests.tools import FuzzyInt, let_user_vote_for_evaluation, make_manager
 from evap.results.tools import cache_results, get_results
 from evap.rewards.models import SemesterActivation, RewardPointGranting
-from evap.staff.tools import generate_import_filename, ImportType
 from evap.staff.forms import ContributionCopyForm, ContributionCopyFormSet, EvaluationCopyForm
+from evap.staff.tests.utils import helper_delete_all_import_files, run_in_staff_mode, \
+    WebTestStaffMode, WebTestStaffModeWith200Check
 from evap.staff.views import get_evaluations_with_prefetched_data
 
 
-def helper_delete_all_import_files(user_id):
-    for import_type in ImportType:
-        filename = generate_import_filename(user_id, import_type)
-        try:
-            os.remove(filename)
-        except FileNotFoundError:
-            pass
-
-
-class TestDownloadSampleXlsView(WebTest):
+class TestDownloadSampleXlsView(WebTestStaffMode):
     url = '/staff/download_sample_xls/sample.xls'
     email_placeholder = "institution.com"
 
@@ -57,7 +49,7 @@ class TestDownloadSampleXlsView(WebTest):
         self.assertEqual(found_institution_domains, 2)
 
 
-class TestStaffIndexView(WebTestWith200Check):
+class TestStaffIndexView(WebTestStaffModeWith200Check):
     url = '/staff/'
 
     @classmethod
@@ -65,7 +57,7 @@ class TestStaffIndexView(WebTestWith200Check):
         cls.test_users = [make_manager()]
 
 
-class TestStaffFAQView(WebTestWith200Check):
+class TestStaffFAQView(WebTestStaffModeWith200Check):
     url = '/staff/faq/'
 
     @classmethod
@@ -73,7 +65,7 @@ class TestStaffFAQView(WebTestWith200Check):
         cls.test_users = [make_manager()]
 
 
-class TestStaffFAQEditView(WebTestWith200Check):
+class TestStaffFAQEditView(WebTestStaffModeWith200Check):
     url = '/staff/faq/1'
 
     @classmethod
@@ -84,7 +76,7 @@ class TestStaffFAQEditView(WebTestWith200Check):
         baker.make(FaqQuestion, section=section)
 
 
-class TestUserIndexView(WebTest):
+class TestUserIndexView(WebTestStaffMode):
     url = '/staff/user/'
 
     @classmethod
@@ -113,7 +105,7 @@ class TestUserIndexView(WebTest):
             self.app.get(self.url, user=self.manager)
 
 
-class TestUserCreateView(WebTest):
+class TestUserCreateView(WebTestStaffMode):
     url = "/staff/user/create"
 
     @classmethod
@@ -137,7 +129,7 @@ class TestUserCreateView(WebTest):
     (2 / 3, 2),
     (3 / 3, 3),
 ])
-class TestUserEditView(WebTest):
+class TestUserEditView(WebTestStaffMode):
     @classmethod
     def setUpTestData(cls):
         cls.manager = make_manager()
@@ -182,7 +174,7 @@ class TestUserEditView(WebTest):
         self.assertIn("The removal of evaluations has granted the user &quot;{}&quot; 3 reward points for the active semester.".format(student.email), page)
 
 
-class TestUserMergeSelectionView(WebTestWith200Check):
+class TestUserMergeSelectionView(WebTestStaffModeWith200Check):
     url = "/staff/user/merge"
 
     @classmethod
@@ -192,7 +184,7 @@ class TestUserMergeSelectionView(WebTestWith200Check):
         baker.make(UserProfile)
 
 
-class TestUserMergeView(WebTestWith200Check):
+class TestUserMergeView(WebTestStaffModeWith200Check):
     url = "/staff/user/3/merge/4"
 
     @classmethod
@@ -220,7 +212,7 @@ class TestUserMergeView(WebTestWith200Check):
                                        "in the column of the voter and in the column of the merged data")
 
 
-class TestUserBulkUpdateView(WebTest):
+class TestUserBulkUpdateView(WebTestStaffMode):
     url = '/staff/user/bulk_update'
     filename = os.path.join(settings.BASE_DIR, 'staff/fixtures/test_user_bulk_update_file.txt')
     filename_random = os.path.join(settings.BASE_DIR, 'staff/fixtures/random.random')
@@ -370,7 +362,7 @@ class TestUserBulkUpdateView(WebTest):
         self.assertIn("An error happened when processing the file", reply)
 
 
-class TestUserImportView(WebTest):
+class TestUserImportView(WebTestStaffMode):
     url = "/staff/user/import"
     filename_valid = os.path.join(settings.BASE_DIR, "staff/fixtures/valid_user_import.xls")
     filename_invalid = os.path.join(settings.BASE_DIR, "staff/fixtures/invalid_user_import.xls")
@@ -465,7 +457,7 @@ class TestUserImportView(WebTest):
 
 
 # Staff - Semester Views
-class TestSemesterView(WebTest):
+class TestSemesterView(WebTestStaffMode):
     url = '/staff/semester/1'
 
     @classmethod
@@ -494,12 +486,14 @@ class TestSemesterView(WebTest):
         self.assertGreater(position_evaluation1, position_evaluation2)
         self.app.reset()  # language is only loaded on login, so we're forcing a re-login here
 
-        self.manager.language = 'de'
-        self.manager.save()
-        page = self.app.get(self.url, user=self.manager).body.decode("utf-8")
-        position_evaluation1 = page.find("Evaluation 1")
-        position_evaluation2 = page.find("Evaluation 2")
-        self.assertLess(position_evaluation1, position_evaluation2)
+        # Re-enter staff mode, since the session was just reset
+        with run_in_staff_mode(self):
+            self.manager.language = 'de'
+            self.manager.save()
+            page = self.app.get(self.url, user=self.manager).body.decode("utf-8")
+            position_evaluation1 = page.find("Evaluation 1")
+            position_evaluation2 = page.find("Evaluation 2")
+            self.assertLess(position_evaluation1, position_evaluation2)
 
     def test_access_to_semester_with_archived_results(self):
         reviewer = baker.make(
@@ -509,11 +503,11 @@ class TestSemesterView(WebTest):
         )
         baker.make(Semester, pk=2, results_are_archived=True)
 
-        # reviewers shouldn't be allowed to access the semester page
-        self.app.get('/staff/semester/2', user=reviewer, status=403)
-
         # managers can access the page
         self.app.get('/staff/semester/2', user=self.manager, status=200)
+
+        # reviewers shouldn't be allowed to access the semester page
+        self.app.get('/staff/semester/2', user=reviewer, status=403)
 
     @override_settings(INSTITUTION_EMAIL_DOMAINS=["institution.com"])
     def test_badge_for_external_responsibles(self):
@@ -568,7 +562,7 @@ class TestGetEvaluationsWithPrefetchedData(TestCase):
         get_evaluations_with_prefetched_data(evaluation.course.semester)
 
 
-class TestSemesterCreateView(WebTest):
+class TestSemesterCreateView(WebTestStaffMode):
     url = '/staff/semester/create'
 
     @classmethod
@@ -592,7 +586,7 @@ class TestSemesterCreateView(WebTest):
         self.assertEqual(Semester.objects.filter(name_de=name_de, name_en=name_en, short_name_de=short_name_de, short_name_en=short_name_en).count(), 1)
 
 
-class TestSemesterEditView(WebTest):
+class TestSemesterEditView(WebTestStaffMode):
     url = '/staff/semester/1/edit'
 
     @classmethod
@@ -617,7 +611,7 @@ class TestSemesterEditView(WebTest):
         self.assertEqual(self.semester.name_en, new_name_en)
 
 
-class TestSemesterDeleteView(WebTest):
+class TestSemesterDeleteView(WebTestStaffMode):
     url = '/staff/semester/delete'
     csrf_checks = False
 
@@ -680,7 +674,7 @@ class TestSemesterDeleteView(WebTest):
         self.assertEqual(response.status_code, 400)
 
 
-class TestSemesterAssignView(WebTest):
+class TestSemesterAssignView(WebTestStaffMode):
     url = '/staff/semester/1/assign'
 
     @classmethod
@@ -721,7 +715,7 @@ class TestSemesterAssignView(WebTest):
             self.assertEqual(evaluation.general_contribution.questionnaires.get(), self.questionnaire)
 
 
-class TestSemesterPreparationReminderView(WebTestWith200Check):
+class TestSemesterPreparationReminderView(WebTestStaffModeWith200Check):
     url = '/staff/semester/1/preparation_reminder'
     csrf_checks = False
 
@@ -772,7 +766,7 @@ class TestSemesterPreparationReminderView(WebTestWith200Check):
         self.assertEqual(email_template_mock.send_to_user.call_args_list[0][0][:4], expected)
 
 
-class TestSendReminderView(WebTest):
+class TestSendReminderView(WebTestStaffMode):
     url = '/staff/semester/1/responsible/3/send_reminder'
 
     @classmethod
@@ -797,7 +791,7 @@ class TestSendReminderView(WebTest):
         self.assertIn("uiae", mail.outbox[0].body)
 
 
-class TestSemesterImportView(WebTest):
+class TestSemesterImportView(WebTestStaffMode):
     url = "/staff/semester/1/import"
     filename_valid = os.path.join(settings.BASE_DIR, "staff/fixtures/test_enrollment_data.xls")
     filename_invalid = os.path.join(settings.BASE_DIR, "staff/fixtures/invalid_enrollment_data.xls")
@@ -951,7 +945,7 @@ class TestSemesterImportView(WebTest):
         self.assertContains(page, 'Import previously uploaded file')
 
 
-class TestSemesterExportView(WebTest):
+class TestSemesterExportView(WebTestStaffMode):
     url = '/staff/semester/1/export'
 
     @classmethod
@@ -983,7 +977,7 @@ class TestSemesterExportView(WebTest):
         )
 
 
-class TestSemesterRawDataExportView(WebTestWith200Check):
+class TestSemesterRawDataExportView(WebTestStaffModeWith200Check):
     url = '/staff/semester/1/raw_export'
 
     @classmethod
@@ -1021,7 +1015,7 @@ class TestSemesterRawDataExportView(WebTestWith200Check):
         self.assertEqual(response.content, expected_content.encode("utf-8"))
 
 
-class TestSemesterParticipationDataExportView(WebTest):
+class TestSemesterParticipationDataExportView(WebTestStaffMode):
     url = '/staff/semester/1/participation_export'
 
     @classmethod
@@ -1074,7 +1068,7 @@ class TestSemesterParticipationDataExportView(WebTest):
         self.assertEqual(response.content, expected_content.encode("utf-8"))
 
 
-class TestLoginKeyExportView(WebTest):
+class TestLoginKeyExportView(WebTestStaffMode):
     url = '/staff/semester/1/evaluation/1/login_key_export'
 
     @classmethod
@@ -1106,7 +1100,7 @@ class TestLoginKeyExportView(WebTest):
         self.assertEqual(response.body.decode(), expected_string)
 
 
-class TestEvaluationOperationView(WebTest):
+class TestEvaluationOperationView(WebTestStaffMode):
     url = '/staff/semester/1/evaluationoperation'
 
     @classmethod
@@ -1345,7 +1339,7 @@ class TestEvaluationOperationView(WebTest):
         self.assertEqual(actual_emails[0]['additional_cc_users'], set())
 
 
-class TestCourseCreateView(WebTest):
+class TestCourseCreateView(WebTestStaffMode):
     url = '/staff/semester/1/course/create'
 
     @classmethod
@@ -1380,7 +1374,7 @@ class TestCourseCreateView(WebTest):
         self.assertEqual(Course.objects.get().name_de, "dskr4jre35m6")
 
 
-class TestSingleResultCreateView(WebTest):
+class TestSingleResultCreateView(WebTestStaffMode):
     url = '/staff/semester/1/singleresult/create'
 
     @classmethod
@@ -1415,7 +1409,7 @@ class TestSingleResultCreateView(WebTest):
         self.assertEqual(Evaluation.objects.get().name_de, "qwertz")
 
 
-class TestEvaluationCreateView(WebTest):
+class TestEvaluationCreateView(WebTestStaffMode):
     url = '/staff/semester/1/evaluation/create'
 
     @classmethod
@@ -1464,12 +1458,12 @@ class TestEvaluationCreateView(WebTest):
         self.assertEqual(Evaluation.objects.get().name_de, "lfo9e7bmxp1xi")
 
 
-class TestEvaluationCopyView(WebTest):
+class TestEvaluationCopyView(WebTestStaffMode):
     url = '/staff/semester/1/evaluation/1/copy'
 
     @classmethod
     def setUpTestData(cls):
-        cls.manager = baker.make(UserProfile, email='manager@institution.example.com', groups=[Group.objects.get(name='Manager')])
+        cls.manager = make_manager()
         cls.semester = baker.make(Semester, pk=1)
         cls.course = baker.make(Course, semester=cls.semester)
         cls.evaluation = baker.make(
@@ -1508,8 +1502,12 @@ class TestEvaluationCopyView(WebTest):
         self.assertEqual(copied_evaluation.contributions.count(), 4)
 
 
-class TestCourseEditView(WebTest):
+class TestCourseEditView(WebTestStaffMode):
     url = '/staff/semester/1/course/1/edit'
+
+    def setUp(self):
+        super().setUp()
+        self.course = Course.objects.get(pk=self.course.pk)
 
     @classmethod
     def setUpTestData(cls):
@@ -1527,9 +1525,6 @@ class TestCourseEditView(WebTest):
             last_modified_user=cls.manager,
             last_modified_time=datetime.datetime(2000, 1, 1, 0, 0),
         )
-
-    def setUp(self):
-        self.course = Course.objects.get(pk=self.course.pk)
 
     def test_edit_course(self):
         page = self.app.get(self.url, user=self.manager)
@@ -1580,8 +1575,12 @@ class TestCourseEditView(WebTest):
     (2 / 3, 2),
     (3 / 3, 3),
 ])
-class TestEvaluationEditView(WebTest):
+class TestEvaluationEditView(WebTestStaffMode):
     url = '/staff/semester/1/evaluation/1/edit'
+
+    def setUp(self):
+        super().setUp()
+        self.evaluation = Evaluation.objects.get(pk=self.evaluation.pk)
 
     @classmethod
     def setUpTestData(cls):
@@ -1615,9 +1614,6 @@ class TestEvaluationEditView(WebTest):
             order=1,
             role=Contribution.Role.EDITOR,
         )
-
-    def setUp(self):
-        self.evaluation = Evaluation.objects.get(pk=self.evaluation.pk)
 
     def test_edit_evaluation(self):
         page = self.app.get(self.url, user=self.manager)
@@ -1777,7 +1773,7 @@ class TestEvaluationEditView(WebTest):
         self.assertEqual(self.evaluation.last_modified_time, last_modified_time_before)
 
 
-class TestSingleResultEditView(WebTestWith200Check):
+class TestSingleResultEditView(WebTestStaffModeWith200Check):
     url = '/staff/semester/1/evaluation/1/edit'
 
     @classmethod
@@ -1804,7 +1800,7 @@ class TestSingleResultEditView(WebTestWith200Check):
         baker.make(RatingAnswerCounter, question=question, contribution=contribution, answer=5, count=30)
 
 
-class TestEvaluationPreviewView(WebTestWith200Check):
+class TestEvaluationPreviewView(WebTestStaffModeWith200Check):
     url = '/staff/semester/1/evaluation/1/preview'
 
     @classmethod
@@ -1816,7 +1812,7 @@ class TestEvaluationPreviewView(WebTestWith200Check):
         evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
 
 
-class TestEvaluationImportPersonsView(WebTest):
+class TestEvaluationImportPersonsView(WebTestStaffMode):
     url = "/staff/semester/1/evaluation/1/person_management"
     filename_valid = os.path.join(settings.BASE_DIR, "staff/fixtures/valid_user_import.xls")
     filename_invalid = os.path.join(settings.BASE_DIR, "staff/fixtures/invalid_user_import.xls")
@@ -2006,7 +2002,7 @@ class TestEvaluationImportPersonsView(WebTest):
         self.assertEqual(reply.status_code, 400)
 
 
-class TestEvaluationEmailView(WebTest):
+class TestEvaluationEmailView(WebTestStaffMode):
     url = '/staff/semester/1/evaluation/1/email'
 
     @classmethod
@@ -2063,23 +2059,27 @@ class TestEvaluationTextAnswerView(WebTest):
 
     def test_textanswers_showing_up(self):
         # in an evaluation with only one voter the view should not be available
-        self.app.get(self.url, user=self.manager, status=403)
+        with run_in_staff_mode(self):
+            self.app.get(self.url, user=self.manager, status=403)
 
         # add additional voter
         let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
 
         # now it should work
-        self.app.get(self.url, user=self.manager, status=200)
+        with run_in_staff_mode(self):
+            self.app.get(self.url, user=self.manager, status=200)
 
     def test_textanswers_quick_view(self):
         let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
-        page = self.app.get(self.url, user=self.manager, status=200)
-        self.assertContains(page, self.answer)
+        with run_in_staff_mode(self):
+            page = self.app.get(self.url, user=self.manager, status=200)
+            self.assertContains(page, self.answer)
 
     def test_textanswers_full_view(self):
         let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
-        page = self.app.get(self.url + '?view=full', user=self.manager, status=200)
-        self.assertContains(page, self.answer)
+        with run_in_staff_mode(self):
+            page = self.app.get(self.url + '?view=full', user=self.manager, status=200)
+            self.assertContains(page, self.answer)
 
 
 class TestEvaluationTextAnswerEditView(WebTest):
@@ -2121,24 +2121,26 @@ class TestEvaluationTextAnswerEditView(WebTest):
 
     def test_textanswers_showing_up(self):
         # in an evaluation with only one voter the view should not be available
-        self.app.get(self.url, user=self.manager, status=403)
+        with run_in_staff_mode(self):
+            self.app.get(self.url, user=self.manager, status=403)
 
         # add additional voter
         let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
 
         # now it should work
-        response = self.app.get(self.url, user=self.manager)
+        with run_in_staff_mode(self):
+            response = self.app.get(self.url, user=self.manager)
 
-        form = response.forms['textanswer-edit-form']
-        self.assertEqual(form['answer'].value, 'test answer text')
-        form['answer'] = 'edited answer text'
-        form.submit()
+            form = response.forms['textanswer-edit-form']
+            self.assertEqual(form['answer'].value, 'test answer text')
+            form['answer'] = 'edited answer text'
+            form.submit()
 
-        self.text_answer.refresh_from_db()
-        self.assertEqual(self.text_answer.answer, 'edited answer text')
+            self.text_answer.refresh_from_db()
+            self.assertEqual(self.text_answer.answer, 'edited answer text')
 
 
-class TestQuestionnaireNewVersionView(WebTest):
+class TestQuestionnaireNewVersionView(WebTestStaffMode):
     url = '/staff/questionnaire/2/new_version'
 
     @classmethod
@@ -2177,7 +2179,7 @@ class TestQuestionnaireNewVersionView(WebTest):
         self.assertEqual(page.location, '/staff/questionnaire/')
 
 
-class TestQuestionnaireCreateView(WebTest):
+class TestQuestionnaireCreateView(WebTestStaffMode):
     url = "/staff/questionnaire/create"
 
     @classmethod
@@ -2219,7 +2221,7 @@ class TestQuestionnaireCreateView(WebTest):
         self.assertFalse(Questionnaire.objects.filter(name_de="Test Fragebogen", name_en="test questionnaire").exists())
 
 
-class TestQuestionnaireIndexView(WebTest):
+class TestQuestionnaireIndexView(WebTestStaffMode):
     url = "/staff/questionnaire/"
 
     @classmethod
@@ -2238,7 +2240,7 @@ class TestQuestionnaireIndexView(WebTest):
         self.assertTrue(top_index < contributor_index < bottom_index)
 
 
-class TestQuestionnaireEditView(WebTestWith200Check):
+class TestQuestionnaireEditView(WebTestStaffModeWith200Check):
     url = '/staff/questionnaire/2/edit'
 
     @classmethod
@@ -2278,7 +2280,7 @@ class TestQuestionnaireEditView(WebTestWith200Check):
         self.assertEqual(form['type'].options, [('20', True, 'Contributor questionnaire')])
 
 
-class TestQuestionnaireViewView(WebTestWith200Check):
+class TestQuestionnaireViewView(WebTestStaffModeWith200Check):
     url = '/staff/questionnaire/2'
 
     @classmethod
@@ -2291,7 +2293,7 @@ class TestQuestionnaireViewView(WebTestWith200Check):
         baker.make(Question, questionnaire=questionnaire, type=Question.LIKERT)
 
 
-class TestQuestionnaireCopyView(WebTest):
+class TestQuestionnaireCopyView(WebTestStaffMode):
     url = '/staff/questionnaire/2/copy'
 
     @classmethod
@@ -2302,7 +2304,7 @@ class TestQuestionnaireCopyView(WebTest):
 
     def test_not_changing_name_fails(self):
         response = self.app.get(self.url, user=self.manager, status=200)
-        response = response.forms[1].submit("", status=200)
+        response = response.forms["questionnaire-form"].submit("", status=200)
         self.assertIn("already exists", response)
 
     def test_copy_questionnaire(self):
@@ -2319,7 +2321,7 @@ class TestQuestionnaireCopyView(WebTest):
         self.assertEqual(questionnaire.questions.count(), 1)
 
 
-class TestQuestionnaireDeletionView(WebTest):
+class TestQuestionnaireDeletionView(WebTestStaffMode):
     url = "/staff/questionnaire/delete"
     csrf_checks = False
 
@@ -2355,7 +2357,7 @@ class TestQuestionnaireDeletionView(WebTest):
         self.assertFalse(Questionnaire.objects.filter(pk=self.q2.pk).exists())
 
 
-class TestCourseTypeView(WebTest):
+class TestCourseTypeView(WebTestStaffMode):
     url = "/staff/course_types/"
 
     @classmethod
@@ -2398,7 +2400,7 @@ class TestCourseTypeView(WebTest):
         self.assertContains(response, 'Import name &quot;V&quot; is duplicated. Import names are not case sensitive.')
 
 
-class TestCourseTypeMergeSelectionView(WebTest):
+class TestCourseTypeMergeSelectionView(WebTestStaffMode):
     url = "/staff/course_types/merge"
 
     @classmethod
@@ -2416,7 +2418,7 @@ class TestCourseTypeMergeSelectionView(WebTest):
         self.assertIn("You must select two different course types", str(response))
 
 
-class TestCourseTypeMergeView(WebTest):
+class TestCourseTypeMergeView(WebTestStaffMode):
     url = "/staff/course_types/1/merge/2"
 
     @classmethod
@@ -2463,19 +2465,20 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         cls.evaluation.general_contribution.questionnaires.set([top_general_questionnaire])
 
     def helper(self, old_state, expected_new_state, action, expect_errors=False):
-        textanswer = baker.make(TextAnswer, state=old_state)
-        response = self.app.post(
-            self.url,
-            params={"id": textanswer.id, "action": action, "evaluation_id": self.evaluation.pk},
-            user=self.manager,
-            expect_errors=expect_errors,
-        )
-        if expect_errors:
-            self.assertEqual(response.status_code, 403)
-        else:
-            self.assertEqual(response.status_code, 200)
-            textanswer.refresh_from_db()
-            self.assertEqual(textanswer.state, expected_new_state)
+        with run_in_staff_mode(self):
+            textanswer = baker.make(TextAnswer, state=old_state)
+            response = self.app.post(
+                self.url,
+                params={"id": textanswer.id, "action": action, "evaluation_id": self.evaluation.pk},
+                user=self.manager,
+                expect_errors=expect_errors,
+            )
+            if expect_errors:
+                self.assertEqual(response.status_code, 403)
+            else:
+                self.assertEqual(response.status_code, 200)
+                textanswer.refresh_from_db()
+                self.assertEqual(textanswer.state, expected_new_state)
 
     def test_review_actions(self):
         # in an evaluation with only one voter reviewing should fail
@@ -2508,7 +2511,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         self.assertEqual(len(results.questionnaire_results[0].question_results[1].answers), 1)
 
 
-class ParticipationArchivingTests(WebTest):
+class ParticipationArchivingTests(WebTestStaffMode):
     @classmethod
     def setUpTestData(cls):
         cls.manager = make_manager()
@@ -2528,7 +2531,7 @@ class ParticipationArchivingTests(WebTest):
         self.app.get(semester_url + "evaluationoperation", user=self.manager, status=403)
 
 
-class TestTemplateEditView(WebTest):
+class TestTemplateEditView(WebTestStaffMode):
     url = "/staff/template/1"
 
     @classmethod
@@ -2552,7 +2555,7 @@ class TestTemplateEditView(WebTest):
         self.assertEqual(EmailTemplate.objects.get(pk=1).body, "body: mflkd862xmnbo5")
 
 
-class TestDegreeView(WebTest):
+class TestDegreeView(WebTestStaffMode):
     url = "/staff/degrees/"
 
     @classmethod
@@ -2592,7 +2595,7 @@ class TestDegreeView(WebTest):
         self.assertContains(response, 'Import name &quot;M&quot; is duplicated.')
 
 
-class TestSemesterQuestionnaireAssignment(WebTest):
+class TestSemesterQuestionnaireAssignment(WebTestStaffMode):
     url = "/staff/semester/1/assign"
 
     @classmethod
@@ -2644,7 +2647,7 @@ class TestSemesterQuestionnaireAssignment(WebTest):
         self.assertEqual(set(self.evaluation_2.contributions.get(contributor=self.responsible).questionnaires.all()), set([self.questionnaire_responsible]))
 
 
-class TestSemesterActiveStateBehaviour(WebTest):
+class TestSemesterActiveStateBehaviour(WebTestStaffMode):
     url = "/staff/semester/make_active"
     csrf_checks = False
 
@@ -2665,3 +2668,34 @@ class TestSemesterActiveStateBehaviour(WebTest):
 
         self.assertFalse(semester1.is_active)
         self.assertTrue(semester2.is_active)
+
+
+class TestStaffMode(WebTest):
+    url_enter = "/staff/enter_staff_mode"
+    url_exit = "/staff/exit_staff_mode"
+
+    some_staff_url = "/staff/degrees/"
+
+    csrf_checks = False
+
+    def test_staff_mode(self):
+        manager = make_manager()
+
+        response = self.app.post(self.url_enter, user=manager).follow().follow()
+        self.assertTrue('staff_mode_start_time' in self.app.session)
+        self.assertContains(response, "Exit Staff Mode")
+        self.assertContains(response, "Users")
+
+        self.app.get(self.some_staff_url, user=manager, status=200)
+
+        response = self.app.post(self.url_exit, user=manager).follow().follow()
+        self.assertFalse('staff_mode_start_time' in self.app.session)
+        self.assertContains(response, "Enter Staff Mode")
+        self.assertNotContains(response, "Users")
+
+        self.app.get(self.some_staff_url, user=manager, status=403)
+
+    def test_staff_permission_required(self):
+        student_user = baker.make(UserProfile, email='student@institution.example.com')
+        self.app.post(self.url_enter, user=student_user, status=403)
+        self.app.post(self.url_exit, user=student_user, status=403)

--- a/evap/staff/tests/utils.py
+++ b/evap/staff/tests/utils.py
@@ -1,0 +1,56 @@
+import os
+import time
+
+from contextlib import contextmanager
+
+from django_webtest import WebTest
+
+from evap.evaluation.tests.tools import WebTestWith200Check
+from evap.staff.tools import ImportType, generate_import_filename
+
+
+def helper_enter_staff_mode(webtest):
+    # This is a bit complicated in WebTest
+    # See https://github.com/django-webtest/django-webtest/issues/68#issuecomment-350244293
+    webtest.app.set_cookie('sessionid', 'initial')
+    session = webtest.app.session
+    session['staff_mode_start_time'] = time.time()
+    session.save()
+    webtest.app.set_cookie('sessionid', session.session_key)
+
+
+def helper_exit_staff_mode(webtest):
+    # This is a bit complicated in WebTest
+    # See https://github.com/django-webtest/django-webtest/issues/68#issuecomment-350244293
+    webtest.app.set_cookie('sessionid', 'initial')
+    session = webtest.app.session
+    if 'staff_mode_start_time' in session:
+        del session['staff_mode_start_time']
+    session.save()
+    webtest.app.set_cookie('sessionid', session.session_key)
+
+
+@contextmanager
+def run_in_staff_mode(webtest):
+    helper_enter_staff_mode(webtest)
+    yield
+    helper_exit_staff_mode(webtest)
+
+
+class WebTestStaffMode(WebTest):
+    def setUp(self):
+        helper_enter_staff_mode(self)
+
+
+class WebTestStaffModeWith200Check(WebTestWith200Check):
+    def setUp(self):
+        helper_enter_staff_mode(self)
+
+
+def helper_delete_all_import_files(user_id):
+    for import_type in ImportType:
+        filename = generate_import_filename(user_id, import_type)
+        try:
+            os.remove(filename)
+        except FileNotFoundError:
+            pass

--- a/evap/staff/urls.py
+++ b/evap/staff/urls.py
@@ -85,4 +85,7 @@ urlpatterns = [
     path("development/components", views.development_components, name="development_components"),
 
     path("export_contributor_results/<int:contributor_id>", views.export_contributor_results_view, name="export_contributor_results"),
+
+    path("enter_staff_mode", views.enter_staff_mode, name="enter_staff_mode"),
+    path("exit_staff_mode", views.exit_staff_mode, name="exit_staff_mode"),
 ]

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -20,7 +20,7 @@ from django.utils.translation import gettext as _, gettext_lazy
 from django.utils.translation import get_language, ngettext
 from django.views.decorators.http import require_POST
 from evap.contributor.views import export_contributor_results
-from evap.evaluation.auth import reviewer_required, manager_required
+from evap.evaluation.auth import reviewer_required, manager_required, staff_permission_required
 from evap.evaluation.models import (Contribution, Course, CourseType, Degree, EmailTemplate, Evaluation, FaqQuestion,
                                     FaqSection, Question, Questionnaire, RatingAnswerCounter, Semester, TextAnswer,
                                     UserProfile)
@@ -31,6 +31,7 @@ from evap.results.tools import calculate_average_distribution, distribution_to_g
 from evap.results.views import update_template_cache_of_published_evaluations_in_course
 from evap.rewards.models import RewardPointGranting
 from evap.rewards.tools import can_reward_points_be_used_by, is_semester_activated
+from evap.staff import staff_mode
 from evap.staff.forms import (AtLeastOneFormSet, ContributionForm, ContributionCopyForm, ContributionFormSet,
                               ContributionCopyFormSet, CourseForm, CourseTypeForm,
                               CourseTypeMergeSelectionForm, DegreeForm, EmailTemplateForm, EvaluationEmailForm,
@@ -1752,3 +1753,19 @@ def development_components(request):
 def export_contributor_results_view(request, contributor_id):
     contributor = get_object_or_404(UserProfile, id=contributor_id)
     return export_contributor_results(contributor)
+
+
+@require_POST
+@staff_permission_required
+def enter_staff_mode(request):
+    staff_mode.enter_staff_mode(request)
+    messages.success(request, _("Successfully entered staff mode."))
+    return redirect('/')
+
+
+@require_POST
+@staff_permission_required
+def exit_staff_mode(request):
+    staff_mode.exit_staff_mode(request)
+    messages.success(request, _("Successfully exited staff mode."))
+    return redirect('/')


### PR DESCRIPTION
This pull request adds a new staff mode. More specifically, all managers see the following navbar.
![manager_off](https://user-images.githubusercontent.com/2820802/87877530-28f11680-c9df-11ea-9c0f-a0da947d7fda.png)
Once they enter staff mode (active for 1 hour), the navbar looks like this:
![manager_on](https://user-images.githubusercontent.com/2820802/87877537-3c03e680-c9df-11ea-9a93-e9d0c442f578.png)

Pretty much all "restrictions" are client-side, since this is not truly security-relevant. However, I tried to fix things like the default index and the full results view if not in staff mode. Please check whether this behaves as expected for different types of users (managers, students, reviewers, grade publishers...).

I had to work on the navbar cache, since the new button uses CSRF, which doesn't play nicely with caching...
This fixes #1109.

