### PR TITLE
Remove usage of get_static_prefix in staff_template_form.html

### DIFF
--- a/evap/staff/templates/staff_template_form.html
+++ b/evap/staff/templates/staff_template_form.html
@@ -40,5 +40,5 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript" src="{% get_static_prefix %}js/copy-to-clipboard.js"></script>
+    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Hi everyone, this is a followup to pull requests #1559 and #1529.
The commit removes the usage of `get_static_prefix` in the code introduced by #1559 (in `staff_template_form.html`) as #1529 removes its usage everywhere else.