### PR TITLE
Do bogus update on Answer update to hide insertion transaction number

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1144,6 +1144,9 @@ class Answer(models.Model):
     user ist not stored in the object. Concrete subclasses are `RatingAnswerCounter`,
     and `TextAnswer`."""
 
+    # we use UUIDs to hide insertion order. See https://github.com/e-valuation/EvaP/wiki/Data-Economy
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
     question = models.ForeignKey(Question, models.PROTECT)
     contribution = models.ForeignKey(Contribution, models.PROTECT, related_name="%(class)s_set")
 
@@ -1160,8 +1163,6 @@ class RatingAnswerCounter(Answer):
     bipolar: -3, -2, -1, 0, 1, 2, 3; where a lower absolute means more agreement and the sign shows the pole
     yes / no: 1, 5; for 1 being the good answer"""
 
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-
     answer = models.IntegerField(verbose_name=_("answer"))
     count = models.IntegerField(verbose_name=_("count"), default=0)
 
@@ -1175,8 +1176,6 @@ class RatingAnswerCounter(Answer):
 
 class TextAnswer(Answer):
     """A free-form text answer to a question."""
-
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
     answer = models.TextField(verbose_name=_("answer"))
     original_answer = models.TextField(verbose_name=_("original answer"), blank=True, null=True)


### PR DESCRIPTION
Fixes parts of #1384.

This will update all existing Answer rows when adding a new answer, inside the same transaction. Thus, from the new tuples, it is not clear which Answer was added / changed.

However, When adding a text answer or a RatingAnswerCounter, obviously, the old tuple is still in the database (and now considered "dead").
You can check out how many dead tuples are currently in the database using
```
SELECT relname, n_dead_tup FROM pg_stat_user_tables;
```

We would want to keep this as close to 0 as possible. We could either add a cron job that runs [`vacuum`](https://www.postgresql.org/docs/9.5/sql-vacuum.html) just as we did for the physical tuple-reordering, or we could try to rely on the [autovacuum](https://www.postgresql.org/docs/9.5/routine-vacuuming.html#AUTOVACUUM), which will be enabled by default and has to be enabled for the database to run smoothly. [This page](https://www.shubhamdipt.com/blog/how-to-clean-dead-tuples-and-monitor-postgresql-using-vacuum/) lists a few commands to inspect the current configuration.

The biggest concern with vacuum is that you will require a `FULL` vacuum for the database to actually give back the memory to the OS, and then we're still waiting for someone to overwrite it. This requires exclusive access to the database, so we will have to stop serving for the time this runs. (EDIT: Currently, the `CLUSTER` we run also requires exclusive access during that period. It might be feasible to actually do a full vacuum then, too).

A non-full vacuum will keep the memory reserved in postgres and use it when it requires new space (which in our should be when someone else votes). Until then, it will not be overwritten.

I'd say we should monitor our dead tuple count on production during a voting phase. If it stays low enough (default autovacuum starts with 50 dead tuples IMO), we might not have to do any additional steps. Otherwise, we might want to add the cronjob. For the actual overwrite, I think hoping that the memory will be overwritten at some point is the best we can do.

(If someone gets a memory dump, actually finding the piece of memory with the dead tuples is really easy, as we use UUIDS, so you can search for their values in the memory dump)