### PR TITLE
http2

### DIFF
--- a/deployment/apache.template.conf
+++ b/deployment/apache.template.conf
@@ -1,3 +1,8 @@
+LoadModule http2_module modules/mod_http2.so
+# NOTE: h2c means http, h2 meaning https
+# I have no idea how tls is set up in production :(
+Protocols h2c http/1.1
+
 <VirtualHost *:80>
     ServerName evap
 
@@ -31,3 +36,5 @@
 
     CustomLog /var/log/apache2/access.log combined
 </VirtualHost>
+
+# vim: ft=apache

--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -23,7 +23,7 @@ sudo -u postgres createdb -O evap evap
 apt-get -q install -y redis-server
 
 # install apache
-apt-get -q install -y apache2 apache2-dev
+apt-get -q install -y apache2 apache2-dev libnghttp2
 
 # make user, create home folder, set uid to the same set in the Vagrantfile (required for becoming the synced folder owner), set default shell to bash
 useradd -m -u 1042 -s /bin/bash evap
@@ -46,6 +46,7 @@ sudo -H -u $USER $ENV_FOLDER/bin/pip install wheel
 sudo -H -u $USER $ENV_FOLDER/bin/pip install mod_wsgi
 
 # setup apache
+a2enmod http2
 a2enmod headers
 cp $REPO_FOLDER/deployment/wsgi.template.conf /etc/apache2/mods-available/wsgi.load
 sed -i -e "s=\${ENV_FOLDER}=$ENV_FOLDER=" /etc/apache2/mods-available/wsgi.load # note this uses '=' as alternate delimiter


### PR DESCRIPTION
Related to #1515

I don't know if there is prior work on this, if so let me know

This enables h2c, which is http2 without tls, in vagrant. I don't know how tls is set up for http/1.1, so I didn't start working on this for now :) The [documentation](https://httpd.apache.org/docs/2.4/howto/http2.html) has a hint "Choose a strong SSLCipherSuite", I don't know if we have anything set there either. I will have to see how h2 works once I find out

This would also be a chance to document the tls setup somewhere
