### PR TITLE
Fix autofocus on email/OpenID button on login page

### DIFF
--- a/evap/evaluation/forms.py
+++ b/evap/evaluation/forms.py
@@ -10,7 +10,7 @@ class LoginEmailForm(forms.Form):
     """Form encapsulating the login with email and password, for example from an Active Directory.
     """
 
-    email = forms.CharField(label=_("Email"), max_length=254)
+    email = forms.CharField(label=_("Email"), max_length=254, widget=forms.EmailInput(attrs={'autofocus': True}))
     password = forms.CharField(label=_("Password"), widget=forms.PasswordInput)
 
     def __init__(self, request, *args, **kwargs):

--- a/evap/evaluation/templates/index.html
+++ b/evap/evaluation/templates/index.html
@@ -17,7 +17,7 @@
                             {% trans 'Log in using HPI OpenID Connect.' %}
                         </p>
                         <div class="text-center mt-5">
-                            <a href="{% url 'oidc_authentication_init' %}{% if 'next' in request.GET %}?next={{ request.GET.next }}{% endif %}" class="btn btn-primary login-button">{% trans 'Login' %}</a>
+                            <a href="{% url 'oidc_authentication_init' %}{% if 'next' in request.GET %}?next={{ request.GET.next }}{% endif %}" class="btn btn-primary login-button" autofocus>{% trans 'Login' %}</a>
                         </div>
                     {% else %}
                         <p class="card-text">
@@ -81,10 +81,4 @@
         </div>
     </div>
 </div>
-{% endblock %}
-
-{% block additional_javascript %}
-    <script type="text/javascript">
-        $("#id_email").focus();
-    </script>
 {% endblock %}


### PR DESCRIPTION
The focus via `$("#id_email")` didn't work when developing locally because there were two email fields. I fixed that.

When OpenID is available, I made it autofocus the OpenID button. Though it looks a little weird and I don't know whether anyone would ever think of using the enter key to press that button... I can also remove it again.

![image](https://user-images.githubusercontent.com/1891915/95791406-9a401d00-0ce1-11eb-91fa-a8822e0c77c4.png)
