### PR TITLE
Fix #1571: Copying Courses

### DIFF
--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -342,7 +342,6 @@ class CourseCopyForm(CourseFormMixin, forms.ModelForm):
                 new_contribution.save()
                 new_contribution.questionnaires.set(old_contribution.questionnaires.all())
 
-        new_course.responsibles.filter(is_active=False).update(is_active=True)
         return new_course
 
 

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -341,6 +341,8 @@ class CourseCopyForm(CourseFormMixin, forms.ModelForm):
                 )
                 new_contribution.save()
                 new_contribution.questionnaires.set(old_contribution.questionnaires.all())
+
+        new_course.responsibles.filter(is_active=False).update(is_active=True)
         return new_course
 
 

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -216,6 +216,21 @@ class CourseTypeMergeSelectionForm(forms.Form):
 
 
 class CourseFormMixin:
+    class Meta:
+        model = Course
+        fields = (
+            "name_de",
+            "name_en",
+            "type",
+            "degrees",
+            "responsibles",
+            "is_private",
+            "semester",
+        )
+        field_classes = {
+            "responsibles": UserModelMultipleChoiceField,
+        }
+
     def _set_responsibles_queryset(self, existing_course=None):
         queryset = UserProfile.objects.exclude(is_active=False)
         if existing_course:
@@ -238,21 +253,6 @@ class CourseFormMixin:
 class CourseForm(CourseFormMixin, forms.ModelForm):
     semester = forms.ModelChoiceField(Semester.objects.all(), disabled=True, required=False, widget=forms.HiddenInput())
 
-    class Meta:
-        model = Course
-        fields = (
-            "name_de",
-            "name_en",
-            "type",
-            "degrees",
-            "responsibles",
-            "is_private",
-            "semester",
-        )
-        field_classes = {
-            "responsibles": UserModelMultipleChoiceField,
-        }
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._set_responsibles_queryset(self.instance if self.instance.pk else None)
@@ -264,9 +264,6 @@ class CourseCopyForm(CourseFormMixin, forms.ModelForm):
     semester = forms.ModelChoiceField(Semester.objects.all())
     vote_start_datetime = forms.DateTimeField(label=_("Start of evaluations"), localize=True)
     vote_end_date = forms.DateField(label=_("Last day of evaluations"), localize=True)
-
-    class Meta(CourseForm.Meta):
-        pass
 
     field_order = ["semester"]
 

--- a/evap/staff/templates/staff_course_copyform.html
+++ b/evap/staff/templates/staff_course_copyform.html
@@ -1,0 +1,44 @@
+{% extends 'staff_course_base.html' %}
+
+{% block content %}
+    {{ block.super }}
+    <h3>
+        {% trans 'Create copy of course' %}
+    </h3>
+    <form id="course-form" method="POST" class="form-horizontal multiselect-form select2form">
+        {% csrf_token %}
+
+        <div class="card mb-3">
+            <div class="card-body">
+                {% include 'bootstrap_form.html' with form=course_form %}
+            </div>
+        </div>
+
+        <div class="card mb-3">
+            <div class="card-body">
+                <h5 class="card-title">{% trans 'Evaluations that will be copied' %}</h5>
+                {% if course.evaluations.count > 0 %}
+                    <ul>
+                        {% for evaluation in evaluations %}
+                            <li>
+                                {{ evaluation.full_name }}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <span class="font-italic">{% trans 'There are no evaluations for this course.' %}</span>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="card card-submit-area card-submit-area-3 text-center mb-3">
+            <div class="card-body">
+                <button type="submit" class="btn btn-primary">{% trans 'Save' %}</button>
+            </div>
+        </div>
+    </form>
+{% endblock %}
+
+{% block additional_javascript %}
+    {% include 'bootstrap_datetimepicker.html' %}
+{% endblock %}

--- a/evap/staff/templates/staff_course_copyform.html
+++ b/evap/staff/templates/staff_course_copyform.html
@@ -26,7 +26,7 @@
                         {% endfor %}
                     </ul>
                 {% else %}
-                    <span class="font-italic">{% trans 'There are no evaluations for this course.' %}</span>
+                    <span class="fst-italic">{% trans 'There are no evaluations for this course.' %}</span>
                 {% endif %}
             </div>
         </div>

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -400,6 +400,11 @@
                                             title="{% trans "Create single result for this course" %}">
                                             <span class="fas fa-poll"></span>
                                         </a>
