### PR TITLE
More results caching for staff users

### DIFF
--- a/evap/evaluation/management/commands/refresh_results_cache.py
+++ b/evap/evaluation/management/commands/refresh_results_cache.py
@@ -3,7 +3,7 @@ from django.core.serializers.base import ProgressBar
 from django.core.cache import caches
 
 from evap.evaluation.models import Evaluation
-from evap.results.tools import collect_results
+from evap.results.tools import collect_results, STATES_WITH_RESULTS_CACHING, STATES_WITH_RESULT_TEMPLATE_CACHING
 from evap.results.views import warm_up_template_cache
 
 
@@ -15,19 +15,18 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.stdout.write("Clearing results cache...")
         caches['results'].clear()
-        total_count = Evaluation.objects.count()
 
         self.stdout.write("Calculating results for all evaluations...")
 
         self.stdout.ending = None
-        progress_bar = ProgressBar(self.stdout, total_count)
-
-        for counter, evaluation in enumerate(Evaluation.objects.all()):
+        evaluations = Evaluation.objects.filter(state__in=STATES_WITH_RESULTS_CACHING)
+        progress_bar = ProgressBar(self.stdout, evaluations.count())
+        for counter, evaluation in enumerate(evaluations):
             progress_bar.update(counter + 1)
             collect_results(evaluation)
 
         self.stdout.write("Prerendering result index page...\n")
 
-        warm_up_template_cache(Evaluation.objects.filter(state='published'))
+        warm_up_template_cache(Evaluation.objects.filter(state__in=STATES_WITH_RESULT_TEMPLATE_CACHING))
 
         self.stdout.write("Results cache has been refreshed.\n")

--- a/evap/evaluation/management/commands/refresh_results_cache.py
+++ b/evap/evaluation/management/commands/refresh_results_cache.py
@@ -3,7 +3,7 @@ from django.core.serializers.base import ProgressBar
 from django.core.cache import caches
 
 from evap.evaluation.models import Evaluation
-from evap.results.tools import collect_results, STATES_WITH_RESULTS_CACHING, STATES_WITH_RESULT_TEMPLATE_CACHING
+from evap.results.tools import cache_results, STATES_WITH_RESULTS_CACHING, STATES_WITH_RESULT_TEMPLATE_CACHING
 from evap.results.views import warm_up_template_cache
 
 
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         progress_bar = ProgressBar(self.stdout, evaluations.count())
         for counter, evaluation in enumerate(evaluations):
             progress_bar.update(counter + 1)
-            collect_results(evaluation)
+            cache_results(evaluation)
 
         self.stdout.write("Prerendering result index page...\n")
 

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -432,11 +432,11 @@ class Evaluation(models.Model):
             from evap.results.tools import STATES_WITH_RESULTS_CACHING, STATES_WITH_RESULT_TEMPLATE_CACHING
 
             if state_changed_to(self, STATES_WITH_RESULTS_CACHING):
-                from evap.results.tools import collect_results
-                collect_results(self)
+                from evap.results.tools import cache_results
+                cache_results(self)
             elif state_changed_from(self, STATES_WITH_RESULTS_CACHING):
-                from evap.results.tools import get_collect_results_cache_key
-                caches['results'].delete(get_collect_results_cache_key(self))
+                from evap.results.tools import get_results_cache_key
+                caches['results'].delete(get_results_cache_key(self))
 
             if state_changed_to(self, STATES_WITH_RESULT_TEMPLATE_CACHING):
                 from evap.results.views import update_template_cache_of_published_evaluations_in_course

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -572,6 +572,10 @@ class Evaluation(models.Model):
         return any(participant.is_external for participant in self.participants.all())
 
     @property
+    def can_staff_see_average_grade(self):
+        return self.state in {'evaluated', 'reviewed', 'published'}
+
+    @property
     def can_publish_average_grade(self):
         if self.is_single_result:
             return True

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -431,7 +431,8 @@ class Evaluation(models.Model):
             # pylint: disable=import-outside-toplevel
             from evap.results.tools import STATES_WITH_RESULTS_CACHING, STATES_WITH_RESULT_TEMPLATE_CACHING
 
-            if state_changed_to(self, STATES_WITH_RESULTS_CACHING):
+            if (state_changed_to(self, STATES_WITH_RESULTS_CACHING)
+                    or self.state_change_source == 'evaluated' and self.state == 'reviewed'): # reviewing changes results -> cache update required
                 from evap.results.tools import cache_results
                 cache_results(self)
             elif state_changed_from(self, STATES_WITH_RESULTS_CACHING):

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -176,10 +176,10 @@ class TestReloadTestdataCommand(TestCase):
 
 
 class TestRefreshResultsCacheCommand(TestCase):
-    def test_calls_collect_results(self):
-        baker.make(Evaluation)
+    def test_calls_cache_results(self):
+        baker.make(Evaluation, state='published')
 
