### PR TITLE
Text answer review filter

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -438,6 +438,7 @@ class Evaluation(LoggedModel):
     class TextAnswerReviewState(Enum):
         do_not_call_in_templates = True  # pylint: disable=invalid-name
         NO_TEXTANSWERS = auto()
+        NO_REVIEW_NEEDED = auto()
         REVIEW_NEEDED = auto()
         REVIEW_URGENT = auto()
         REVIEWED = auto()
@@ -879,10 +880,10 @@ class Evaluation(LoggedModel):
         if self.num_textanswers == self.num_reviewed_textanswers:
             return self.TextAnswerReviewState.REVIEWED
 
-        if self.state != Evaluation.State.EVALUATED:
-            return self.TextAnswerReviewState.REVIEW_NEEDED
+        if self.state < Evaluation.State.EVALUATED:
+            return self.TextAnswerReviewState.NO_REVIEW_NEEDED
 
-        if self.grading_process_is_finished:
+        if self.state == Evaluation.State.EVALUATED and self.grading_process_is_finished:
             return self.TextAnswerReviewState.REVIEW_URGENT
 
         return self.TextAnswerReviewState.REVIEW_NEEDED

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -488,13 +488,13 @@ class TestEvaluations(WebTest):
         textanswer = baker.make(TextAnswer, contribution=evaluation.general_contribution)
         del evaluation.num_textanswers  # reset cached_property cache
 
-        # text_answer_review_state should be REVIEW_NEEDED as long as we are still in_evaluation
+        # text_answer_review_state should be NO_REVIEW_NEEDED as long as we are still in_evaluation
         self.assert_textanswer_review_state(
             evaluation,
-            evaluation.TextAnswerReviewState.REVIEW_NEEDED,
-            evaluation.TextAnswerReviewState.REVIEW_NEEDED,
-            evaluation.TextAnswerReviewState.REVIEW_NEEDED,
-            evaluation.TextAnswerReviewState.REVIEW_NEEDED,
+            evaluation.TextAnswerReviewState.NO_REVIEW_NEEDED,
+            evaluation.TextAnswerReviewState.NO_REVIEW_NEEDED,
+            evaluation.TextAnswerReviewState.NO_REVIEW_NEEDED,
+            evaluation.TextAnswerReviewState.NO_REVIEW_NEEDED,
         )
 
         evaluation.end_evaluation()

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -198,8 +198,8 @@
                             </button>
                         </div>
                         <div class="btn-switch btn-group icon-buttons">
-                            <button type="button" class="btn btn-sm btn-light" data-filter="no_textanswers"
-                                data-toggle="tooltip" data-placement="top" title="{% trans 'No text answers available' %}">
+                            <button type="button" class="btn btn-sm btn-light" data-filter="no_review"
+                                data-toggle="tooltip" data-placement="top" title="{% trans 'No text answers available or evaluation not yet finished' %}">
                                 <span class="fas fa-comment icon-gray"></span>
                             </button>
                             <button type="button" class="btn btn-sm btn-light" data-filter="unreviewed_textanswers_urgent"

--- a/evap/staff/templates/staff_semester_view_evaluation.html
+++ b/evap/staff/templates/staff_semester_view_evaluation.html
@@ -38,9 +38,9 @@
     </td>
 {% endif %}
 
-{% if evaluation.textanswer_review_state == evaluation.TextAnswerReviewState.NO_TEXTANSWERS %}
-    <td class="icon" data-col="state-textanswers" data-order="3" data-filter="no_textanswers">
-        <span class="fas fa-comment icon-gray" data-toggle="tooltip" data-placement="top" title="{% trans 'No text answers available' %}"></span>
+{% if evaluation.textanswer_review_state == evaluation.TextAnswerReviewState.NO_TEXTANSWERS or evaluation.textanswer_review_state == evaluation.TextAnswerReviewState.NO_REVIEW_NEEDED %}
+    <td class="icon" data-col="state-textanswers" data-order="3" data-filter="no_review">
+        <span class="fas fa-comment icon-gray" data-toggle="tooltip" data-placement="top" title="{% trans 'No text answers available or evaluation not yet finished' %}"></span>
     </td>
 {% elif evaluation.textanswer_review_state == evaluation.TextAnswerReviewState.REVIEW_URGENT %}
     <td class="icon" data-col="state-textanswers" data-order="1" data-filter="unreviewed_textanswers_urgent">

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -592,23 +592,27 @@ class TestSemesterView(WebTestStaffMode):
 
         textanswer_review_state_mock.return_value = Evaluation.TextAnswerReviewState.NO_TEXTANSWERS
         page = self.app.get(f"/staff/semester/{evaluation.course.semester.id}", user=self.manager)
-        expected_count = page.body.decode().count("no_textanswers")
+        expected_count = page.body.decode().count("no_review")
+
+        textanswer_review_state_mock.return_value = Evaluation.TextAnswerReviewState.NO_REVIEW_NEEDED
+        page = self.app.get(f"/staff/semester/{evaluation.course.semester.id}", user=self.manager)
+        self.assertEqual(page.body.decode().count("no_review"), expected_count)
 
         textanswer_review_state_mock.return_value = Evaluation.TextAnswerReviewState.REVIEW_NEEDED
         page = self.app.get(f"/staff/semester/{evaluation.course.semester.id}", user=self.manager)
         # + 1 because the buttons at the top of the page contain it two times (once for _urgent)
         self.assertEqual(page.body.decode().count("unreviewed_textanswers"), expected_count + 1)
-        self.assertEqual(page.body.decode().count("no_textanswers"), 1)
+        self.assertEqual(page.body.decode().count("no_review"), 1)
 
         textanswer_review_state_mock.return_value = Evaluation.TextAnswerReviewState.REVIEW_URGENT
         page = self.app.get(f"/staff/semester/{evaluation.course.semester.id}", user=self.manager)
         self.assertEqual(page.body.decode().count("unreviewed_textanswers_urgent"), expected_count)
-        self.assertEqual(page.body.decode().count("no_textanswers"), 1)
+        self.assertEqual(page.body.decode().count("no_review"), 1)
 
         textanswer_review_state_mock.return_value = Evaluation.TextAnswerReviewState.REVIEWED
         page = self.app.get(f"/staff/semester/{evaluation.course.semester.id}", user=self.manager)
         self.assertEqual(page.body.decode().count("textanswers_reviewed"), expected_count)
-        self.assertEqual(page.body.decode().count("no_textanswers"), 1)
+        self.assertEqual(page.body.decode().count("no_review"), 1)
 
 
 class TestGetEvaluationsWithPrefetchedData(TestCase):


### PR DESCRIPTION
Text answer reviews are usually done after the evaluation period ended.
The current filter for text answers "awaiting review" on the staff semester page does include running evaluations, which is changed in this PR.