### PR TITLE
Take user's names from OIDC if empty

### DIFF
--- a/evap/evaluation/auth.py
+++ b/evap/evaluation/auth.py
@@ -190,3 +190,13 @@ class OpenIDAuthenticationBackend(OIDCAuthenticationBackend):
             last_name=claims.get('family_name', ''),
         )
         return user
+
+    @staticmethod
+    def update_user(user, claims):
+        if not user.first_name:
+            user.first_name = claims.get('given_name', '')
+            user.save()
+        if not user.last_name:
+            user.last_name = claims.get('family_name', '')
+            user.save()
+        return user


### PR DESCRIPTION
Partly revert 94fc6dc8b87
First name and last name of a user should be updated via OIDC if they are currently empty