### PR TITLE
Remove manual reloading of DB models in tests

### DIFF
--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -96,9 +96,7 @@ class TestContributorEvaluationView(WebTestWith200Check):
         cls.editor = result["editor"]
 
         cls.test_users = [cls.editor, cls.responsible]
-
-    def setUp(self):
-        self.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)
+        cls.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)
 
     def test_wrong_state(self):
         self.evaluation.revert_to_new()
@@ -125,11 +123,9 @@ class TestContributorEvaluationPreviewView(WebTestWith200Check):
     def setUpTestData(cls):
         result = create_evaluation_with_responsible_and_editor(evaluation_id=TESTING_EVALUATION_ID)
         cls.responsible = result["responsible"]
-
         cls.test_users = [result["editor"], result["responsible"]]
 
-    def setUp(self):
-        self.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)
+        cls.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)
 
     def test_wrong_state(self):
         self.evaluation.revert_to_new()
@@ -145,9 +141,7 @@ class TestContributorEvaluationEditView(WebTest):
         result = create_evaluation_with_responsible_and_editor(evaluation_id=TESTING_EVALUATION_ID)
         cls.responsible = result["responsible"]
         cls.editor = result["editor"]
-
-    def setUp(self):
-        self.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)
+        cls.evaluation = Evaluation.objects.get(pk=TESTING_EVALUATION_ID)
 
     def test_not_authenticated(self):
         """

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -653,10 +653,6 @@ class ParticipationArchivingTests(TestCase):
         """refresh_from_db does not work with evaluations"""
         self.evaluation = self.semester.evaluations.first()
 
-    def setUp(self):
-        self.semester.refresh_from_db()
-        self.refresh_evaluation()
-
     def test_counts_dont_change(self):
         """
         Asserts that evaluation.num_voters evaluation.num_participants don't change after archiving.

--- a/evap/evaluation/tests/test_models_logging.py
+++ b/evap/evaluation/tests/test_models_logging.py
@@ -9,25 +9,26 @@ from evap.evaluation.models_logging import FieldAction
 
 
 class TestLoggedModel(TestCase):
-    def setUp(self):
-        self.old_start_date = datetime.now()
-        self.new_start_date = self.old_start_date + timedelta(days=10)
+    @classmethod
+    def setUpTestData(cls):
+        cls.old_start_date = datetime.now()
+        cls.new_start_date = cls.old_start_date + timedelta(days=10)
 
-        self.course = baker.make(Course)
+        cls.course = baker.make(Course)
 
-        self.evaluation = baker.make(
+        cls.evaluation = baker.make(
             Evaluation,
-            course=self.course,
+            course=cls.course,
             state=Evaluation.State.PREPARED,
-            vote_start_datetime=self.old_start_date,
+            vote_start_datetime=cls.old_start_date,
             vote_end_date=date.today() + timedelta(days=20),
         )
-        self.evaluation.save()  # first logentry
+        cls.evaluation.save()  # first logentry
 
-        self.evaluation.vote_start_datetime = self.new_start_date
-        self.evaluation.save()  # second logentry
+        cls.evaluation.vote_start_datetime = cls.new_start_date
+        cls.evaluation.save()  # second logentry
 
-        self.logentry = self.evaluation.related_logentries()[1]
+        cls.logentry = cls.evaluation.related_logentries()[1]
 
     def test_voters_not_in_evaluation_data(self):
         self.assertFalse(any("voters" in entry.data for entry in self.evaluation.related_logentries()))

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -46,9 +46,6 @@ class GradeUploadTest(WebTest):
 
         cls.evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
 
-    def setUp(self):
-        self.evaluation = Evaluation.objects.get(pk=self.evaluation.pk)
-
     def tearDown(self):
         for course in Course.objects.all():
             for grade_document in course.grade_documents.all():

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -431,9 +431,6 @@ class TestResultsSemesterEvaluationDetailViewFewVoters(WebTest):
             Contribution, contributor=responsible, evaluation=cls.evaluation, questionnaires=[questionnaire]
         )
 
-    def setUp(self):
-        self.evaluation = Evaluation.objects.get(pk=self.evaluation.pk)
-
     def helper_test_answer_visibility_one_voter(self, user_email, expect_page_not_visible=False):
         page = self.app.get("/results/semester/2/evaluation/22", user=user_email, expect_errors=expect_page_not_visible)
         if expect_page_not_visible:

--- a/evap/staff/tests/test_tools.py
+++ b/evap/staff/tests/test_tools.py
@@ -95,11 +95,6 @@ class MergeUsersTest(TestCase):
         cls.rewardpointredemption_main = baker.make(RewardPointRedemption, user_profile=cls.main_user)
         cls.rewardpointredemption_other = baker.make(RewardPointRedemption, user_profile=cls.other_user)
 
-    def setUp(self):
-        # merge users changes these instances in such a way that refresh_from_db doesn't work anymore.
-        self.main_user = UserProfile.objects.get(first_name="Main", last_name="")
-        self.other_user = UserProfile.objects.get(email="other@test.com")
-
     def test_merge_handles_all_attributes(self):
         user1 = baker.make(UserProfile)
         user2 = baker.make(UserProfile)

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1645,10 +1645,6 @@ class TestEvaluationCopyView(WebTestStaffMode):
 class TestCourseEditView(WebTestStaffMode):
     url = "/staff/semester/1/course/1/edit"
 
-    def setUp(self):
-        super().setUp()
-        self.course = Course.objects.get(pk=self.course.pk)
-
     @classmethod
     def setUpTestData(cls):
         cls.manager = make_manager()
@@ -1683,10 +1679,6 @@ class TestCourseEditView(WebTestStaffMode):
 )
 class TestEvaluationEditView(WebTestStaffMode):
     url = "/staff/semester/1/evaluation/1/edit"
-
-    def setUp(self):
-        super().setUp()
-        self.evaluation = Evaluation.objects.get(pk=self.evaluation.pk)
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
This has been made obsolete by django 3.2, which now properly isolates
test data created in setUpTestData between tests.

(see https://docs.djangoproject.com/en/3.2/releases/3.2/#tests)