### PR TITLE
Staff mode changes

### DIFF
--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -83,19 +83,6 @@
                         </div>
                     </li>
                 {% endif %}
-                {% if user.has_staff_permission %}
-                    {% if user.is_staff %}
-                        <form class="form-inline" method="post" action="{% url 'staff:exit_staff_mode' %}">
-                            {% csrf_token %}
-                            <button type="submit" class="ml-2 btn btn-sm btn-navbar btn-outline-secondary">{% trans 'Exit Staff Mode' %}</button>
-                        </form>
-                    {% else %}
-                        <form id="enter-staff-mode-form" class="form-inline" method="post" action="{% url 'staff:enter_staff_mode' %}">
-                            {% csrf_token %}
-                            <button type="submit" class="ml-2 btn btn-sm btn-navbar btn-outline-secondary">{% trans 'Enter Staff Mode' %}</button>
-                        </form>
-                    {% endif %}
-                {% endif %}
             {% endif %}
         </ul>
         <ul class="navbar-nav justify-content-end">
@@ -111,6 +98,24 @@
                 </div>
             </div>
             {% if user.is_authenticated %}
+                {% if user.has_staff_permission %}
+                    <div class="nav-item btn-switch-navbar my-auto pl-2">
+                        <div class="btn-group">
+                            <form class="form-inline" method="post" action="{% url 'staff:exit_staff_mode' %}">
+                                {% csrf_token %}
+                                <button type="submit" {% if user.is_staff %}class="btn btn-sm btn-navbar"{% else %}class="btn btn-sm btn-navbar active" disabled{% endif %} data-toggle="tooltip" data-placement="bottom" title="{% trans 'Regular mode' %}">
+                                    <span class="fas fa-user"></span>
+                                </button>
+                            </form>
+                            <form id="enter-staff-mode-form" class="form-inline" method="post" action="{% url 'staff:enter_staff_mode' %}">
+                                {% csrf_token %}
+                                <button type="submit" {% if user.is_staff %}class="btn btn-sm btn-navbar active" disabled{% else %}class="btn btn-sm btn-navbar"{% endif %} data-toggle="tooltip" data-placement="bottom" title="{% trans 'Staff mode' %}">
+                                    <span class="fas fa-briefcase"></span>
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                {% endif %}
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarUserDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="fas fa-user"></span> {{ user.full_name }}</a>
                     <div class="dropdown-menu dropdown-menu-right dropdown-menu-tight" aria-labelledby="navbarUserDropdownMenuLink">

--- a/evap/evaluation/tests/test_auth.py
+++ b/evap/evaluation/tests/test_auth.py
@@ -181,4 +181,4 @@ class LoginTestsWithCSRF(WebTest):
         page.forms['enter-staff-mode-form'].submit()
         page = self.app.get(reverse('results:index'))
         self.assertTrue('staff_mode_start_time' in self.app.session)
-        self.assertContains(page, 'Exit Staff Mode')
+        self.assertContains(page, 'Users')

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -272,7 +272,7 @@ SESSION_CACHE_ALIAS = "sessions"
 SESSION_SAVE_EVERY_REQUEST = True
 SESSION_COOKIE_AGE = 60 * 60 * 24 * 365  # one year
 
-STAFF_MODE_TIMEOUT = 60 * 60  # one hour
+STAFF_MODE_TIMEOUT = 3 * 60 * 60  # three hours
 STAFF_MODE_INFO_TIMEOUT = 3 * 60 * 60  # three hours
 
 ### Internationalization

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2598,14 +2598,12 @@ class TestStaffMode(WebTest):
 
         response = self.app.post(self.url_enter, user=manager).follow().follow()
         self.assertTrue('staff_mode_start_time' in self.app.session)
-        self.assertContains(response, "Exit Staff Mode")
         self.assertContains(response, "Users")
 
         self.app.get(self.some_staff_url, user=manager, status=200)
 
         response = self.app.post(self.url_exit, user=manager).follow().follow()
         self.assertFalse('staff_mode_start_time' in self.app.session)
-        self.assertContains(response, "Enter Staff Mode")
         self.assertNotContains(response, "Users")
 
         self.app.get(self.some_staff_url, user=manager, status=403)

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1793,7 +1793,6 @@ def export_contributor_results_view(request, contributor_id):
 @staff_permission_required
 def enter_staff_mode(request):
     staff_mode.enter_staff_mode(request)
-    messages.success(request, _("Successfully entered staff mode."))
     return redirect('evaluation:index')
 
 
@@ -1801,5 +1800,4 @@ def enter_staff_mode(request):
 @staff_permission_required
 def exit_staff_mode(request):
     staff_mode.exit_staff_mode(request)
-    messages.success(request, _("Successfully exited staff mode."))
     return redirect('evaluation:index')

--- a/evap/static/scss/components/_buttons.scss
+++ b/evap/static/scss/components/_buttons.scss
@@ -105,6 +105,9 @@ a:not([href]):not(.disabled) {
     padding: 0.5rem 0.75rem;
 
     .btn-group {
+        border: $darker-gray 1px solid;
+        border-radius: 0.2rem;
+
         .btn-navbar {
             padding: 0 0.25rem;
             background-color: lighten($darker-gray, 5%);


### PR DESCRIPTION
- The default staff mode timeout is increased to three hours based on the evaluation team's feedback
- The button to enter/leave staff mode is changed to a switch button next to the language selection