### PR TITLE
Mark evaluations that are expired as deactivated on student index page

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -376,6 +376,7 @@ class Evaluation(LoggedModel):
 
     # when the evaluation takes place
     vote_start_datetime = models.DateTimeField(verbose_name=_("start of evaluation"))
+    # Usually the property vote_end_datetime should be used instead of this field
     vote_end_date = models.DateField(verbose_name=_("last day of evaluation"))
 
     # Disable to prevent editors from changing evaluation data

--- a/evap/student/templates/student_index_unfinished_evaluations_list.html
+++ b/evap/student/templates/student_index_unfinished_evaluations_list.html
@@ -3,7 +3,7 @@
 <table class="table table-seamless-links table-vertically-aligned table-headerless">
     <tbody>
         {% for evaluation in unfinished_evaluations %}
-            <tr{% if evaluation.state == 'in_evaluation' and not evaluation.voted_for %}
+            <tr{% if evaluation.state == 'in_evaluation' and not evaluation.voted_for and evaluation.is_in_evaluation_period %}
                     class="hover-row hover-row-info" data-url="{% url 'student:vote' evaluation.id %}"
                 {% else %} class="deactivate"{% endif %}>
                 <td style="width: 65%">
@@ -24,7 +24,7 @@
                     {% include 'student_index_evaluation_period.html' %}
                 </td>
                 <td style="width: 10%" class="text-right">
-                    {% if evaluation.state == 'in_evaluation' and not evaluation.voted_for %}
+                    {% if evaluation.state == 'in_evaluation' and not evaluation.voted_for and evaluation.is_in_evaluation_period  %}
                         <a class="btn btn-sm btn-primary btn-row-hover" href="{% url 'student:vote' evaluation.id %}">{% trans 'Evaluate' %}</a>
                     {% endif %}
                 </td>


### PR DESCRIPTION
Closes #1524

Evaluations with a `vote_end_date` that is before the current day are now displayed like evaluations that are not active anymore or have been already been completed.

Evaluations that are affected by this may still show up above ongoing evaluations. I think the extra logic to separate the evaluations into two sets to fix this is not worth it, as this situation rarely (?) occurs. Let me know that you think!

To reproduce the error (I think the example from the issue page is fixed by now):

```plain
$ ./manage.py shell_plus
>>> import datetime
>>> ev = Evaluation.objects.filter(course__name_en="Modeling II")[1]
>>> ev.vote_end_date = datetime.date.today() - datetime.timedelta(days=1)
>>> ev.save()
```