-        with patch('evap.evaluation.management.commands.refresh_results_cache.collect_results') as mock:
+        with patch('evap.evaluation.management.commands.refresh_results_cache.cache_results') as mock:
             management.call_command('refresh_results_cache', stdout=StringIO())
 
         self.assertEqual(mock.call_count, Evaluation.objects.count())

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -14,7 +14,7 @@ from evap.evaluation.models import (Contribution, Course, CourseType, EmailTempl
                                     Question, Questionnaire, RatingAnswerCounter, Semester, TextAnswer, UserProfile)
 from evap.grades.models import GradeDocument
 from evap.evaluation.tests.tools import let_user_vote_for_evaluation, make_contributor, make_editor
-from evap.results.tools import calculate_average_distribution
+from evap.results.tools import calculate_average_distribution, cache_results
 from evap.results.views import get_evaluation_result_template_fragment_cache_key
 
 
@@ -547,12 +547,14 @@ class ParticipationArchivingTests(TestCase):
         self.assertTrue(self.evaluation.participations_are_archived)
 
     def test_archiving_participations_does_not_change_results(self):
+        cache_results(self.evaluation)
         distribution = calculate_average_distribution(self.evaluation)
 
         self.semester.archive_participations()
         self.refresh_evaluation()
         caches['results'].clear()
 
+        cache_results(self.evaluation)
         new_distribution = calculate_average_distribution(self.evaluation)
         self.assertEqual(new_distribution, distribution)
 

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -135,24 +135,12 @@ class GradeUploadTest(WebTest):
         self.helper_check_final_grade_upload(course, 0)
 
     def test_toggle_no_grades(self):
-        evaluation = baker.make(
-            Evaluation,
-            name_en="Toggle",
-            vote_start_datetime=datetime.now(),
-            state="reviewed",
-            participants=[self.student, self.student2, self.student3],
-            voters=[self.student, self.student2]
-        )
-        baker.make(
-            Contribution,
-            evaluation=evaluation,
-            contributor=UserProfile.objects.get(email="editor@institution.example.com"),
-            questionnaires=[baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)],
-            role=Contribution.Role.EDITOR,
-            textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
-        )
-
-        evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
+        evaluation = self.evaluation
+        evaluation.manager_approve()
+        evaluation.evaluation_begin()
+        evaluation.evaluation_end()
+        evaluation.review_finished()
+        evaluation.save()
 
         self.assertFalse(evaluation.course.gets_no_grade_documents)
 

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -9,7 +9,7 @@ import xlwt
 
 from evap.evaluation.models import CourseType, Degree, Evaluation, Questionnaire
 from evap.evaluation.tools import ExcelExporter
-from evap.results.tools import (collect_results, calculate_average_course_distribution, calculate_average_distribution,
+from evap.results.tools import (get_results, calculate_average_course_distribution, calculate_average_distribution,
                                 distribution_to_grade, get_grade_color)
 
 
@@ -108,7 +108,7 @@ class ResultsExporter(ExcelExporter):
             if not evaluation.can_publish_rating_results and not include_not_enough_voters:
                 continue
             results = OrderedDict()
-            for contribution_result in collect_results(evaluation).contribution_results:
+            for contribution_result in get_results(evaluation).contribution_results:
                 for questionnaire_result in contribution_result.questionnaire_results:
                     # RatingQuestion.counts is a tuple of integers or None, if this tuple is all zero, we want to exclude it
                     if all(not question_result.question.is_rating_question or question_result.counts is None or sum(question_result.counts) == 0 for question_result in questionnaire_result.question_results):

--- a/evap/results/templates/evaluation_result_widget.html
+++ b/evap/results/templates/evaluation_result_widget.html
@@ -10,7 +10,7 @@
         {% include "distribution_with_grade.html" with distribution=course_or_evaluation.distribution average=course_or_evaluation.avg_grade weight_info=course_or_evaluation|weight_info %}
     </div>
 {% else %}
-    <div class="d-flex"{% if not question_result %} data-toggle="tooltip" data-placement="left" title="{% trans 'Not enough answers were given.' %}"{% endif %}>
+    <div class="d-flex" data-toggle="tooltip" data-placement="left" title="{% trans 'Not enough answers were given.' %}">
         {% include "distribution_with_grade_disabled.html" with icon="far fa-eye-slash" %}
     </div>
 {% endif %}

--- a/evap/results/templates/results_index_evaluation.html
+++ b/evap/results/templates/results_index_evaluation.html
@@ -61,7 +61,13 @@
     {% endif %}
 
     <div data-col="result"{% if not is_subentry %} data-order="{% if evaluation.is_single_result %}{{ evaluation.single_result_rating_result.average }}{% else %}{{ evaluation.avg_grade|default:7 }}{% endif %}"{% endif %}>
-        {% include 'evaluation_result_widget.html' with course_or_evaluation=evaluation %}
+        {% if not evaluation.can_staff_see_average_grade %}
+            <div class="d-flex" data-toggle="tooltip" data-placement="left" title="{% trans 'Evaluation result is not yet available.' %}">
+                {% include "distribution_with_grade_disabled.html" with icon="fas fa-hourglass-half" %}
+            </div>
+        {% else %}
+            {% include 'evaluation_result_widget.html' with course_or_evaluation=evaluation %}
+        {% endif %}
     </div>
 </{% if links_to_results_page %}a{% else %}div{% endif %}>
 

--- a/evap/results/templatetags/results_templatetags.py
+++ b/evap/results/templatetags/results_templatetags.py
@@ -1,5 +1,5 @@
 from django.template import Library
-from evap.results.tools import get_grade_color, normalized_distribution
+from evap.results.tools import get_grade_color, normalized_distribution, STATES_WITH_RESULT_TEMPLATE_CACHING
 
 register = Library()
 
@@ -16,7 +16,7 @@ def norm_distribution(distribution):
 
 @register.filter(name='evaluation_results_cache_timeout')
 def evaluation_results_cache_timeout(evaluation):
-    if evaluation.state == 'published':
+    if evaluation.state in STATES_WITH_RESULT_TEMPLATE_CACHING:
         return None  # cache forever
     return 0  # don't cache at all
 

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -10,7 +10,7 @@ from evap.contributor.views import export_contributor_results
 from evap.evaluation.models import (Contribution, Course, CourseType, Degree, Evaluation, Question, Questionnaire,
                                     RatingAnswerCounter, Semester, UserProfile, TextAnswer)
 from evap.results.exporters import ResultsExporter, TextAnswerExporter
-from evap.results.tools import collect_results
+from evap.results.tools import get_results
 from evap.results.views import filter_text_answers
 
 
@@ -468,7 +468,7 @@ class TestExporters(TestCase):
                 state=TextAnswer.State.PUBLISHED
             )
 