+                                        <a class="btn btn-sm btn-dark" data-toggle="tooltip"
+                                            href="{% url 'staff:course_copy' semester.id course.id %}"
+                                            title="{% trans "Copy course" %}">
+                                            <span class="fas fa-copy"></span>
+                                        </a>
                                     {% endif %}
                                     {% if course.can_be_deleted_by_manager %}
                                         <button type="button" onclick="deleteCourseModalShow({{ course.id }}, '{{ course.name|escapejs }}');" class="btn btn-sm btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -392,17 +392,17 @@
                                     {% if request.user.is_manager %}
                                         <a class="btn btn-sm btn-dark" data-bs-toggle="tooltip"
                                             href="{% url 'staff:evaluation_create' semester.id course.id %}"
-                                            title="{% trans "Create evaluation for this course" %}">
+                                            title="{% trans 'Create evaluation for this course' %}">
                                             <span class="fas fa-clipboard-check"></span>
                                         </a>
                                         <a class="btn btn-sm btn-dark" data-bs-toggle="tooltip"
                                             href="{% url 'staff:single_result_create' semester.id course.id %}"
-                                            title="{% trans "Create single result for this course" %}">
+                                            title="{% trans 'Create single result for this course' %}">
                                             <span class="fas fa-poll"></span>
                                         </a>
                                         <a class="btn btn-sm btn-dark" data-toggle="tooltip"
                                             href="{% url 'staff:course_copy' semester.id course.id %}"
-                                            title="{% trans "Copy course" %}">
+                                            title="{% trans 'Copy course' %}">
                                             <span class="fas fa-copy"></span>
                                         </a>
                                     {% endif %}

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -713,14 +713,15 @@ class ContributionFormset775RegressionTests(TestCase):
 
 
 class CourseCopyFormTests(TestCase):
-    # pylint: disable=no-self-use
-    def test_all_evaluation_attributes_covered(self):
+    @staticmethod
+    def test_all_evaluation_attributes_covered():
         for field in Evaluation._meta.get_fields():
             assert field.name in (
                 CourseCopyForm.EVALUATION_COPIED_FIELDS | CourseCopyForm.EVALUATION_EXCLUDED_FIELDS
             ), "evaluation field {} is not considered by CourseCopyForm".format(field.name)
 
-    def test_all_contribution_attributes_covered(self):
+    @staticmethod
+    def test_all_contribution_attributes_covered():
         for field in Contribution._meta.get_fields():
             assert field.name in (
                 CourseCopyForm.CONTRIBUTION_COPIED_FIELDS | CourseCopyForm.CONTRIBUTION_EXCLUDED_FIELDS

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -29,6 +29,7 @@ from evap.staff.forms import (
     ContributionCopyForm,
     ContributionForm,
     ContributionFormSet,
+    CourseCopyForm,
     CourseForm,
     EvaluationCopyForm,
     EvaluationEmailForm,
@@ -709,6 +710,21 @@ class ContributionFormset775RegressionTests(TestCase):
         )
         formset.save()
         self.assertEqual(Questionnaire.objects.filter(contributions=self.contribution2).count(), 2)
+
+
+class CourseCopyFormTests(TestCase):
+    # pylint: disable=no-self-use
+    def test_all_evaluation_attributes_covered(self):
+        for field in Evaluation._meta.get_fields():
+            assert field.name in (
+                CourseCopyForm.EVALUATION_COPIED_FIELDS | CourseCopyForm.EVALUATION_EXCLUDED_FIELDS
+            ), "evaluation field {} is not considered by CourseCopyForm".format(field.name)
+
+    def test_all_contribution_attributes_covered(self):
+        for field in Contribution._meta.get_fields():
+            assert field.name in (
+                CourseCopyForm.CONTRIBUTION_COPIED_FIELDS | CourseCopyForm.CONTRIBUTION_EXCLUDED_FIELDS
+            ), "contribution field {} is not considered by CourseCopyForm".format(field.name)
 
 
 class CourseFormTests(TestCase):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1654,13 +1654,11 @@ class TestEvaluationCopyView(WebTestStaffMode):
 
 
 class TestCourseCopyView(WebTestStaffMode):
-    url = "/staff/semester/1/course/1/copy"
-
     @classmethod
     def setUpTestData(cls):
         cls.manager = make_manager()
-        cls.semester = baker.make(Semester, pk=1)
-        cls.other_semester = baker.make(Semester, pk=2)
+        cls.semester = baker.make(Semester)
+        cls.other_semester = baker.make(Semester)
         degree = baker.make(Degree)
         cls.responsibles = [
             baker.make(UserProfile, last_name="Muller"),
@@ -1672,11 +1670,9 @@ class TestCourseCopyView(WebTestStaffMode):
             semester=cls.semester,
             degrees=[degree],
             responsibles=cls.responsibles,
-            pk=1,
         )
         cls.evaluation = baker.make(
             Evaluation,
-            pk=1,
             course=cls.course,
             name_de="Das Original",
             name_en="The Original",
@@ -1689,6 +1685,7 @@ class TestCourseCopyView(WebTestStaffMode):
             _quantity=3,
             _fill_optional=["contributor"],
         )
+        cls.url = f"/staff/semester/{cls.semester.id}/course/{cls.course.id}/copy"
 
     def test_copy_forms_are_used(self):
         response = self.app.get(self.url, user=self.manager, status=200)

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1710,6 +1710,7 @@ class TestCourseCopyView(WebTestStaffMode):
             set(copied_evaluation.general_contribution.questionnaires.all()),
             set(self.evaluation.general_contribution.questionnaires.all()),
         )
