### PR TITLE
Detect installed CPU cores and system memory and initialize VM accordingly

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,25 @@ Vagrant.configure("2") do |config|
 
     # show virtualbox gui, uncomment this to debug startup problems
     #v.gui = true
+
+    if not Vagrant::Util::Platform.windows?
+      # use half of the available CPUs or 1 if retrieval fails
+      # adapted from https://gist.github.com/dublado/9309673aae5cf0fa5305
+      total_cpus = Integer(`awk "/^processor/ {++n} END {print n}" /proc/cpuinfo 2> /dev/null || sh -c 'sysctl hw.logicalcpu 2> /dev/null || echo ": 1"' | awk \'{print \$2}\'`.chomp)
+      cpus = total_cpus / 2
+
+      # the first line of /proc/meminfo
+      memory_info = (File.open("/proc/meminfo") {|f| f.readline}).strip.split
+      raise "Dang it, the file can be sorted differently, ..." unless memory_info[0] == "MemTotal:"
+      raise "Dang it, other units are possible too..." unless memory_info[2] == "kB"
+      # end value should be in MB
+      total_memory = Integer(memory_info[1]) / 1000
+      # adapted from https://stackoverflow.com/a/34938001/13679671
+      # total_memory = Integer(`awk '/MemTotal/ { printf "\%.3f \n", $2/1024 }' /proc/meminfo || echo 4096`.chomp)
+      memory = total_memory / 4
+
+      v.customize [ "modifyvm", :id, "--cpus", cpus, "--memory", memory ]
+    end
   end
 
   # override username to be evap instead of vagrant, just as it is on production.


### PR DESCRIPTION
I think I will remove the part where I open files and make assumptions with another awk oneliner from the Internet. Originally, I wanted to not rely on having awk installed, but these are just so much simpler and since this branch doesn't run on Windows hosts, installing awk should be painful when in doubt.