-        evaluation_result = collect_results(evaluation)
+        evaluation_result = get_results(evaluation)
         filter_text_answers(evaluation_result)
 
         results = TextAnswerExporter.InputData(evaluation_result.contribution_results)

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -10,7 +10,7 @@ from evap.contributor.views import export_contributor_results
 from evap.evaluation.models import (Contribution, Course, CourseType, Degree, Evaluation, Question, Questionnaire,
                                     RatingAnswerCounter, Semester, UserProfile, TextAnswer)
 from evap.results.exporters import ResultsExporter, TextAnswerExporter
-from evap.results.tools import get_results
+from evap.results.tools import cache_results, get_results
 from evap.results.views import filter_text_answers
 
 
@@ -57,6 +57,8 @@ class TestExporters(TestCase):
         baker.make(RatingAnswerCounter, question=question_3, contribution=evaluation.general_contribution, answer=3, count=100)
         baker.make(RatingAnswerCounter, question=question_4, contribution=evaluation.general_contribution, answer=3, count=100)
 
+        cache_results(evaluation)
+
         binary_content = BytesIO()
         ResultsExporter().export(
             binary_content,
@@ -101,6 +103,8 @@ class TestExporters(TestCase):
         contribution = baker.make(Contribution, evaluation=evaluation, questionnaires=[questionnaire], contributor=contributor)
         baker.make(RatingAnswerCounter, question=likert_question, contribution=contribution, answer=3, count=100)
 
+        cache_results(evaluation)
+
         binary_content = BytesIO()
         ResultsExporter().export(
             binary_content,
@@ -121,20 +125,23 @@ class TestExporters(TestCase):
         semester = baker.make(Semester)
         course_type = baker.make(CourseType)
         degree = baker.make(Degree)
-        baker.make(
+        evaluation1 = baker.make(
             Evaluation,
             state='published',
             course=baker.make(Course, degrees=[degree], type=course_type, semester=semester, name_de="A", name_en="B"),
             name_de='Evaluation1',
             name_en='Evaluation1'
         )
-        baker.make(
+        evaluation2 = baker.make(
             Evaluation,
             state='published',
             course=baker.make(Course, degrees=[degree], type=course_type, semester=semester, name_de="B", name_en="A"),
             name_de='Evaluation2',
             name_en='Evaluation2'
         )
+
+        cache_results(evaluation1)
+        cache_results(evaluation2)
 
         content_de = BytesIO()
         with translation.override("de"):
@@ -173,6 +180,9 @@ class TestExporters(TestCase):
             _participant_count=2,
             _voter_count=2
         )
+
+        cache_results(evaluation_1)
+        cache_results(evaluation_2)
 
         questionnaire = baker.make(Questionnaire)
         question = baker.make(Question, type=Question.LIKERT, questionnaire=questionnaire)
@@ -233,6 +243,9 @@ class TestExporters(TestCase):
         unpublished_evaluation = baker.make(Evaluation, state="reviewed", course__semester=semester, course__degrees=[degree], course__type__order=2)
         course_types = [published_evaluation.course.type.id, unpublished_evaluation.course.type.id]
 
+        cache_results(published_evaluation)
+        cache_results(unpublished_evaluation)
+
         # First, make sure that the unpublished does not appear
         sheet = self.get_export_sheet(include_unpublished=False, semester=semester, degree=degree, course_types=course_types)
         self.assertEqual(len(sheet.row_values(0)), 2)
@@ -268,6 +281,9 @@ class TestExporters(TestCase):
             _participant_count=1000,
         )
 
+        cache_results(enough_voters_evaluation)
+        cache_results(not_enough_voters_evaluation)
+
         course_types = [enough_voters_evaluation.course.type.id, not_enough_voters_evaluation.course.type.id]
 
         # First, make sure that the one with only a single voter does not appear
@@ -294,6 +310,7 @@ class TestExporters(TestCase):
     def test_exclude_single_result(self):
         degree = baker.make(Degree)
         evaluation = baker.make(Evaluation, is_single_result=True, state="published", course__degrees=[degree])
+        cache_results(evaluation)
         sheet = self.get_export_sheet(evaluation.course.semester, degree, [evaluation.course.type.id])
         self.assertEqual(len(sheet.row_values(0)), 1, "There should be no column for the evaluation, only the row description")
 
@@ -306,6 +323,7 @@ class TestExporters(TestCase):
         unused_question = baker.make(Question, type=Question.LIKERT, questionnaire=unused_questionnaire)
         baker.make(RatingAnswerCounter, question=used_question, contribution=evaluation.general_contribution, answer=3, count=10)
         evaluation.general_contribution.questionnaires.set([used_questionnaire, unused_questionnaire])
+        cache_results(evaluation)
 
         sheet = self.get_export_sheet(evaluation.course.semester, degree, [evaluation.course.type.id])
         self.assertEqual(sheet.row_values(4)[0], used_questionnaire.name)
@@ -317,6 +335,7 @@ class TestExporters(TestCase):
         degree = baker.make(Degree, name_en="Celsius")
         course_type = baker.make(CourseType, name_en="LetsPlay")
         evaluation = baker.make(Evaluation, course__degrees=[degree], course__type=course_type, state="published")
+        cache_results(evaluation)
 
         sheet = self.get_export_sheet(evaluation.course.semester, degree, [course_type.id])
         self.assertEqual(sheet.col_values(1)[1:3], [degree.name, course_type.name])
@@ -326,6 +345,8 @@ class TestExporters(TestCase):
         degree = baker.make(Degree)
         evaluation1 = baker.make(Evaluation, course__semester=semester, course__degrees=[degree], state="published")
         evaluation2 = baker.make(Evaluation, course__semester=semester, course__degrees=[degree], state="published")
+        cache_results(evaluation1)
+        cache_results(evaluation2)
 
         sheet = self.get_export_sheet(semester, degree, [evaluation1.course.type.id, evaluation2.course.type.id])
 
@@ -347,6 +368,7 @@ class TestExporters(TestCase):
         baker.make(RatingAnswerCounter, answer=4, count=1, question=question2, contribution=evaluation.general_contribution)
 
         evaluation.general_contribution.questionnaires.set([questionnaire1, questionnaire2])
+        cache_results(evaluation)
 
         sheet = self.get_export_sheet(evaluation.course.semester, degree, [evaluation.course.type.id])
 
@@ -379,6 +401,8 @@ class TestExporters(TestCase):
             for grade in grades:
                 baker.make(RatingAnswerCounter, answer=grade, count=1, question=question, contribution=e.general_contribution)
             e.general_contribution.questionnaires.set([questionnaire])
+        for evaluation in evaluations:
+            cache_results(evaluation)
 
         sheet = self.get_export_sheet(course.semester, degree, [course.type.id])
         self.assertEqual(sheet.row_values(12)[1], expected_average)
@@ -394,6 +418,7 @@ class TestExporters(TestCase):
         baker.make(RatingAnswerCounter, answer=1, count=4, question=question, contribution=evaluation.general_contribution)
         baker.make(RatingAnswerCounter, answer=5, count=2, question=question, contribution=evaluation.general_contribution)
         evaluation.general_contribution.questionnaires.set([questionnaire])
+        cache_results(evaluation)
 
         sheet = self.get_export_sheet(evaluation.course.semester, degree, [evaluation.course.type.id])
         self.assertEqual(sheet.row_values(5)[0], question.text)
@@ -435,6 +460,9 @@ class TestExporters(TestCase):
         other_contribution.questionnaires.set([contributor_questionnaire])
         baker.make(RatingAnswerCounter, question=contributor_question, contribution=other_contribution, answer=2, count=2)
 
+        cache_results(evaluation_1)
+        cache_results(evaluation_2)
+
         binary_content = export_contributor_results(contributor).content
         workbook = xlrd.open_workbook(file_contents=binary_content)
 
@@ -456,7 +484,7 @@ class TestExporters(TestCase):
         self.assertEqual(workbook.sheets()[0].row_values(10)[2], 3.25)
 
     def test_text_answer_export(self):
-        evaluation = baker.make(Evaluation, can_publish_text_results=True)
+        evaluation = baker.make(Evaluation, state='published', can_publish_text_results=True)
         questions = [baker.make(Question, questionnaire__type=t, type=Question.TEXT) for t in Questionnaire.Type.values]
 
         for idx in [0, 1, 2, 2, 0]:
@@ -468,6 +496,7 @@ class TestExporters(TestCase):
                 state=TextAnswer.State.PUBLISHED
             )
 
+        cache_results(evaluation)
         evaluation_result = get_results(evaluation)
         filter_text_answers(evaluation_result)
 

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -25,14 +25,17 @@ class TestCalculateResults(TestCase):
 
         self.assertIsNotNone(caches['results'].get(get_results_cache_key(evaluation)))
 
-    def test_cache_unpublished_evaluation(self):
-        evaluation = baker.make(Evaluation, state='reviewed')
-        evaluation.publish()
+    def test_caching_lifecycle(self):
+        evaluation = baker.make(Evaluation, state='in_evaluation')
+
+        self.assertIsNone(caches['results'].get(get_results_cache_key(evaluation)))
+
+        evaluation.evaluation_end()
         evaluation.save()
 
         self.assertIsNotNone(caches['results'].get(get_results_cache_key(evaluation)))
 
-        evaluation.unpublish()
+        evaluation.reopen_evaluation()
         evaluation.save()
 
         self.assertIsNone(caches['results'].get(get_results_cache_key(evaluation)))

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -168,6 +168,7 @@ class TestCalculateAverageDistribution(TestCase):
         baker.make(RatingAnswerCounter, question=self.question_likert_2, contribution=self.general_contribution, answer=3, count=3)
         baker.make(RatingAnswerCounter, question=self.question_bipolar, contribution=self.general_contribution, answer=3, count=2)
         baker.make(RatingAnswerCounter, question=self.question_bipolar_2, contribution=self.general_contribution, answer=-1, count=4)
+        cache_results(self.evaluation)
 
         contributor_weights_sum = settings.CONTRIBUTOR_GRADE_QUESTIONS_WEIGHT + settings.CONTRIBUTOR_NON_GRADE_RATING_QUESTIONS_WEIGHT
         contributor1_average = ((settings.CONTRIBUTOR_GRADE_QUESTIONS_WEIGHT * ((2 * 1) + (1 * 1)) / (1 + 1)) + (settings.CONTRIBUTOR_NON_GRADE_RATING_QUESTIONS_WEIGHT * 3)) / contributor_weights_sum  # 2.4
@@ -195,6 +196,7 @@ class TestCalculateAverageDistribution(TestCase):
         baker.make(RatingAnswerCounter, question=self.question_likert, contribution=self.contribution1, answer=5, count=3)
         baker.make(RatingAnswerCounter, question=self.question_likert, contribution=self.general_contribution, answer=5, count=5)
         baker.make(RatingAnswerCounter, question=self.question_likert_2, contribution=self.general_contribution, answer=3, count=3)
+        cache_results(self.evaluation)
 
         # contribution1: 0.4 * (0.5, 0, 0.5, 0, 0) + 0.6 * (0, 0, 0.5, 0, 0.5) = (0.2, 0, 0.5, 0, 0.3)
         # contribution2: (0, 0.5, 0, 0.5, 0)
@@ -222,6 +224,7 @@ class TestCalculateAverageDistribution(TestCase):
         baker.make(RatingAnswerCounter, question=self.question_likert, contribution=self.general_contribution, answer=5, count=5)
         baker.make(RatingAnswerCounter, question=self.question_likert_2, contribution=self.general_contribution, answer=3, count=3)
         baker.make(RatingAnswerCounter, question=self.question_grade, contribution=self.general_contribution, answer=2, count=10)
+        cache_results(self.evaluation)
 
         # contributions and general_non_grade are as above
         # general_grade: (0, 1, 0, 0, 0)
@@ -248,6 +251,7 @@ class TestCalculateAverageDistribution(TestCase):
         )
         baker.make(RatingAnswerCounter, question=questionnaire.questions.first(), contribution=contribution, answer=1, count=1)
         baker.make(RatingAnswerCounter, question=questionnaire.questions.first(), contribution=contribution, answer=4, count=1)