+        assert not copied_course.responsibles.filter(is_active=False).exists()
 
 
 class TestCourseEditView(WebTestStaffMode):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1699,9 +1699,9 @@ class TestCourseCopyView(WebTestStaffMode):
         form["vote_end_date"] = datetime.date(2099, 12, 31)
 
         # check that the user activation is mentioned
-        assert not self.responsibles[1].is_active
+        self.assertFalse(self.responsibles[1].is_active)
         response = form.submit().follow()
-        assert self.responsibles[1].full_name in str(response)
+        self.assertIn(self.responsibles[1].full_name, response)
 
         self.assertEqual(Course.objects.count(), 2)
         copied_course = Course.objects.exclude(pk=self.course.pk).get()
@@ -1714,7 +1714,7 @@ class TestCourseCopyView(WebTestStaffMode):
             set(copied_evaluation.general_contribution.questionnaires.all()),
             set(self.evaluation.general_contribution.questionnaires.all()),
         )
-        assert not copied_course.responsibles.filter(is_active=False).exists()
+        self.assertFalse(copied_course.responsibles.filter(is_active=False).exists())
 
 
 class TestCourseEditView(WebTestStaffMode):

--- a/evap/staff/urls.py
+++ b/evap/staff/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path("semester/<int:semester_id>/grade_reminder", views.semester_grade_reminder, name="semester_grade_reminder"),
     path("semester/<int:semester_id>/course/create", views.course_create, name="course_create"),
     path("semester/<int:semester_id>/course/<int:course_id>/edit", views.course_edit, name="course_edit"),
+    path("semester/<int:semester_id>/course/<int:course_id>/copy", views.course_copy, name="course_copy"),
     path("semester/<int:semester_id>/evaluation/create", views.evaluation_create, name="evaluation_create"),
     path("semester/<int:semester_id>/evaluation/create/<int:course_id>", views.evaluation_create, name="evaluation_create"),
     path("semester/<int:semester_id>/evaluation/<int:evaluation_id>/edit", views.evaluation_edit, name="evaluation_edit"),

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -962,8 +962,8 @@ def course_copy(request, semester_id, course_id):
         messages.success(request, _("Successfully copied course."))
 
         inactive_users = UserProfile.objects.filter(
-            Q(contributions__evaluation__course__in=[copied_course], is_active=False)
-            | Q(courses_responsible_for__in=[copied_course], is_active=False)
+            Q(contributions__evaluation__course=copied_course, is_active=False)
+            | Q(courses_responsible_for=copied_course, is_active=False)
         ).distinct()
         if inactive_users:
             messages.warning(

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -960,6 +960,17 @@ def course_copy(request, semester_id, course_id):
     if course_form.is_valid():
         copied_course = course_form.save()
         messages.success(request, _("Successfully copied course."))
+
+        inactive_users = copied_course.responsibles.filter(is_active=False)
+        if inactive_users:
+            messages.warning(
+                request,
+                _("Accounts of some responsibles were reactivated: {accounts}.").format(
+                    accounts=", ".join(user.full_name for user in inactive_users)
+                ),
+            )
+            inactive_users.update(is_active=True)
+
         return redirect("staff:semester_view", copied_course.semester_id)
 
     evaluations = sorted(course.evaluations.exclude(is_single_result=True), key=lambda cr: cr.full_name)


### PR DESCRIPTION
Fixes #1571, although that requested Evaluation copy to other semesters. Problem though, we are missing the Course, which is why @janno42 suggested to create Course Copy instead, on which I had a go here.

Somewhat complicated is copying the evaluations.