### PR TITLE
Fix vagrant setup on windows

### DIFF
--- a/deployment/apache.template.conf
+++ b/deployment/apache.template.conf
@@ -3,11 +3,11 @@
 
     DocumentRoot /var/www/
 
-    WSGIScriptAlias / /opt/evap/evap/wsgi.py
-    WSGIDaemonProcess evap processes=2 threads=15 display-name=%{GROUP} user=evap python-home=/opt/evap/env
+    WSGIScriptAlias / ${REPO_FOLDER}/evap/wsgi.py
+    WSGIDaemonProcess evap processes=2 threads=15 display-name=%{GROUP} user=evap python-home=${ENV_FOLDER}
     WSGIProcessGroup evap
 
-    Alias /static /opt/evap/evap/static_collected
+    Alias /static ${REPO_FOLDER}/evap/static_collected
     <Location /static>
         ExpiresActive On
         ExpiresDefault "access plus 1 month"

--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -4,7 +4,7 @@ set -x # print executed commands
 
 USER="evap"
 REPO_FOLDER="/opt/evap"
-ENV_FOLDER="$REPO_FOLDER/env"
+ENV_FOLDER="/home/$USER/venv"
 
 # force apt to not ask, just do defaults.
 export DEBIAN_FRONTEND=noninteractive
@@ -49,8 +49,11 @@ sudo -H -u $USER $ENV_FOLDER/bin/pip install mod_wsgi
 # setup apache
 a2enmod expires
 cp $REPO_FOLDER/deployment/wsgi.template.conf /etc/apache2/mods-available/wsgi.load
+sed -i -e "s=\${ENV_FOLDER}=$ENV_FOLDER=" /etc/apache2/mods-available/wsgi.load # note this uses '=' as alternate delimiter
 a2enmod wsgi
 cp $REPO_FOLDER/deployment/apache.template.conf /etc/apache2/sites-available/evap.conf
+sed -i -e "s=\${ENV_FOLDER}=$ENV_FOLDER=" /etc/apache2/sites-available/evap.conf
+sed -i -e "s=\${REPO_FOLDER}=$REPO_FOLDER=" /etc/apache2/sites-available/evap.conf
 a2ensite evap.conf
 a2dissite 000-default.conf
 # this comments in some line in some apache config file to fix the locale.

--- a/deployment/wsgi.template.conf
+++ b/deployment/wsgi.template.conf
@@ -1,1 +1,1 @@
-LoadModule wsgi_module /opt/evap/env/lib/python3.7/site-packages/mod_wsgi/server/mod_wsgi-py37.cpython-37m-x86_64-linux-gnu.so
+LoadModule wsgi_module ${ENV_FOLDER}/lib/python3.7/site-packages/mod_wsgi/server/mod_wsgi-py37.cpython-37m-x86_64-linux-gnu.so


### PR DESCRIPTION
... by moving the venv out of the mounted repo dir.

It failed when setting up the virtual env with some symlink-related error.
It's generally not possible to create symlinks in the directory that vagrant
mounts with the repo dir on the host. So i moved it to another location.