### PR TITLE
Fix access denied on manager login, fixes #1523

### DIFF
--- a/evap/evaluation/views.py
+++ b/evap/evaluation/views.py
@@ -74,6 +74,7 @@ def index(request):
             # clean up our test cookie
             if request.session.test_cookie_worked():
                 request.session.delete_test_cookie()
+            return redirect('evaluation:index')
 
     # if not logged in by now, render form
     if not request.user.is_authenticated:


### PR DESCRIPTION
The evaluation:index view was logging the user in and would redirect them immediately afterwards. Since no new page load happened, the staff mode middleware wouldn't run before determining the redirect target. By reloading the index page, this is fixed at the expense of an additional HTTP request.

On production, this doesn't change anything, as the only login methods there (OpenID and login url) don't have this issue.

fixes #1523 