### PR TITLE
Order evaluations on result index page

### DIFF
--- a/evap/results/templates/results_index.html
+++ b/evap/results/templates/results_index.html
@@ -110,7 +110,7 @@
                         {% if course.num_evaluations > 1 %}
                             <div>
                                 {% include 'results_index_course.html' %}
-                                {% for evaluation in evaluations %}
+                                {% for evaluation in evaluations|dictsort:"name" %}
                                     {% include 'results_index_evaluation.html' with links_to_results_page=evaluation|can_results_page_be_seen_by:request.user is_subentry=True %}
                                 {% endfor %}
                             </div>

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -62,11 +62,8 @@ class TestResultsView(WebTest):
         evaluation2 = baker.make(Evaluation, name_de='random_evaluation_b', name_en='random_evaluation_b', course=course, state='published')
         evaluation1 = baker.make(Evaluation, name_de='random_evaluation_a', name_en='random_evaluation_a', course=course, state='published')
 
-        page = self.app.get(self.url, user=student)
-        elem1 = page.html.find('span', {'class':'evaluation-name'}, text=re.compile('.*{}.*'.format(evaluation1.name_en)))
-        elem2 = page.html.find('span', {'class':'evaluation-name'}, text=re.compile('.*{}.*'.format(evaluation2.name_en)))
-        evaluation_names = page.html.find_all('span', {'class':'evaluation-name'})
-        self.assertTrue(evaluation_names.index(elem1) < evaluation_names.index(elem2))
+        page = str(self.app.get(self.url, user=student))
+        self.assertTrue(page.index(evaluation1.name_en) < page.index(evaluation2.name_en))
 
 
     # using LocMemCache so the cache queries don't show up in the query count that's measured here

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 from io import StringIO
 import random
-import re
 
 from django.contrib.auth.models import Group
 from django.core.cache import caches

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -52,7 +52,6 @@ class TestResultsView(WebTest):
         self.assertNotContains(page, evaluation2.full_name)
         caches['results'].clear()
 
-
     @patch('evap.evaluation.models.Evaluation.can_be_seen_by', new=(lambda self, user: True))
     def test_order(self):
         student = baker.make(UserProfile, email="student@institution.example.com")
@@ -62,11 +61,10 @@ class TestResultsView(WebTest):
         evaluation2 = baker.make(Evaluation, name_de='random_evaluation_c', name_en='random_evaluation_b', course=course, state='published')
 
         page = self.app.get(self.url, user=student).body.decode()
-        self.assertTrue(page.index(evaluation1.name_en) < page.index(evaluation2.name_en))
+        self.assertLess(page.index(evaluation1.name_en), page.index(evaluation2.name_en))
 
         page = self.app.get(self.url, user=student, extra_environ={'HTTP_ACCEPT_LANGUAGE': 'de'}).body.decode()
-        self.assertTrue(page.index(evaluation1.name_de) > page.index(evaluation2.name_de))
-
+        self.assertGreater(page.index(evaluation1.name_de), page.index(evaluation2.name_de))
 
     # using LocMemCache so the cache queries don't show up in the query count that's measured here
     @override_settings(CACHES={

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -58,11 +58,14 @@ class TestResultsView(WebTest):
         student = baker.make(UserProfile, email="student@institution.example.com")
 
         course = baker.make(Course)
-        evaluation2 = baker.make(Evaluation, name_de='random_evaluation_b', name_en='random_evaluation_b', course=course, state='published')
-        evaluation1 = baker.make(Evaluation, name_de='random_evaluation_a', name_en='random_evaluation_a', course=course, state='published')
+        evaluation1 = baker.make(Evaluation, name_de='random_evaluation_d', name_en='random_evaluation_a', course=course, state='published')
+        evaluation2 = baker.make(Evaluation, name_de='random_evaluation_c', name_en='random_evaluation_b', course=course, state='published')
 
-        page = str(self.app.get(self.url, user=student))
+        page = self.app.get(self.url, user=student).body.decode()
         self.assertTrue(page.index(evaluation1.name_en) < page.index(evaluation2.name_en))
+
+        page = self.app.get(self.url, user=student, extra_environ={'HTTP_ACCEPT_LANGUAGE': 'de'}).body.decode()
+        self.assertTrue(page.index(evaluation1.name_de) > page.index(evaluation2.name_de))
 
 
     # using LocMemCache so the cache queries don't show up in the query count that's measured here


### PR DESCRIPTION
Fixes #1557 
This commit introduces the same sorting behavior as the results detail page. The empty evaluation (same name as the course) is shown at the top.