+        cache_results(single_result_evaluation)
         distribution = calculate_average_distribution(single_result_evaluation)
         self.assertEqual(distribution, (0.5, 0, 0, 0.5, 0))
         rating_result = get_single_result_rating_result(single_result_evaluation)
@@ -261,6 +265,7 @@ class TestCalculateAverageDistribution(TestCase):
 
         evaluation.general_contribution.questionnaires.set([self.questionnaire])
         baker.make(RatingAnswerCounter, question=self.question_grade, contribution=evaluation.general_contribution, answer=1, count=1)
+        cache_results(evaluation)
 
         distribution = calculate_average_distribution(evaluation)
         self.assertEqual(distribution[0], 1)
@@ -334,6 +339,8 @@ class TestCalculateAverageDistribution(TestCase):
         contribution = baker.make(Contribution, evaluation=single_result, contributor=None, questionnaires=[single_result_questionnaire])
         baker.make(RatingAnswerCounter, question=single_result_question, contribution=contribution, answer=2, count=1)
         baker.make(RatingAnswerCounter, question=single_result_question, contribution=contribution, answer=3, count=1)
+        cache_results(single_result)
+        cache_results(self.evaluation)
 
         distribution = calculate_average_course_distribution(course)
         self.assertEqual(distribution[0], 0.25)

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -32,6 +32,18 @@ class TestCalculateResults(TestCase):
 
         self.assertIsNone(caches['results'].get(get_collect_results_cache_key(evaluation)))
 
