### PR TITLE
Upgrade pip to fix vagrant up

### DIFF
--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -65,6 +65,9 @@ systemctl reload apache2
 echo "cd $REPO_FOLDER" >> /home/$USER/.bashrc
 echo "source $ENV_FOLDER/bin/activate" >> /home/$USER/.bashrc
 
+# upgrade pip. this works around a problem with a dependency of mozilla-django-oidc,
+# see https://github.com/pyca/cryptography/issues/5753
+sudo -H -u $USER $ENV_FOLDER/bin/pip install --upgrade pip
 # install requirements
 sudo -H -u $USER $ENV_FOLDER/bin/pip install -r $REPO_FOLDER/requirements-dev.txt
 


### PR DESCRIPTION
When I tried `vagrant up`, it gave me the error below, and this change fixed it.

```
    default: Collecting cryptography (from mozilla-django-oidc==1.2.3->-r /opt/evap/requirements.txt (line 15))
    default:   Downloading https://files.pythonhosted.org/packages/9b/77/461087a514d2e8ece1c975d8216bc03f7048e6090c5166bc34115afdaa53/cryptography-3.4.7.tar.gz (546kB)
    default:     Complete output from command python setup.py egg_info:
    default:
    default:             =============================DEBUG ASSISTANCE==========================
    default:             If you are seeing an error here please try the following to
    default:             successfully install cryptography:
    default:
    default:             Upgrade to the latest pip and try again. This will fix errors for most
    default:             users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
    default:             =============================DEBUG ASSISTANCE==========================
    default:
    default:     Traceback (most recent call last):
    default:       File "<string>", line 1, in <module>
    default:       File "/tmp/pip-build-89j24u_v/cryptography/setup.py", line 14, in <module>
    default:         from setuptools_rust import RustExtension
    default:     ModuleNotFoundError: No module named 'setuptools_rust'
    default:
    default:     ----------------------------------------
    default: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-89j24u_v/cryptography/
```