### PR TITLE
Text follow ups

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1337,9 +1337,11 @@ CHOICES = {
 
 
 class Answer(models.Model):
-    """An abstract answer to a question. For anonymity purposes, the answering
-    user ist not stored in the object. Concrete subclasses are `RatingAnswerCounter`,
-    and `TextAnswer`."""
+    """
+    An abstract answer to a question. For anonymity purposes, the answering
+    user ist not stored in the object. Concrete subclasses are
+    `RatingAnswerCounter`, and `TextAnswer`.
+    """
 
     # we use UUIDs to hide insertion order. See https://github.com/e-valuation/EvaP/wiki/Data-Economy
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -1354,11 +1356,13 @@ class Answer(models.Model):
 
 
 class RatingAnswerCounter(Answer):
-    """A rating answer counter to a question.
+    """
+    A rating answer counter to a question.
     The interpretation depends on the type of question:
     unipolar: 1, 2, 3, 4, 5; where lower value means more agreement
     bipolar: -3, -2, -1, 0, 1, 2, 3; where a lower absolute means more agreement and the sign shows the pole
-    yes / no: 1, 5; for 1 being the good answer"""
+    yes / no: 1, 5; for 1 being the good answer
+    """
 
     answer = models.IntegerField(verbose_name=_("answer"))
     count = models.IntegerField(verbose_name=_("count"), default=0)
@@ -1373,6 +1377,7 @@ class TextAnswer(Answer):
     """A free-form text answer to a question."""
 
     answer = models.TextField(verbose_name=_("answer"))
+    # If the text answer was changed during review, original_answer holds the original text. Otherwise, it's null.
     original_answer = models.TextField(verbose_name=_("original answer"), blank=True, null=True)
 
     class State(models.TextChoices):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2205,6 +2205,10 @@ class TestEvaluationTextAnswerView(WebTest):
             answer="test answer text",
         )
 
+        cls.num_questions = 100
+        for _ in range(cls.num_questions):
+            baker.make(TextAnswer, question__questionnaire=questionnaire, answer="yeet")
+
     def test_textanswers_showing_up(self):
         # in an evaluation with only one voter the view should not be available
         with run_in_staff_mode(self):
@@ -2244,6 +2248,12 @@ class TestEvaluationTextAnswerView(WebTest):
             page = self.app.get(self.url, user=self.manager, status=200)
             # unfinished because still in EVALUATION_END_OFFSET_HOURS
             self.assertNotContains(page, self.evaluation2.full_name)
+
+    def test_num_queries_is_constant(self):
+        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        with run_in_staff_mode(self):
+            with self.assertNumQueries(FuzzyInt(0, self.num_questions)):
+                self.app.get(self.url, user=self.manager)
 
 
 class TestEvaluationTextAnswerEditView(WebTest):

--- a/evap/static/scss/components/_buttons.scss
+++ b/evap/static/scss/components/_buttons.scss
@@ -262,4 +262,18 @@ a.collapse-toggle {
     height: 2.5rem;
     background-color: $lighter-gray;
     border-color: $medium-gray;
+
+    & > .fa-comment {
+        color: $darker-gray;
+    }
+
+    &.has-contents > .fa-comment {
+        font-weight: 900;
+    }
+
+    box-shadow: inset 0 0 10px $dark-gray;
+
+    &.collapsed {
+        box-shadow: none;
+    }
 }

--- a/evap/student/forms.py
+++ b/evap/student/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from evap.evaluation.models import CHOICES
+from evap.evaluation.models import CHOICES, Question
 from evap.student.tools import answer_field_id
 
 
@@ -10,6 +10,10 @@ class HeadingField(forms.Field):
 
     def __init__(self, label):
         super().__init__(label=label, required=False)
+
+    @classmethod
+    def from_question(cls, question: Question):
+        return cls(label=question.text)
 
 
 class TextAnswerField(forms.CharField):
@@ -26,6 +30,10 @@ class TextAnswerField(forms.CharField):
         if self.related_answer_field_id is not None:
             kwargs["related_answer_field_id"] = self.related_answer_field_id
         return name, path, args, kwargs
+
+    @classmethod
+    def from_question(cls, question: Question):
+        return cls(label=question.text)
 
 
 class RatingAnswerField(forms.TypedChoiceField):
@@ -48,6 +56,15 @@ class RatingAnswerField(forms.TypedChoiceField):
             kwargs["allows_textanswer"] = self.allows_textanswer
         return name, path, args, kwargs
 