+    def test_caching_works_after_multiple_transitions(self):
+        evaluation = baker.make(Evaluation, state='in_evaluation')
+
+        self.assertIsNone(caches['results'].get(get_results_cache_key(evaluation)))
+
+        evaluation.evaluation_end()
+        evaluation.review_finished()
+        evaluation.publish()
+        evaluation.save()
+
+        self.assertIsNotNone(caches['results'].get(get_results_cache_key(evaluation)))
+
     def test_calculation_unipolar_results(self):
         contributor1 = baker.make(UserProfile)
         student = baker.make(UserProfile)

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -796,7 +796,8 @@ class TestTextAnswerExportView(WebTest):
             email="reviewer@institution.example.com",
             groups=[Group.objects.get(name="Reviewer")],
         )
-        evaluation = baker.make(Evaluation)
+        evaluation = baker.make(Evaluation, state='published')
+
         cls.url = f"/results/evaluation/{evaluation.id}/text_answers_export"
 
     def test_file_sent(self):

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -138,10 +138,14 @@ def cache_results(evaluation):
 
 
 def get_results(evaluation):
+    assert evaluation.state in STATES_WITH_RESULTS_CACHING | {'in_evaluation'}
+
+    if evaluation.state == 'in_evaluation':
+        return _get_results_impl(evaluation)
+
     cache_key = get_results_cache_key(evaluation)
     result = caches['results'].get(cache_key)
