### PR TITLE
'I can't give feedback about this contributor' button: performance, don't scroll away

### DIFF
--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -228,7 +228,6 @@
                     } else {
                         lastSavedLabel.text("{% trans 'Could not save your information locally' %}");
                     }
-                    
             }
 
             function padWithLeadingZeros(number){
@@ -299,9 +298,14 @@
                 button.addEventListener("click", () => {
                     const contributorId = button.dataset.markNoAnswersFor;
                     const voteArea = document.querySelector(`#vote-area-${contributorId}`);
-                    // check "no answer" and uncheck all other options
-                    voteArea.querySelectorAll(".vote-inputs [type=radio][value='6']")
-                        .forEach(radioInput => radioInput.click());
+
+                    voteArea.querySelectorAll(".vote-btn.active").forEach(el => el.classList.remove("active"));
+                    voteArea.querySelectorAll(".vote-inputs [type=radio][value='6']").forEach(radioInput => {
+                        radioInput.checked = true;
+                        radioInput.closest(".vote-btn").classList.add("active");
+                    });
+
+                    sisyphus.saveAllData();
 
                     // hide questionnaire for contributor
                     $(voteArea).collapse("hide");


### PR DESCRIPTION
The old code will save `questions_of_the_contributor` * `total_evaluation_questions` many elements, which is slow (we've had reports of up to 5 seconds). 

Sisyphus does not support a nice way to say "Hey, I'm going to bulk update, please only save once", so we have to monkey-patch it. It supports a `onBeforeSave` method, which can abort saving if it returns `false`. However, up to the point where it evaluates this function, it has already spent half the time on just finding all the elements, so we have to stop it earlier.
Fun Fact: Sisyphus also always saves all elements, even if just one element was changed #scalesnicely.

Bootstrap's `button.js` click event listener causes a scroll to any button that is clicked. So, if the contributor's card is bigger than the screen, we get weird scrolling. I didn't find any way to tell bootstrap to stop this, but maybe, I just didn't look in the right place -- ideas are welcome.

With both these changes, it feels like we don't want to actually use `.click()` anymore, but I don't see any way to nicely set the bootstrap buttons (which from my experience are a pain to work with), so I guess we're stuck with that.