### PR TITLE
Fix test failures in test_results_cache_refreshed

### DIFF
--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -142,14 +142,14 @@ class UserFormTests(TestCase):
 
         results_after = collect_results(evaluation)
 
-        self.assertEqual(
-            results_before.contribution_results[0].contributor.first_name,
-            "Peter"
+        self.assertCountEqual(
+            (result.contributor.first_name for result in results_before.contribution_results if result.contributor),
+            ("Peter", ),
         )
 
-        self.assertEqual(
-            results_after.contribution_results[0].contributor.first_name,
-            "Patrick"
+        self.assertCountEqual(
+            (result.contributor.first_name for result in results_after.contribution_results if result.contributor),
+            ("Patrick", ),
         )
 
 


### PR DESCRIPTION
fixes  #1486

I initially thought about using `assertEqual(next(filter(...)))` but I felt like this was simpler and open for adding other contributors -- however, if anyone has a strong opinion about the asserts, I can as well change them.