-    if result is None:
-        result = _get_results_impl(evaluation)
+    assert result is not None
     return result
 
 

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -11,6 +11,10 @@ from evap.evaluation.models import CHOICES, NO_ANSWER, Contribution, Question,\
         Evaluation
 
 
+STATES_WITH_RESULTS_CACHING = {'published'}
+STATES_WITH_RESULT_TEMPLATE_CACHING = {'published'}
+
+
 GRADE_COLORS = {
     1: (136, 191, 74),
     2: (187, 209, 84),
@@ -129,7 +133,7 @@ def get_collect_results_cache_key(evaluation):
 
 
 def collect_results(evaluation, force_recalculation=False):
-    if evaluation.state != "published":
+    if evaluation.state not in STATES_WITH_RESULTS_CACHING:
         return _collect_results_impl(evaluation)
 
     cache_key = get_collect_results_cache_key(evaluation)

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -10,7 +10,7 @@ from evap.evaluation.models import CHOICES, NO_ANSWER, Contribution, Question,\
         Evaluation
 
 
-STATES_WITH_RESULTS_CACHING = {'published'}
+STATES_WITH_RESULTS_CACHING = {'evaluated', 'reviewed', 'published'}
 STATES_WITH_RESULT_TEMPLATE_CACHING = {'published'}
 
 

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -271,7 +271,9 @@ def get_evaluations_with_course_result_attributes(evaluations):
 
 
 def calculate_average_distribution(evaluation):
-    if not evaluation.can_publish_average_grade:
+    assert evaluation.state in {'in_evaluation', 'evaluated', 'reviewed', 'published'}
+
+    if not evaluation.can_staff_see_average_grade or not evaluation.can_publish_average_grade:
         return None
 
     # will contain a list of question results for each contributor and one for the evaluation (where contributor is None)

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -15,7 +15,7 @@ from evap.evaluation.models import Semester, Degree, Evaluation, CourseType, Use
 from evap.evaluation.auth import internal_required
 from evap.evaluation.tools import FileResponse
 from evap.results.exporters import TextAnswerExporter
-from evap.results.tools import (collect_results, calculate_average_distribution, distribution_to_grade,
+from evap.results.tools import (get_results, calculate_average_distribution, distribution_to_grade,
                                 get_evaluations_with_course_result_attributes, get_single_result_rating_result,
                                 HeadingResult, TextResult, can_textanswer_be_seen_by, normalized_distribution, STATES_WITH_RESULT_TEMPLATE_CACHING)
 
@@ -176,7 +176,7 @@ def evaluation_detail(request, semester_id, evaluation_id):
 
     view, view_as_user, represented_users, contributor_id = evaluation_detail_parse_get_parameters(request, evaluation)
 
-    evaluation_result = collect_results(evaluation)
+    evaluation_result = get_results(evaluation)
     remove_textanswers_that_the_user_must_not_see(evaluation_result, view_as_user, represented_users, view)
     exclude_empty_headings(evaluation_result)
     remove_empty_questionnaire_and_contribution_results(evaluation_result)
@@ -367,7 +367,7 @@ def extract_evaluation_answer_data(request, evaluation):
 
     view, view_as_user, represented_users, contributor_id = evaluation_detail_parse_get_parameters(request, evaluation)
 
-    evaluation_result = collect_results(evaluation)
+    evaluation_result = get_results(evaluation)
     filter_text_answers(evaluation_result)
     remove_textanswers_that_the_user_must_not_see(evaluation_result, view_as_user, represented_users, view)
 

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -17,7 +17,7 @@ from evap.evaluation.tools import FileResponse
 from evap.results.exporters import TextAnswerExporter
 from evap.results.tools import (collect_results, calculate_average_distribution, distribution_to_grade,
                                 get_evaluations_with_course_result_attributes, get_single_result_rating_result,
-                                HeadingResult, TextResult, can_textanswer_be_seen_by, normalized_distribution)
+                                HeadingResult, TextResult, can_textanswer_be_seen_by, normalized_distribution, STATES_WITH_RESULT_TEMPLATE_CACHING)
 
 
 def get_course_result_template_fragment_cache_key(course_id, language):
@@ -29,7 +29,7 @@ def get_evaluation_result_template_fragment_cache_key(evaluation_id, language, l
 
 
 def delete_template_cache(evaluation):
-    assert evaluation.state != 'published'
+    assert evaluation.state not in STATES_WITH_RESULT_TEMPLATE_CACHING
     _delete_template_cache_impl(evaluation)
 
 
@@ -63,7 +63,7 @@ def warm_up_template_cache(evaluations):
             assert get_course_result_template_fragment_cache_key(course.id, 'en') in caches['results']
             assert get_course_result_template_fragment_cache_key(course.id, 'de') in caches['results']
         for evaluation in evaluations:
-            assert evaluation.state == 'published'
+            assert evaluation.state in STATES_WITH_RESULT_TEMPLATE_CACHING
             is_subentry = evaluation.course.evaluation_count > 1
             translation.activate('en')
             get_template('results_index_evaluation.html').render(dict(evaluation=evaluation, links_to_results_page=True, is_subentry=is_subentry))
@@ -81,13 +81,13 @@ def warm_up_template_cache(evaluations):
 
 def update_template_cache(evaluations):
     for evaluation in evaluations:
-        assert evaluation.state == "published"
+        assert evaluation.state in STATES_WITH_RESULT_TEMPLATE_CACHING
         _delete_template_cache_impl(evaluation)
         warm_up_template_cache([evaluation])
 
 
 def update_template_cache_of_published_evaluations_in_course(course):
-    course_evaluations = course.evaluations.filter(state="published")
+    course_evaluations = course.evaluations.filter(state__in=STATES_WITH_RESULT_TEMPLATE_CACHING)
     for course_evaluation in course_evaluations:
         _delete_evaluation_template_cache_impl(course_evaluation)
     _delete_course_template_cache_impl(course)
@@ -197,9 +197,9 @@ def evaluation_detail(request, semester_id, evaluation_id):
             if contribution_result.contributor not in [None, view_as_user]
         ]
 
-    # if the evaluation is not published, the rendered results are not cached, so we need to attach distribution
+    # if the results are not cached, we need to attach distribution
     # information for rendering the distribution bar
-    if evaluation.state != 'published':
+    if evaluation.state not in STATES_WITH_RESULT_TEMPLATE_CACHING:
         evaluation = get_evaluations_with_course_result_attributes(get_evaluations_with_prefetched_data([evaluation]))[0]
 
     is_responsible_or_contributor_or_delegate = evaluation.is_user_responsible_or_contributor_or_delegate(view_as_user)

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -17,7 +17,7 @@ from evap.evaluation.models import (Contribution, Course, CourseType, Degree, Em
                                     UserProfile)
 from evap.evaluation.tools import date_to_datetime
 from evap.staff.tools import remove_user_from_represented_and_ccing_users
-from evap.results.tools import collect_results, STATES_WITH_RESULTS_CACHING, STATES_WITH_RESULT_TEMPLATE_CACHING
+from evap.results.tools import cache_results, STATES_WITH_RESULTS_CACHING, STATES_WITH_RESULT_TEMPLATE_CACHING
 from evap.results.views import (update_template_cache,
                                 update_template_cache_of_published_evaluations_in_course)
 
@@ -788,7 +788,7 @@ class UserForm(forms.ModelForm):
                 state__in=STATES_WITH_RESULTS_CACHING
             ).distinct()
             for evaluation in evaluations:
