### PR TITLE
Fix wrong padding from ac26c1ca: Add margin to logging paragraphs

### DIFF
--- a/evap/evaluation/templates/log/changed_fields_entry.html
+++ b/evap/evaluation/templates/log/changed_fields_entry.html
@@ -1,7 +1,7 @@
 {% load static %}
 {% load i18n %}
 
-<p>
+<p class="mt-3">
     {{ log.message }}
 </p>
 


### PR DESCRIPTION
Before (current master after ac26c1ca):
<img src="https://user-images.githubusercontent.com/13838962/127900115-90f92d81-21c9-4a69-b70b-82b587222180.png" src="https://user-images.githubusercontent.com/13838962/127900115-90f92d81-21c9-4a69-b70b-82b587222180.png" width="400" />
Note that the first log entry group does not have appropriate padding between the two entries of the group.

After this PR:
<img src="https://user-images.githubusercontent.com/13838962/127899942-3c6ab04e-216a-4586-ba7c-b4477155ca38.png" src="https://user-images.githubusercontent.com/13838962/127899942-3c6ab04e-216a-4586-ba7c-b4477155ca38.png" width="400" />