+    @classmethod
+    def from_question(cls, question: Question):
+        return cls(
+            widget_choices=CHOICES[question.type],
+            choices=zip(CHOICES[question.type].values, CHOICES[question.type].names),
+            label=question.text,
+            allows_textanswer=question.allows_additional_textanswers,
+        )
+
 
 class QuestionnaireVotingForm(forms.Form):
     """Dynamic form class that adds required fields per question.
@@ -60,16 +77,11 @@ class QuestionnaireVotingForm(forms.Form):
 
         for question in self.questionnaire.questions.all():
             if question.is_text_question:
-                field = TextAnswerField(label=question.text)
+                field = TextAnswerField.from_question(question)
             elif question.is_rating_question:
-                field = RatingAnswerField(
-                    widget_choices=CHOICES[question.type],
-                    choices=zip(CHOICES[question.type].values, CHOICES[question.type].names),
-                    label=question.text,
-                    allows_textanswer=question.allows_additional_textanswers,
-                )
+                field = RatingAnswerField.from_question(question)
             elif question.is_heading_question:
-                field = HeadingField(label=question.text)
+                field = HeadingField.from_question(question)
 
             identifier = answer_field_id(contribution, questionnaire, question)
             self.fields[identifier] = field

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -195,9 +195,9 @@
                     }
 
                     // show all non-empty additional text answer fields
-                    $(".collapse textarea").each(function(index) {
-                        if($(this).val()){
-                            $($(this).closest(".row")).find(".btn-textanswer").click()
+                    document.querySelectorAll(".collapse textarea").forEach(el => {
+                        if (el.value.length !== 0) {
+                            el.closest(".row").getElementsByClassName("btn-textanswer")[0].click();
                         }
                     });
                 },
@@ -343,6 +343,24 @@
                 });
             });
 
+            document.querySelectorAll(".btn-textanswer").forEach(textanswerButton => {
+                const textfieldClass = textanswerButton.dataset.target;
+                const textfield = textanswerButton.closest(".row").querySelector(textfieldClass + " textarea");
+                textanswerButton.addEventListener("click", () => {
+                    // focus textarea when opening the collapsed area
+                    const isOpening = textanswerButton.classList.contains("collapsed");
+                    if (isOpening) {
+                        requestAnimationFrame(() => textfield.focus());
+                    }
+                });
+                textfield.addEventListener("input", () => {
+                    if (textfield.value.length !== 0)
+                        textanswerButton.classList.add("has-contents");
+                    else
+                        textanswerButton.classList.remove("has-contents");
+                });
+                textfield.dispatchEvent(new Event("input"));
+            });
 
             // handle text_results_publish_confirmation checkbox changes
             function updateTextResultsPublishConfirmation() {
@@ -448,6 +466,7 @@
                                 block: "center",
                             });
                             textField.value += e.key;
+                            textField.dispatchEvent(new Event("input"));
                         }
                     }
                     return;

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -1,7 +1,6 @@
 from functools import partial
 
-from django.db import connection
-from django.test.utils import CaptureQueriesContext, override_settings
+from django.test.utils import override_settings
 from django.urls import reverse
 from django_webtest import WebTest
 from model_bakery import baker
@@ -17,7 +16,7 @@ from evap.evaluation.models import (
     TextAnswer,
     UserProfile,
 )
-from evap.evaluation.tests.tools import WebTestWith200Check
+from evap.evaluation.tests.tools import FuzzyInt, WebTestWith200Check
 from evap.student.tools import answer_field_id
 from evap.student.views import SUCCESS_MAGIC_STRING
 
@@ -51,12 +50,8 @@ class TestStudentIndexView(WebTestWith200Check):
             _quantity=100,
         )
 
-        with CaptureQueriesContext(connection) as context:
+        with self.assertNumQueries(FuzzyInt(0, 100)):
             self.app.get(self.url, user=self.user)
-
-        num_queries = context.final_queries - context.initial_queries
-
-        self.assertLess(num_queries, 100)
 
 
 @override_settings(INSTITUTION_EMAIL_DOMAINS=["example.com"])


### PR DESCRIPTION
Some things mentioned in #1592 

okay, I cant remember what is already done all the time anymore
- [x] (comment) indicated we might have O(N) queries in `get_evaluation_and_contributor_textanswer_sections`
- [x] (comment) had another O(N) query issue there
- [x] (comment) indicated a refactoring of `make_questionnaire_edit_forms` would be appropriate
- [x] (comment) indicated it might make sense to let a `RatingAnswerField` take a `question`
- [x] (comment) indicated the line `$($(this).closest(".row")).find(".btn-textanswer").click()` in student_vote.html might be slow; edit: we concluded that we really want to click those buttons, only replaced jquery with vanilla js on that one
- [x] There was a discussion that we should maybe add a database constraint: Only rating answers can have additional text answers. This was, for some time, asserted in the save method, but this will not help for .update() queries.; edit: not possible as per my comment below
- [x] Related to "Keyboard navigation for voting site" We would want that when a user clicks on the "add additional text answer", the cursor focus goes to the input field automatically.
- [x] When the additional textanswer button should look "activated" / "pressed" when when the additional text answer field is visible.