-                collect_results(evaluation, force_recalculation=True)
+                cache_results(evaluation)
 
         self.instance.save()
 

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -11,7 +11,7 @@ from evap.evaluation.tests.tools import (create_evaluation_with_responsible_and_
 from evap.staff.forms import (ContributionForm, ContributionCopyForm, ContributionFormSet, CourseForm,
                               EvaluationEmailForm, EvaluationForm, EvaluationCopyForm,
                               QuestionnaireForm, SingleResultForm, UserForm)
-from evap.results.tools import collect_results
+from evap.results.tools import cache_results, get_results
 from evap.contributor.forms import EvaluationForm as ContributorEvaluationForm
 
 
@@ -133,14 +133,15 @@ class UserFormTests(TestCase):
         baker.make(Contribution, contributor=contributor,
                    evaluation=evaluation)
 
-        results_before = collect_results(evaluation)
+        cache_results(evaluation)
+        results_before = get_results(evaluation)
 
         form_data = get_form_data_from_instance(UserForm, contributor)
         form_data["first_name"] = "Patrick"
         form = UserForm(form_data, instance=contributor)
         form.save()
 
-        results_after = collect_results(evaluation)
+        results_after = get_results(evaluation)
 
         self.assertCountEqual(
             (result.contributor.first_name for result in results_before.contribution_results if result.contributor),

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -17,6 +17,7 @@ from evap.evaluation.models import (Contribution, Course, CourseType, Degree, Em
                                     FaqQuestion, Question, Questionnaire, RatingAnswerCounter, Semester, TextAnswer,
                                     UserProfile)
 from evap.evaluation.tests.tools import FuzzyInt, let_user_vote_for_evaluation, WebTestWith200Check, make_manager
+from evap.results.tools import cache_results
 from evap.rewards.models import SemesterActivation, RewardPointGranting
 from evap.staff.tools import generate_import_filename, ImportType
 from evap.staff.forms import ContributionCopyForm, ContributionCopyFormSet, EvaluationCopyForm
@@ -1138,6 +1139,7 @@ class TestEvaluationOperationView(WebTest):
         evaluation = baker.make(Evaluation, course=self.course, state='reviewed',
                                 participants=[participant1, participant2], voters=[participant1, participant2])
         baker.make(Contribution, contributor=contributor1, evaluation=evaluation)
+        cache_results(evaluation)
 
         self.helper_publish_evaluation_with_publish_notifications_for(evaluation, contributors=False, participants=False)
         self.assertEqual(len(mail.outbox), 0)
@@ -1186,6 +1188,7 @@ class TestEvaluationOperationView(WebTest):
             participants=[participant1, participant2],
             voters=[participant1, participant2]
         )
+        cache_results(evaluation)
 
         self.helper_semester_state_views(evaluation, "reviewed", "published")
         self.assertEqual(len(mail.outbox), 3)

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -537,11 +537,11 @@ def semester_raw_export(_request, semester_id):
         _('#Participants'), _('#Text answers'), _('Average grade')])
     for evaluation in sorted(semester.evaluations.all(), key=lambda cr: cr.full_name):
         degrees = ", ".join([degree.name for degree in evaluation.course.degrees.all()])
