### PR TITLE
Fix staff mode problems

### DIFF
--- a/evap/evaluation/auth.py
+++ b/evap/evaluation/auth.py
@@ -7,7 +7,6 @@ from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from evap.evaluation.models import UserProfile
 from evap.evaluation.tools import clean_email
 from evap.rewards.tools import can_reward_points_be_used_by
-from evap.staff.tools import delete_navbar_cache_for_users
 
 
 class RequestAuthUserBackend(ModelBackend):
@@ -26,7 +25,6 @@ class RequestAuthUserBackend(ModelBackend):
 
         try:
             user = UserProfile.objects.get(login_key=key)
-            after_login_function(request, user, None)
             return user
         except UserProfile.DoesNotExist:
             return None
@@ -41,13 +39,8 @@ class EmailAuthenticationBackend(ModelBackend):
             return None
         else:
             if user.check_password(password):
-                after_login_function(request, user, None)
                 return user
         return None
-
-
-def after_login_function(request, user, _client):
-    delete_navbar_cache_for_users([user])
 
 
 def user_passes_test(test_func):

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -161,6 +161,10 @@
             error: function(){}
         });
     };
+
+    function setSpinnerIcon(id) {
+        $("#" + id).removeClass().addClass('fas fa-spinner fa-spin');
+    };
 </script>
 
 {% block additional_javascript %}{% endblock %}

--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -103,14 +103,14 @@
                         <div class="btn-group">
                             <form class="form-inline" method="post" action="{% url 'staff:exit_staff_mode' %}">
                                 {% csrf_token %}
-                                <button type="submit" {% if user.is_staff %}class="btn btn-sm btn-navbar"{% else %}class="btn btn-sm btn-navbar active" disabled{% endif %} data-toggle="tooltip" data-placement="bottom" title="{% trans 'Regular mode' %}">
-                                    <span class="fas fa-user"></span>
+                                <button type="submit" {% if user.is_staff %}class="btn btn-sm btn-navbar"{% else %}class="btn btn-sm btn-navbar active" disabled{% endif %} data-toggle="tooltip" data-placement="bottom" title="{% trans 'Regular mode' %}" onclick="setSpinnerIcon('span-exit-staff-mode')">
+                                    <span id="span-exit-staff-mode" class="fas fa-user"></span>
                                 </button>
                             </form>
                             <form id="enter-staff-mode-form" class="form-inline" method="post" action="{% url 'staff:enter_staff_mode' %}">
                                 {% csrf_token %}
-                                <button type="submit" {% if user.is_staff %}class="btn btn-sm btn-navbar active" disabled{% else %}class="btn btn-sm btn-navbar"{% endif %} data-toggle="tooltip" data-placement="bottom" title="{% trans 'Staff mode' %}">
-                                    <span class="fas fa-briefcase"></span>
+                                <button type="submit" {% if user.is_staff %}class="btn btn-sm btn-navbar active" disabled{% else %}class="btn btn-sm btn-navbar"{% endif %} data-toggle="tooltip" data-placement="bottom" title="{% trans 'Staff mode' %}" onclick="setSpinnerIcon('span-enter-staff-mode')">
+                                    <span id="span-enter-staff-mode" class="fas fa-briefcase"></span>
                                 </button>
                             </form>
                         </div>

--- a/evap/evaluation/tests/test_auth.py
+++ b/evap/evaluation/tests/test_auth.py
@@ -159,10 +159,9 @@ class LoginTestsWithCSRF(WebTest):
         form = page.forms['email-login-form']
         form['email'] = self.staff_user.email
         form['password'] = self.staff_user_password
-        form.submit()
+        page = form.submit().follow().follow()
 
         # staff user should now be logged in and see the logout button
-        page = self.app.get(reverse('results:index'))
         self.assertContains(page, 'Logout')
 
         # log out user
@@ -174,11 +173,9 @@ class LoginTestsWithCSRF(WebTest):
         form = page.forms['email-login-form']
         form['email'] = self.staff_user.email
         form['password'] = self.staff_user_password
-        form.submit()
+        page = form.submit().follow().follow()
 
         # enter staff mode
-        page = self.app.get(reverse('results:index'))
-        page.forms['enter-staff-mode-form'].submit()
-        page = self.app.get(reverse('results:index'))
+        page = page.forms['enter-staff-mode-form'].submit().follow().follow()
         self.assertTrue('staff_mode_start_time' in self.app.session)
         self.assertContains(page, 'Users')

--- a/evap/evaluation/views.py
+++ b/evap/evaluation/views.py
@@ -13,8 +13,10 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.views.i18n import set_language
 
 from evap.evaluation.forms import NewKeyForm, LoginEmailForm
-from evap.middleware import no_login_required
 from evap.evaluation.models import FaqSection, EmailTemplate, Semester
+from evap.middleware import no_login_required
+from evap.staff.tools import delete_navbar_cache_for_users
+
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +89,9 @@ def index(request):
             openid_active=settings.ACTIVATE_OPEN_ID_LOGIN,
         )
         return render(request, "index.html", template_data)
+
+    # the cached navbar might contain CSRF tokens that are invalid after a new login
+    delete_navbar_cache_for_users([request.user])
 
     # check for redirect variable
     redirect_to = request.GET.get("next", None)

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -354,7 +354,6 @@ SLOGANS_EN = [
 ### OpenID Login
 # replace 'example.com', OIDC_RP_CLIENT_ID and OIDC_RP_CLIENT_SECRET with real values in localsettings when activating
 ACTIVATE_OPEN_ID_LOGIN = False
-OIDC_AFTER_USERLOGIN_HOOK = 'evap.evaluation.auth.after_login_function'
 OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = 60 * 60 * 24 * 7  # one week
 OIDC_RP_SIGN_ALGO = 'RS256'
 OIDC_USERNAME_ALGO = ''

--- a/evap/staff/staff_mode.py
+++ b/evap/staff/staff_mode.py
@@ -4,7 +4,6 @@ from django.contrib import messages
 from django.utils.translation import ugettext as _
 
 from evap.settings import STAFF_MODE_TIMEOUT, STAFF_MODE_INFO_TIMEOUT
-from evap.staff.tools import delete_navbar_cache_for_users
 
 
 def staff_mode_middleware(get_response):
@@ -59,11 +58,9 @@ def update_staff_mode(request):
 
 def enter_staff_mode(request):
     update_staff_mode(request)
-    delete_navbar_cache_for_users([request.user])
 
 
 def exit_staff_mode(request):
     if is_in_staff_mode(request):
         del request.session['staff_mode_start_time']
         request.session.modified = True
-        delete_navbar_cache_for_users([request.user])


### PR DESCRIPTION
The `OIDC_AFTER_USERLOGIN_HOOK` introduced in #1562 is actually not working. It looks like I found this part in the docs of a library that we're not using. 🤦 

This PR removes the `after_login_ function` added in the previous PR and instead deletes the navbar cache when accessing the `evaluation:index` view as a logged-in user. This is the redirect location after login, which is always passed.

Also, because entering the staff mode takes a few seconds on production (loading the active semester's index), a spinner is added to the button for immediate feedback.