### PR TITLE
Configurable text answer warnings

### DIFF
--- a/evap/evaluation/fixtures/test_data.json
+++ b/evap/evaluation/fixtures/test_data.json
@@ -130389,6 +130389,16 @@
   }
 },
 {
+  "model": "student.textanswerwarning",
+  "pk": 1,
+  "fields": {
+    "warning_text_de": "Es sieht so aus, als ob du auf eine andere Antwort verweist. Alle Antworten werden unabh\u00e4ngig voneinander gespeichert, also werden andere nicht wissen, worauf du dich beziehst.",
+    "warning_text_en": "It looks like you are referencing another answer. All answers are saved independently of each other, so others won't know which answer you are referring to.",
+    "trigger_strings": "[\"s.o.\", \"s. o.\", \"siehe oben\", \"wie oben\", \"see above\", \"bereits erw\\u00e4hnt\", \"already stated\"]",
+    "order": 0
+  }
+},
+{
   "model": "grades.gradedocument",
   "pk": 2,
   "fields": {

--- a/evap/evaluation/management/commands/dump_testdata.py
+++ b/evap/evaluation/management/commands/dump_testdata.py
@@ -13,5 +13,5 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         outfile_name = os.path.join(settings.BASE_DIR, "evaluation", "fixtures", "test_data.json")
         call_command(
-            "dumpdata", "auth.group", "evaluation", "rewards", "grades", "--exclude=evaluation.LogEntry", indent=2,
+            "dumpdata", "auth.group", "evaluation", "rewards", "student", "grades", "--exclude=evaluation.LogEntry", indent=2,
             output=outfile_name, natural_foreign=True, natural_primary=True)

--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -77,6 +77,9 @@
                             <a class="dropdown-item" href="{% url 'staff:index' %}">{% trans 'Email templates' %}</a>
                             <a class="dropdown-item" href="{% url 'staff:faq_index' %}">{% trans 'FAQ' %}</a>
                             <a class="dropdown-item" href="{% url 'rewards:reward_point_redemption_events' %}">{% trans 'Reward point redemption events' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:text_answer_warnings' %}">
+                                {% trans 'Text answer warnings' %}
+                            </a>
                         </div>
                     </li>
                 {% endif %}

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -200,7 +200,7 @@ class TestDumpTestDataCommand(TestCase):
             management.call_command('dump_testdata')
 
         outfile_name = os.path.join(settings.BASE_DIR, "evaluation", "fixtures", "test_data.json")
-        mock.assert_called_once_with('dumpdata', 'auth.group', 'evaluation', 'rewards', 'grades',
+        mock.assert_called_once_with('dumpdata', 'auth.group', 'evaluation', 'rewards', 'student', 'grades',
                                      '--exclude=evaluation.LogEntry', indent=2, natural_foreign=True,
                                      natural_primary=True, output=outfile_name)
 

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -19,6 +19,7 @@ from evap.staff.tools import remove_user_from_represented_and_ccing_users
 from evap.results.tools import cache_results, STATES_WITH_RESULTS_CACHING, STATES_WITH_RESULT_TEMPLATE_CACHING
 from evap.results.views import (update_template_cache,
                                 update_template_cache_of_published_evaluations_in_course)
+from evap.student.models import TextAnswerWarning
 
 logger = logging.getLogger(__name__)
 
@@ -808,6 +809,20 @@ class TextAnswerForm(forms.ModelForm):
         if original_answer == normalize_newlines(self.cleaned_data.get('answer')):
             return None
         return original_answer
+
+
+class TextAnswerWarningForm(forms.ModelForm):
+    class Meta:
+        model = TextAnswerWarning
+        fields = ('warning_text_de', 'warning_text_en', 'trigger_strings', 'order')
+        field_classes = {
+            'trigger_strings': CharArrayField,
+        }
+        widgets = {
+            'warning_text_de': forms.Textarea(attrs={'rows': 5}),
+            'warning_text_en': forms.Textarea(attrs={'rows': 5}),
+            'order': forms.HiddenInput(),
+        }
 
 
 class ExportSheetForm(forms.Form):

--- a/evap/staff/templates/staff_index.html
+++ b/evap/staff/templates/staff_index.html
@@ -60,6 +60,18 @@
                     </ul>
                 </div>
             </div>
+            <div class="card mb-3">
+                <div class="card-body">
+                    <h4 class="card-title">{% trans 'Text answer warnings' %}</h4>
+                    <ul>
+                        <li>
+                            <a href="{% url 'staff:text_answer_warnings' %}">
+                                {% trans 'All text answer warnings' %}
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
             <div class="card">
                 <div class="card-body">
                     <h4 class="card-title">{% trans 'Reward Points' %}</h4>

--- a/evap/staff/templates/staff_text_answer_warnings.html
+++ b/evap/staff/templates/staff_text_answer_warnings.html
@@ -1,5 +1,8 @@
 {% extends 'staff_base.html' %}
 
+{% load static %}
+{% load student_filters %}
+
 {% block breadcrumb %}
     {{ block.super }}
     <li class="breadcrumb-item">{% trans 'Text answer warnings' %}</li>
@@ -63,13 +66,44 @@
                 <button type="submit" class="btn btn-primary">{% trans 'Save text answer warnings' %}</button>
             </div>
         </div>
+        <div class="card">
+            <div class="card-header">
+                {% trans 'Preview' %}
+            </div>
+            <div class="card-body">
+                <p>
+                    {% blocktrans %}
+                        Changes of the form above are only reflected after the form has been saved.
+                    {% endblocktrans %}
+                </p>
+                <div class="row">
+                    <div class="col-question col-lg-4 col-xl-5 d-flex flex-column">
+                        <label for="preview-textarea">
+                            {% trans 'Test textarea' %}
+                        </label>
+                        {% include 'student_text_answer_warnings.html' with text_answer_warnings=text_answer_warnings %}
+                    </div>
+                    <div class="col-answer col-lg-8 col-xl-7 d-flex">
+                        <div class="vote-inputs">
+                            <textarea id="preview-textarea"></textarea>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </form>
 {% endblock %}
 
 {% block additional_javascript %}
     {% include 'sortable_form_js.html' %}
 
+    {{ text_answer_warnings|text_answer_warning_trigger_strings|json_script:'text-answer-warnings' }}
+
     <script type="module">
+        import {initTextAnswerWarnings} from "{% static 'js/text-answer-warnings.js' %}";
+
+        initTextAnswerWarnings($("#preview-textarea"), JSON.parse($("#text-answer-warnings").text()));
+
         const rowChanged = function(row) {
             const triggerStrings = row.find("select[id$=-trigger_strings]").val();
             const warningTextDe = row.find("textarea[id$=-warning_text_de]").val();

--- a/evap/staff/templates/staff_text_answer_warnings.html
+++ b/evap/staff/templates/staff_text_answer_warnings.html
@@ -1,0 +1,98 @@
+{% extends 'staff_base.html' %}
+
+{% block breadcrumb %}
+    {{ block.super }}
+    <li class="breadcrumb-item">{% trans 'Text answer warnings' %}</li>
+{% endblock %}
+
+{% block content %}
+    {{ block.super }}
+
+    <form id="text-answer-warnings-form" method="POST" class="form-horizontal select2form">
+        {% csrf_token %}
+        {{ formset.management_form }}
+
+        <div class="card mb-3">
+            <div class="card-body">
+                <table id="text-answer-warnings-table" class="table table-vertically-aligned">
+                    <colgroup>
+                        <col />
+                        <col />
+                        <col style="width: 30%" />
+                        <col style="width: 30%" />
+                        <col />
+                    </colgroup>
+                    <thead>
+                        <tr>
+                            <th class="movable"></th>
+                            <th>{% trans 'Trigger strings (case-insensitive)' %}</th>
+                            <th>{% trans 'Warning text (German)' %}</th>
+                            <th>{% trans 'Warning text (English)' %}</th>
+                            <th>{% trans 'Actions' %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for form in formset %}
+                            <tr class="select2tr sortable">
+                                {% for hidden in form.hidden_fields %}
+                                    {{ hidden }}
+                                {% endfor %}
+                                <td class="movable">
+                                    <span class="movable-icon fas fa-arrows-alt-v"></span>
+                                </td>
+                                <td>
+                                    {% include 'bootstrap_form_field_widget.html' with field=form.trigger_strings %}
+                                </td>
+                                <td>
+                                    {% include 'bootstrap_form_field_widget.html' with field=form.warning_text_de %}
+                                </td>
+                                <td>
+                                    {% include 'bootstrap_form_field_widget.html' with field=form.warning_text_en %}
+                                </td>
+                                <td class="align-right">
+                                    {% include 'bootstrap_form_field_widget.html' with class="d-none" field=form.DELETE %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="card card-submit-area text-center mb-3">
+            <div class="card-body">
+                <button type="submit" class="btn btn-primary">{% trans 'Save text answer warnings' %}</button>
+            </div>
+        </div>
+    </form>
+{% endblock %}
+
+{% block additional_javascript %}
+    {% include 'sortable_form_js.html' %}
+
+    <script type="module">
+        const rowChanged = function(row) {
+            const triggerStrings = row.find("select[id$=-trigger_strings]").val();
+            const warningTextDe = row.find("textarea[id$=-warning_text_de]").val();
+            const warningTextEn = row.find("textarea[id$=-warning_text_en]").val();
+            return triggerStrings || warningTextDe || warningTextEn;
+        };
+        const rowAdded = function(row) {
+            applySelect2(row.find("select"));
+        };
+        makeFormSortable("text-answer-warnings-table", "form", rowChanged, rowAdded, "", true, true);
+
+        function applySelect2(element) {
+            element.select2({
+                language: "{{ LANGUAGE_CODE }}",
+                placeholder: "{% trans 'Add items...' %}",
+                tags: true,
+                // Disable search so that new items can be created instead of using an existing suggestion
+                matcher: () => null,
+                // Use a detached container to hide the dropdown
+                dropdownParent: $("<div>"),
+            });
+        }
+
+        applySelect2($("select").not('.form-template select'));
+    </script>
+{% endblock %}

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -20,7 +20,8 @@ from evap.evaluation.tests.tools import FuzzyInt, let_user_vote_for_evaluation, 
 from evap.results.tools import cache_results, get_results
 from evap.rewards.models import SemesterActivation, RewardPointGranting
 from evap.staff.forms import ContributionCopyForm, ContributionCopyFormSet, EvaluationCopyForm
-from evap.staff.tests.utils import helper_delete_all_import_files, run_in_staff_mode, \
+from evap.staff.tests.utils import helper_delete_all_import_files, helper_set_dynamic_choices_field_value, \
+    run_in_staff_mode, \
     WebTestStaffMode, WebTestStaffModeWith200Check
 from evap.staff.views import get_evaluations_with_prefetched_data
 import evap.staff.fixtures.excel_files_test_data as excel_data
@@ -2432,12 +2433,6 @@ class TestDegreeView(WebTestStaffMode):
     def setUpTestData(cls):
         cls.manager = make_manager()
 
-    @staticmethod
-    def set_import_names(field, value):
-        # Webtest will check that all values are included in the options, so we modify the options beforehand
-        field.options = [(name, False, name) for name in value]
-        field.value = value
-
     def test_degree_form(self):
         """
             Adds a degree via the staff form and verifies that the degree was created in the db.
@@ -2448,19 +2443,23 @@ class TestDegreeView(WebTestStaffMode):
         last_form_id = int(form["form-TOTAL_FORMS"].value) - 1
         form[f'form-{last_form_id}-name_de'].value = "Diplom"
         form[f'form-{last_form_id}-name_en'].value = "Diploma"
-        self.set_import_names(form[f'form-{last_form_id}-import_names'], ["Diplom", "D"])
+        helper_set_dynamic_choices_field_value(form[f'form-{last_form_id}-import_names'], ["Diplom", "D"])
         response = form.submit().follow()
         self.assertContains(response, "Successfully")
 
         self.assertEqual(Degree.objects.count(), degree_count_before + 1)
-        self.assertTrue(Degree.objects.filter(name_de="Diplom", name_en="Diploma", import_names=["Diplom", "D"]).exists())
+        self.assertTrue(Degree.objects.filter(
+            name_de="Diplom",
+            name_en="Diploma",
+            import_names=["Diplom", "D"],
+        ).exists())
 
     def test_import_names_duplicated_error(self):
         baker.make(Degree, _quantity=2)
         page = self.app.get(self.url, user=self.manager, status=200)
         form = page.forms['degree-form']
-        self.set_import_names(form['form-0-import_names'], ["Master of Arts", "M"])
-        self.set_import_names(form['form-1-import_names'], ["Master of Science", "M"])
+        helper_set_dynamic_choices_field_value(form['form-0-import_names'], ["Master of Arts", "M"])
+        helper_set_dynamic_choices_field_value(form['form-1-import_names'], ["Master of Science", "M"])
         response = form.submit()
         self.assertContains(response, 'Import name &quot;M&quot; is duplicated.')
 

--- a/evap/staff/tests/utils.py
+++ b/evap/staff/tests/utils.py
@@ -54,3 +54,12 @@ def helper_delete_all_import_files(user_id):
             os.remove(filename)
         except FileNotFoundError:
             pass
+
+
+# For some form fields, like a <select> which can be configured to create new options,
+# setting the value directly would be rejected by Webtest,
+# as it would check whether all values are included in the options.
+# To circumvent this, set the options beforehand with this helper.
+def helper_set_dynamic_choices_field_value(field, value):
+    field.options = [(name, False, name) for name in value]
+    field.value = value

--- a/evap/staff/urls.py
+++ b/evap/staff/urls.py
@@ -77,6 +77,8 @@ urlpatterns = [
     path("template/", RedirectView.as_view(url='/staff/', permanent=True)),
     path("template/<int:template_id>", views.template_edit, name="template_edit"),
 
+    path("text_answer_warnings/", views.text_answer_warnings_index, name="text_answer_warnings"),
+
     path("faq/", views.faq_index, name="faq_index"),
     path("faq/<int:section_id>", views.faq_section, name="faq_section"),
 

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1494,7 +1494,10 @@ def text_answer_warnings_index(request):
         messages.success(request, _("Successfully updated text warning answers."))
         return redirect('staff:text_answer_warnings')
 
-    return render(request, "staff_text_answer_warnings.html", dict(formset=formset))
+    return render(request, "staff_text_answer_warnings.html", dict(
+        formset=formset,
+        text_answer_warnings=TextAnswerWarning.objects.all(),
+    ))
 
 
 @manager_required

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -38,12 +38,14 @@ from evap.staff.forms import (AtLeastOneFormSet, ContributionForm, ContributionC
                               EvaluationForm, EvaluationCopyForm, EvaluationParticipantCopyForm, ExportSheetForm,
                               FaqQuestionForm,
                               FaqSectionForm, ModelWithImportNamesFormSet, ImportForm, QuestionForm, QuestionnaireForm, QuestionnairesAssignForm,
-                              RemindResponsibleForm, SemesterForm, SingleResultForm, TextAnswerForm, UserBulkUpdateForm,
+                              RemindResponsibleForm, SemesterForm, SingleResultForm, TextAnswerForm, TextAnswerWarningForm,
+                              UserBulkUpdateForm,
                               UserForm, UserImportForm, UserMergeSelectionForm)
 from evap.staff.importers import EnrollmentImporter, UserImporter, PersonImporter, sorted_messages
 from evap.staff.tools import (bulk_update_users, delete_import_file, delete_navbar_cache_for_users,
                               forward_messages, get_import_file_content_or_raise, import_file_exists, merge_users,
                               save_import_file, find_next_unreviewed_evaluation, ImportType)
+from evap.student.models import TextAnswerWarning
 from evap.student.forms import QuestionnaireVotingForm
 from evap.student.views import get_valid_form_groups_or_render_vote_page
 
@@ -1477,6 +1479,22 @@ def course_type_merge(request, main_type_id, other_type_id):
     courses_with_other_type = Course.objects.filter(type=other_type).order_by('semester__created_at', 'name_de')
     return render(request, "staff_course_type_merge.html",
         dict(main_type=main_type, other_type=other_type, courses_with_other_type=courses_with_other_type))
+
+
+@manager_required
+def text_answer_warnings_index(request):
+    text_answer_warnings = TextAnswerWarning.objects.all()
+
+    TextAnswerWarningFormSet = modelformset_factory(TextAnswerWarning, form=TextAnswerWarningForm,
+        can_delete=True, extra=1)
+    formset = TextAnswerWarningFormSet(request.POST or None, queryset=text_answer_warnings)
+
+    if formset.is_valid():
+        formset.save()
+        messages.success(request, _("Successfully updated text warning answers."))
+        return redirect('staff:text_answer_warnings')
+
+    return render(request, "staff_text_answer_warnings.html", dict(formset=formset))
 
 
 @manager_required

--- a/evap/static/js/text-answer-warnings.js
+++ b/evap/static/js/text-answer-warnings.js
@@ -1,0 +1,50 @@
+function normalize(string) {
+    return string.toLowerCase().replace(/\s{2,}/g, " ").trim();
+}
+
+function isTextMeaningless(text) {
+    return text.length > 0 && ["", "ka", "na"].includes(text.replace(/\W/g,''));
+}
+
+function doesTextContainTriggerString(text, triggerStrings) {
+    return triggerStrings.some(triggerString => text.includes(triggerString));
+}
+
+function updateTextareaWarning(textarea, textAnswerWarnings) {
+    const text = normalize(textarea.val());
+
+    let matchingWarnings = [];
+    if (isTextMeaningless(text)) {
+        matchingWarnings.push("meaningless");
+    }
+    for (const [i, triggerStrings] of textAnswerWarnings.entries()) {
+        if (doesTextContainTriggerString(text, triggerStrings)) {
+            matchingWarnings.push(`trigger-string-${i}`);
+        }
+    }
+
+    const showWarning = matchingWarnings.length > 0;
+    const row = textarea.parents(".row");
+    textarea.toggleClass('border border-warning', showWarning);
+
+    row.find("[data-warning]").addClass("d-none");
+    for (const matchingWarning of matchingWarnings) {
+        row.find(`[data-warning=${matchingWarning}]`).removeClass('d-none');
+    }
+}
+
+export function initTextAnswerWarnings(textareas, textAnswerWarnings) {
+    textAnswerWarnings = textAnswerWarnings.map(triggerStrings => triggerStrings.map(normalize));
+
+    let warningDelayTimer;
+    textareas.on("input", function() {
+        clearTimeout(warningDelayTimer);
+        warningDelayTimer = setTimeout(() => updateTextareaWarning($(this), textAnswerWarnings), 300);
+    });
+    textareas.blur(function() {
+        updateTextareaWarning($(this), textAnswerWarnings);
+    });
+    textareas.each(function() {
+        updateTextareaWarning($(this), textAnswerWarnings);
+    });
+}

--- a/evap/student/migrations/0001_text_answer_warnings.py
+++ b/evap/student/migrations/0001_text_answer_warnings.py
@@ -1,0 +1,27 @@
+from django.contrib.postgres.fields import ArrayField
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TextAnswerWarning',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('warning_text_de', models.CharField(max_length=1024, verbose_name='Warning text (German)')),
+                ('warning_text_en', models.CharField(max_length=1024, verbose_name='Warning text (English)')),
+                ('trigger_strings', ArrayField(base_field=models.CharField(max_length=1024), blank=True, default=list,
+                    size=None, verbose_name='Trigger strings (case-insensitive)')),
+                ('order', models.IntegerField(default=-1, verbose_name='Warning order')),
+            ],
+            options={
+                'ordering': ['order'],
+            },
+        ),
+    ]

--- a/evap/student/models.py
+++ b/evap/student/models.py
@@ -1,0 +1,19 @@
+from django.db import models
+from django.contrib.postgres.fields import ArrayField
+from django.utils.translation import gettext_lazy as _
+
+from evap.evaluation.tools import translate
+
+
+class TextAnswerWarning(models.Model):
+    warning_text_de = models.CharField(max_length=1024, verbose_name=_("Warning text (German)"))
+    warning_text_en = models.CharField(max_length=1024, verbose_name=_("Warning text (English)"))
+    warning_text = translate(en='warning_text_en', de='warning_text_de')
+
+    trigger_strings = ArrayField(models.CharField(max_length=1024), default=list,
+        verbose_name=_("Trigger strings (case-insensitive)"), blank=True)
+
+    order = models.IntegerField(verbose_name=_("Warning order"), default=-1)
+
+    class Meta:
+        ordering = ['order']

--- a/evap/student/templates/student_text_answer_warnings.html
+++ b/evap/student/templates/student_text_answer_warnings.html
@@ -1,0 +1,10 @@
+<span class="mt-2 warning-label d-none" data-warning="meaningless">
+    <span class="fas fa-exclamation-triangle"></span>
+    {% trans "This answer will probably be filtered out. You can simply leave the textbox empty." %}
+</span>
+{% for warning in text_answer_warnings %}
+    <span class="mt-2 warning-label d-none" data-warning="trigger-string-{{ forloop.counter0 }}">
+        <span class="fas fa-exclamation-triangle"></span>
+        {{ warning.warning_text }}
+    </span>
+{% endfor %}

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -168,7 +168,9 @@
 
         {{ text_answer_warnings|text_answer_warning_trigger_strings|json_script:'text-answer-warnings' }}
 
-        <script type="text/javascript">
+        <script type="module">
+            import {initTextAnswerWarnings} from "{% static 'js/text-answer-warnings.js' %}";
+
             var sisyphus = $("#student-vote-form").sisyphus({
                 locationBased: true,
                 excludeFields: $("input[type=hidden]"), // exclude the csrf token
@@ -189,50 +191,7 @@
             // (the data gets deleted every time the form is submitted, i.e. also when the form had errors and is displayed again)
             sisyphus.saveAllData();
 
-            function isTextMeaningless(text) {
-                return text.length > 0 && ["", "ka", "na"].includes(text.replace(/\W/g,''));
-            }
-
-            function doesTextContainTriggerString(text, triggerStrings) {
-                return triggerStrings.some(triggerString => text.includes(triggerString));
-            }
-
-            const textAnswerWarnings = JSON.parse($("#text-answer-warnings").text());
-
-            function updateTextareaWarning(textarea) {
-                const text = textarea.val().toLowerCase().replace(/\s{2,}/, " ");
-
-                let matchingWarnings = [];
-                if (isTextMeaningless(text)) {
-                    matchingWarnings.push("meaningless");
-                }
-                for (const [i, triggerStrings] of textAnswerWarnings.entries()) {
-                    if (doesTextContainTriggerString(text, triggerStrings)) {
-                        matchingWarnings.push(`trigger-string-${i}`);
-                    }
-                }
-
-                const showWarning = matchingWarnings.length > 0;
-                const row = textarea.parents(".row");
-                textarea.toggleClass('border border-warning', showWarning);
-
-                row.find("[data-warning]").addClass("d-none");
-                for (const matchingWarning of matchingWarnings) {
-                    row.find(`[data-warning=${matchingWarning}]`).removeClass("d-none");
-                }
-            }
-            var warningdelayTimer;
-            $('textarea').on('input', function() { // Run the check on input
-                //let textarea = $(this);
-                clearTimeout(warningdelayTimer);
-                warningdelayTimer = setTimeout(() => updateTextareaWarning($(this)), 300);
-            });
-            $('textarea').blur(function() { // Run the check when focus is lost
-                updateTextareaWarning($(this));
-            });
-            $('textarea').each(function() { // Run the check after page load
-                updateTextareaWarning($(this));
-            });
+            initTextAnswerWarnings($("textarea"), JSON.parse($("#text-answer-warnings").text()));
 
             var form = $('#student-vote-form');
 

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -3,6 +3,7 @@
 
 {% load static %}
 {% load evaluation_filters %}
+{% load student_filters %}
 {% load compress %}
 
 {% block title %}{{ evaluation.full_name }} - {% trans 'Evaluation' %} - {{ block.super }}{% endblock %}
@@ -165,6 +166,8 @@
             <script src="{% get_static_prefix %}js/sisyphus.min.js" type="text/javascript"></script>
         {% endcompress %}
 
+        {{ text_answer_warnings|text_answer_warning_trigger_strings|json_script:'text-answer-warnings' }}
+
         <script type="text/javascript">
             var sisyphus = $("#student-vote-form").sisyphus({
                 locationBased: true,
@@ -186,27 +189,37 @@
             // (the data gets deleted every time the form is submitted, i.e. also when the form had errors and is displayed again)
             sisyphus.saveAllData();
 
-            // Show a warning on textareas if they only contain meaningless text (punctuation, k.A., n/a, ...)
-            function isTextareaInvalid(textarea) {
-                return textarea.val().length > 0 && ["", "ka", "na"].includes(textarea.val().replace(/\W/g,'').toLowerCase());
+            function isTextMeaningless(text) {
+                return text.length > 0 && ["", "ka", "na"].includes(text.replace(/\W/g,''));
             }
-            // if it is not invalid, maybe show a reference warning (because referencing other answers is bad)
-            function doesTextareaContainReference(textarea) {
-                const text = textarea.val().toLowerCase();
-                return ["s.o.", "s. o.", "siehe oben", "wie oben", "see above", "bereits erwähnt", "already stated"]
-                    .some(ref => text.includes(ref));
-            }
-            function updateTextareaWarning(textarea) {
-                const isInvalid = isTextareaInvalid(textarea);
-                const containsReference = !isInvalid && doesTextareaContainReference(textarea);
 
-                const showWarning = isInvalid || containsReference;
-                const warningLabel = textarea.parents('.row').find('.warning-label');
-                warningLabel.toggleClass('d-none', !showWarning);
+            function doesTextContainTriggerString(text, triggerStrings) {
+                return triggerStrings.some(triggerString => text.includes(triggerString));
+            }
+
+            const textAnswerWarnings = JSON.parse($("#text-answer-warnings").text());
+
+            function updateTextareaWarning(textarea) {
+                const text = textarea.val().toLowerCase().replace(/\s{2,}/, " ");
+
+                let matchingWarnings = [];
+                if (isTextMeaningless(text)) {
+                    matchingWarnings.push("meaningless");
+                }
+                for (const [i, triggerStrings] of textAnswerWarnings.entries()) {
+                    if (doesTextContainTriggerString(text, triggerStrings)) {
+                        matchingWarnings.push(`trigger-string-${i}`);
+                    }
+                }
+
+                const showWarning = matchingWarnings.length > 0;
+                const row = textarea.parents(".row");
                 textarea.toggleClass('border border-warning', showWarning);
 
-                warningLabel.find('.warning-filtered-out').toggleClass('d-none', !isInvalid);
-                warningLabel.find('.warning-text-reference').toggleClass('d-none', !containsReference);
+                row.find("[data-warning]").addClass("d-none");
+                for (const matchingWarning of matchingWarnings) {
+                    row.find(`[data-warning=${matchingWarning}]`).removeClass("d-none");
+                }
             }
             var warningdelayTimer;
             $('textarea').on('input', function() { // Run the check on input

--- a/evap/student/templates/student_vote_questionnaire_group.html
+++ b/evap/student/templates/student_vote_questionnaire_group.html
@@ -22,11 +22,16 @@
                     {% else %}
                         <div class="col-question col-lg-4 col-xl-5 d-flex flex-column">
                             {{ field.label }}
-                            <div class="warning-label mt-auto d-none">
+                            <span class="mt-2 warning-label d-none" data-warning="meaningless">
                                 <span class="fas fa-exclamation-triangle"></span>
-                                <span class="warning-filtered-out d-none">{% trans "This answer will probably be filtered out. You can simply leave the textbox empty." %}</span>
-                                <span class="warning-text-reference d-none">{% trans "It looks like you are referencing another answer. All answers are saved independently of each other, so others won't know which answer you are referring to." %}</span>
-                            </div>
+                                {% trans "This answer will probably be filtered out. You can simply leave the textbox empty." %}
+                            </span>
+                            {% for warning in text_answer_warnings %}
+                                <span class="mt-2 warning-label d-none" data-warning="trigger-string-{{ forloop.counter0 }}">
+                                    <span class="fas fa-exclamation-triangle"></span>
+                                    {{ warning.warning_text }}
+                                </span>
+                            {% endfor %}
                         </div>
                     {% endif %}
                     {% if field|is_choice_field %}

--- a/evap/student/templates/student_vote_questionnaire_group.html
+++ b/evap/student/templates/student_vote_questionnaire_group.html
@@ -22,16 +22,7 @@
                     {% else %}
                         <div class="col-question col-lg-4 col-xl-5 d-flex flex-column">
                             {{ field.label }}
-                            <span class="mt-2 warning-label d-none" data-warning="meaningless">
-                                <span class="fas fa-exclamation-triangle"></span>
-                                {% trans "This answer will probably be filtered out. You can simply leave the textbox empty." %}
-                            </span>
-                            {% for warning in text_answer_warnings %}
-                                <span class="mt-2 warning-label d-none" data-warning="trigger-string-{{ forloop.counter0 }}">
-                                    <span class="fas fa-exclamation-triangle"></span>
-                                    {{ warning.warning_text }}
-                                </span>
-                            {% endfor %}
+                            {% include 'student_text_answer_warnings.html' with text_answer_warnings=text_answer_warnings %}
                         </div>
                     {% endif %}
                     {% if field|is_choice_field %}

--- a/evap/student/templatetags/student_filters.py
+++ b/evap/student/templatetags/student_filters.py
@@ -1,0 +1,8 @@
+from django.template import Library
+
+register = Library()
+
+
+@register.filter
+def text_answer_warning_trigger_strings(text_answer_warnings):
+    return [text_answer_warning.trigger_strings for text_answer_warning in text_answer_warnings]

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -13,6 +13,7 @@ from django.utils.translation import gettext as _
 from evap.evaluation.auth import participant_required
 from evap.evaluation.models import Evaluation, NO_ANSWER, Semester
 
+from evap.student.models import TextAnswerWarning
 from evap.student.forms import QuestionnaireVotingForm
 from evap.student.tools import question_id
 
@@ -128,6 +129,7 @@ def get_valid_form_groups_or_render_vote_page(request, evaluation, preview, for_
         success_redirect_url=reverse('student:index'),
         for_rendering_in_modal=for_rendering_in_modal,
         general_contribution_textanswers_visible_to=textanswers_visible_to(evaluation.general_contribution),
+        text_answer_warnings=TextAnswerWarning.objects.all(),
     )
     return None, render(request, "student_vote.html", template_data)
 


### PR DESCRIPTION
Closes #1507 

Remember to run:
```
./manage.py migrate student
```

- Creates the `TextAnswerWarning` model (the first one in the student app) which contains so-called trigger strings which will trigger a warning when used in a text answer
- Now, multiple text answers can be displayed at the same time, so the styling is a bit adjusted
- Staff not only gets a configuration form, but a little preview textarea as well

![textarea-with-warnings](https://user-images.githubusercontent.com/7093655/94599970-87fdc200-0291-11eb-9c52-b7a761452b88.png)

![staff-configuration](https://user-images.githubusercontent.com/7093655/94599967-87652b80-0291-11eb-94af-cc13de8a1eca.png)