-        distribution = calculate_average_distribution(evaluation)
-        if evaluation.state in ['evaluated', 'reviewed', 'published'] and distribution is not None:
-            avg_grade = "{:.1f}".format(distribution_to_grade(distribution))
-        else:
-            avg_grade = ""
+        avg_grade = ""
+        if evaluation.can_staff_see_average_grade:
+            distribution = calculate_average_distribution(evaluation)
+            if distribution is not None:
+                avg_grade = "{:.1f}".format(distribution_to_grade(distribution))
         writer.writerow([evaluation.full_name, degrees, evaluation.course.type.name, evaluation.is_single_result, evaluation.state,
             evaluation.num_voters, evaluation.num_participants, evaluation.textanswer_set.count(), avg_grade])
 


### PR DESCRIPTION
This should speed up the results index for staff users by a lot. (1300 -> 350ms with the test data, the effect is larger the more evaluations have begun but are not published yet).

First, this caches results also for the states `evaluated` and `reviewed`, since the results in those states doesn't change frequently anymore. The exception is reviewing textanswers, which does change the results. In this PR, the results are refreshed on review_finished. That means that if some textanswers are reviewed already, but others aren't, they still wont show up on the results page if staff users looked at it. 

Sadly, for the assertion that those two states always have the results cached, I had to add a `cache_results` to lots of tests. An alternative would be perhaps to send an email to the admins instead, but then calculate the results on the fly. If we didn't do any of that, I wouldn't be surprised if we'd introduce a silent performance degradation in the future.

The second change is not displaying results on the results index for evaluations that are in_evaluation, which fixes #1510 (and also speeds up the results index).

Best reviewed per commit ;)