### PR TITLE
Add a test utility function that creates RatingAnswerCounters

### DIFF
--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -25,7 +25,12 @@ from evap.evaluation.models import (
     UserProfile,
 )
 from evap.grades.models import GradeDocument
-from evap.evaluation.tests.tools import let_user_vote_for_evaluation, make_contributor, make_editor
+from evap.evaluation.tests.tools import (
+    let_user_vote_for_evaluation,
+    make_contributor,
+    make_editor,
+    make_rating_answer_counters,
+)
 from evap.results.tools import calculate_average_distribution, cache_results
 from evap.results.views import get_evaluation_result_template_fragment_cache_key
 
@@ -219,13 +224,7 @@ class TestEvaluations(WebTest):
             role=Contribution.Role.EDITOR,
             textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
         )
-        baker.make(
-            RatingAnswerCounter,
-            answer=1,
-            count=1,
-            question=Questionnaire.single_result_questionnaire().questions.first(),
-            contribution=contribution,
-        )
+        make_rating_answer_counters(Questionnaire.single_result_questionnaire().questions.first(), contribution)
         evaluation.skip_review_single_result()
         evaluation.publish()
         evaluation.save()
@@ -253,13 +252,7 @@ class TestEvaluations(WebTest):
             role=Contribution.Role.EDITOR,
             textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
         )
-        baker.make(
-            RatingAnswerCounter,
-            answer=1,
-            count=1,
-            question=Questionnaire.single_result_questionnaire().questions.first(),
-            contribution=contribution,
-        )
+        make_rating_answer_counters(Questionnaire.single_result_questionnaire().questions.first(), contribution)
 
         single_result.skip_review_single_result()
         single_result.publish()  # used to crash

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -7,7 +7,15 @@ from django.utils import timezone
 from django_webtest import WebTest
 from model_bakery import baker
 
-from evap.evaluation.models import Contribution, Course, Degree, Evaluation, Questionnaire, UserProfile
+from evap.evaluation.models import (
+    Contribution,
+    Course,
+    Degree,
+    Evaluation,
+    Questionnaire,
+    RatingAnswerCounter,
+    UserProfile,
+)
 from evap.student.tools import answer_field_id
 
 
@@ -116,4 +124,26 @@ def make_editor(user, evaluation):
         evaluation=evaluation,
         contributor=user,
         role=Contribution.Role.EDITOR,
+    )
+
+
+def make_rating_answer_counters(question, contribution, answer_counts=None):
+    """
+    Create RatingAnswerCounters for a question for a contribution.
+    Examples:
+    make_rating_answer_counters(rating_question, contribution, {1:15, 2:12, 4:100, 5:2})
+    make_rating_answer_counters(yesno_question, contribution, {1:15, 5:2})
+    make_rating_answer_counters(bipolar_question, contribution, {-3:20, -2:15, 0:1, 1:15, 3:2})
+    """
+    if answer_counts is None:
+        answer_counts = {1: 20}
+
+    return baker.make(
+        RatingAnswerCounter,
+        question=question,
+        contribution=contribution,
+        _bulk_create=True,
+        _quantity=len(answer_counts),
+        answer=iter(answer_counts.keys()),
+        count=iter(answer_counts.values()),
     )

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -8,6 +8,7 @@ from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import (
+    CHOICES,
     Contribution,
     Course,
     Degree,
@@ -131,12 +132,17 @@ def make_rating_answer_counters(question, contribution, answer_counts=None):
     """
     Create RatingAnswerCounters for a question for a contribution.
     Examples:
-    make_rating_answer_counters(rating_question, contribution, {1:15, 2:12, 4:100, 5:2})
-    make_rating_answer_counters(yesno_question, contribution, {1:15, 5:2})
-    make_rating_answer_counters(bipolar_question, contribution, {-3:20, -2:15, 0:1, 1:15, 3:2})
+    make_rating_answer_counters(rating_question, contribution, [5, 15, 40, 60, 30])
+    make_rating_answer_counters(yesno_question, contribution, [15, 2])
+    make_rating_answer_counters(bipolar_question, contribution, [5, 5, 15, 30, 25, 15, 10])
     """
+    expected_counts = len(CHOICES[question.type].grades)
+
     if answer_counts is None:
-        answer_counts = {1: 20}
+        answer_counts = [0] * expected_counts
+        answer_counts[0] = 42
+
+    assert len(answer_counts) == expected_counts
 
     return baker.make(
         RatingAnswerCounter,
@@ -144,6 +150,6 @@ def make_rating_answer_counters(question, contribution, answer_counts=None):
         contribution=contribution,
         _bulk_create=True,
         _quantity=len(answer_counts),
-        answer=iter(answer_counts.keys()),
-        count=iter(answer_counts.values()),
+        answer=iter(CHOICES[question.type].values),
+        count=iter(answer_counts),
     )

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -416,8 +416,8 @@ class TestExporters(TestCase):
         question1 = baker.make(Question, type=Question.LIKERT, questionnaire=questionnaire1)
         question2 = baker.make(Question, type=Question.LIKERT, questionnaire=questionnaire2)
 
-        make_rating_answer_counters(question1, evaluation.general_contribution, {1: 1, 3: 1})
-        make_rating_answer_counters(question2, evaluation.general_contribution, {2: 1, 4: 1})
+        make_rating_answer_counters(question1, evaluation.general_contribution, [1, 0, 1, 0, 0])
+        make_rating_answer_counters(question2, evaluation.general_contribution, [0, 1, 0, 1, 0])
 
         evaluation.general_contribution.questionnaires.set([questionnaire1, questionnaire2])
         cache_results(evaluation)
@@ -446,7 +446,7 @@ class TestExporters(TestCase):
             for i in range(3)
         ]
 
-        grades_per_eval = [{1: 1, 2: 1}, {2: 1, 3: 1}, {1: 1, 3: 1}]
+        grades_per_eval = [[1, 1, 0, 0, 0], [0, 1, 1, 0, 0], [1, 0, 1, 0, 0]]
         expected_average = 2.0
 
         questionnaire = baker.make(Questionnaire)
@@ -474,8 +474,7 @@ class TestExporters(TestCase):
         questionnaire = baker.make(Questionnaire)
         question = baker.make(Question, type=Question.POSITIVE_YES_NO, questionnaire=questionnaire)
 
-        # 1,5 are yes, no according to RatingAnswerCounter class definition
-        make_rating_answer_counters(question, evaluation.general_contribution, {1: 4, 5: 2})
+        make_rating_answer_counters(question, evaluation.general_contribution, [4, 2])
 
         evaluation.general_contribution.questionnaires.set([questionnaire])
         cache_results(evaluation)
@@ -511,14 +510,14 @@ class TestExporters(TestCase):
         contributor_question = baker.make(Question, type=Question.LIKERT, questionnaire=contributor_questionnaire)
 
         evaluation_1.general_contribution.questionnaires.set([general_questionnaire])
-        make_rating_answer_counters(general_question, evaluation_1.general_contribution, {1: 2})
+        make_rating_answer_counters(general_question, evaluation_1.general_contribution, [2, 0, 0, 0, 0])
         evaluation_2.general_contribution.questionnaires.set([general_questionnaire])
-        make_rating_answer_counters(general_question, evaluation_2.general_contribution, {4: 2})
+        make_rating_answer_counters(general_question, evaluation_2.general_contribution, [0, 0, 0, 2, 0])
 
         contribution.questionnaires.set([contributor_questionnaire])
-        make_rating_answer_counters(contributor_question, contribution, {3: 2})
+        make_rating_answer_counters(contributor_question, contribution, [0, 0, 2, 0, 0])
         other_contribution.questionnaires.set([contributor_questionnaire])
-        make_rating_answer_counters(contributor_question, other_contribution, {2: 2})
+        make_rating_answer_counters(contributor_question, other_contribution, [0, 2, 0, 0, 0])
 
         cache_results(evaluation_1)
         cache_results(evaluation_2)

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -86,7 +86,7 @@ class TestCalculateResults(TestCase):
             Contribution, contributor=contributor1, evaluation=evaluation, questionnaires=[questionnaire]
         )
 
-        make_rating_answer_counters(question, contribution1, {1: 5, 2: 15, 3: 40, 4: 60, 5: 30})
+        make_rating_answer_counters(question, contribution1, [5, 15, 40, 60, 30])
 
         cache_results(evaluation)
         evaluation_results = get_results(evaluation)
@@ -116,7 +116,7 @@ class TestCalculateResults(TestCase):
             Contribution, contributor=contributor1, evaluation=evaluation, questionnaires=[questionnaire]
         )
 
-        make_rating_answer_counters(question, contribution1, {-3: 5, -2: 5, -1: 15, 0: 30, 1: 25, 2: 15, 3: 10})
+        make_rating_answer_counters(question, contribution1, [5, 5, 15, 30, 25, 15, 10])
 
         cache_results(evaluation)
         evaluation_results = get_results(evaluation)
@@ -205,14 +205,14 @@ class TestCalculateAverageDistribution(TestCase):
     def test_average_grade(self):
         question_grade2 = baker.make(Question, questionnaire=self.questionnaire, type=Question.GRADE)
 
-        make_rating_answer_counters(self.question_grade, self.contribution1, {2: 1})
-        make_rating_answer_counters(self.question_grade, self.contribution2, {4: 2})
-        make_rating_answer_counters(question_grade2, self.contribution1, {1: 1})
-        make_rating_answer_counters(self.question_likert, self.contribution1, {3: 4})
-        make_rating_answer_counters(self.question_likert, self.general_contribution, {5: 5})
-        make_rating_answer_counters(self.question_likert_2, self.general_contribution, {3: 3})
-        make_rating_answer_counters(self.question_bipolar, self.general_contribution, {3: 2})
-        make_rating_answer_counters(self.question_bipolar_2, self.general_contribution, {-1: 4})
+        make_rating_answer_counters(self.question_grade, self.contribution1, [0, 1, 0, 0, 0])
+        make_rating_answer_counters(self.question_grade, self.contribution2, [0, 0, 0, 2, 0])
+        make_rating_answer_counters(question_grade2, self.contribution1, [1, 0, 0, 0, 0])
+        make_rating_answer_counters(self.question_likert, self.contribution1, [0, 0, 4, 0, 0])
+        make_rating_answer_counters(self.question_likert, self.general_contribution, [0, 0, 0, 0, 5])
+        make_rating_answer_counters(self.question_likert_2, self.general_contribution, [0, 0, 3, 0, 0])
+        make_rating_answer_counters(self.question_bipolar, self.general_contribution, [0, 0, 0, 0, 0, 0, 2])
+        make_rating_answer_counters(self.question_bipolar_2, self.general_contribution, [0, 0, 4, 0, 0, 0, 0])
 
         cache_results(self.evaluation)
 
@@ -251,11 +251,11 @@ class TestCalculateAverageDistribution(TestCase):
         GENERAL_NON_GRADE_QUESTIONS_WEIGHT=5,
     )
     def test_distribution_without_general_grade_question(self):
-        make_rating_answer_counters(self.question_grade, self.contribution1, {1: 1, 3: 1})
-        make_rating_answer_counters(self.question_grade, self.contribution2, {4: 1, 2: 1})
-        make_rating_answer_counters(self.question_likert, self.contribution1, {3: 3, 5: 3})
-        make_rating_answer_counters(self.question_likert, self.general_contribution, {5: 5})
-        make_rating_answer_counters(self.question_likert_2, self.general_contribution, {3: 3})
+        make_rating_answer_counters(self.question_grade, self.contribution1, [1, 0, 1, 0, 0])
+        make_rating_answer_counters(self.question_grade, self.contribution2, [0, 1, 0, 1, 0])
+        make_rating_answer_counters(self.question_likert, self.contribution1, [0, 0, 3, 0, 3])
+        make_rating_answer_counters(self.question_likert, self.general_contribution, [0, 0, 0, 0, 5])
+        make_rating_answer_counters(self.question_likert_2, self.general_contribution, [0, 0, 3, 0, 0])
 
         cache_results(self.evaluation)
 
@@ -282,12 +282,12 @@ class TestCalculateAverageDistribution(TestCase):
         GENERAL_NON_GRADE_QUESTIONS_WEIGHT=5,
     )
     def test_distribution_with_general_grade_question(self):
-        make_rating_answer_counters(self.question_grade, self.contribution1, {1: 1, 3: 1})
-        make_rating_answer_counters(self.question_grade, self.contribution2, {4: 1, 2: 1})
-        make_rating_answer_counters(self.question_likert, self.contribution1, {3: 3, 5: 3})
-        make_rating_answer_counters(self.question_likert, self.general_contribution, {5: 5})
-        make_rating_answer_counters(self.question_likert_2, self.general_contribution, {3: 3})
-        make_rating_answer_counters(self.question_grade, self.general_contribution, {2: 10})
+        make_rating_answer_counters(self.question_grade, self.contribution1, [1, 0, 1, 0, 0])
+        make_rating_answer_counters(self.question_grade, self.contribution2, [0, 1, 0, 1, 0])
+        make_rating_answer_counters(self.question_likert, self.contribution1, [0, 0, 3, 0, 3])
+        make_rating_answer_counters(self.question_likert, self.general_contribution, [0, 0, 0, 0, 5])
+        make_rating_answer_counters(self.question_likert_2, self.general_contribution, [0, 0, 3, 0, 0])
+        make_rating_answer_counters(self.question_grade, self.general_contribution, [0, 10, 0, 0, 0])
 
         cache_results(self.evaluation)
 
@@ -314,7 +314,7 @@ class TestCalculateAverageDistribution(TestCase):
             role=Contribution.Role.EDITOR,
             textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
         )
-        make_rating_answer_counters(questionnaire.questions.first(), contribution, {1: 1, 4: 1})
+        make_rating_answer_counters(questionnaire.questions.first(), contribution, [1, 0, 0, 1, 0])
 
         cache_results(single_result_evaluation)
         distribution = calculate_average_distribution(single_result_evaluation)
@@ -339,16 +339,14 @@ class TestCalculateAverageDistribution(TestCase):
         )
 
         evaluation.general_contribution.questionnaires.set([self.questionnaire])
-        make_rating_answer_counters(self.question_grade, evaluation.general_contribution, {1: 1})
+        make_rating_answer_counters(self.question_grade, evaluation.general_contribution, [1, 0, 0, 0, 0])
         cache_results(evaluation)
 
         distribution = calculate_average_distribution(evaluation)
         self.assertEqual(distribution[0], 1)
 
     def test_unipolarized_unipolar(self):
-        answer_counters = make_rating_answer_counters(
-            self.question_likert, self.general_contribution, {1: 5, 2: 3, 3: 1, 4: 1, 5: 0}
-        )
+        answer_counters = make_rating_answer_counters(self.question_likert, self.general_contribution, [5, 3, 1, 1, 0])
 
         result = RatingResult(self.question_likert, answer_counters)
         distribution = unipolarized_distribution(result)
@@ -360,7 +358,7 @@ class TestCalculateAverageDistribution(TestCase):
 
     def test_unipolarized_bipolar(self):
         answer_counters = make_rating_answer_counters(
-            self.question_bipolar, self.general_contribution, {-3: 0, -2: 1, -1: 4, 0: 8, 1: 2, 2: 2, 3: 3}
+            self.question_bipolar, self.general_contribution, [0, 1, 4, 8, 2, 2, 3]
         )
 
         result = RatingResult(self.question_bipolar, answer_counters)
@@ -373,7 +371,7 @@ class TestCalculateAverageDistribution(TestCase):
 
     def test_unipolarized_yesno(self):
         question_yesno = baker.make(Question, questionnaire=self.questionnaire, type=Question.POSITIVE_YES_NO)
-        answer_counters = make_rating_answer_counters(question_yesno, self.general_contribution, {1: 57, 5: 43})
+        answer_counters = make_rating_answer_counters(question_yesno, self.general_contribution, [57, 43])
 
         result = RatingResult(question_yesno, answer_counters)
         distribution = unipolarized_distribution(result)
@@ -384,7 +382,7 @@ class TestCalculateAverageDistribution(TestCase):
         self.assertAlmostEqual(distribution[4], 0.43)
 
     def test_calculate_average_course_distribution(self):
-        make_rating_answer_counters(self.question_grade, self.contribution1, {1: 2})
+        make_rating_answer_counters(self.question_grade, self.contribution1, [2, 0, 0, 0, 0])
 
         course = self.evaluation.course
         single_result = baker.make(
@@ -404,7 +402,7 @@ class TestCalculateAverageDistribution(TestCase):
         contribution = baker.make(
             Contribution, evaluation=single_result, contributor=None, questionnaires=[single_result_questionnaire]
         )
-        make_rating_answer_counters(single_result_question, contribution, {2: 1, 3: 1})
+        make_rating_answer_counters(single_result_question, contribution, [0, 1, 1, 0, 0])
         cache_results(single_result)
         cache_results(self.evaluation)
 

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -11,10 +11,10 @@ from evap.evaluation.models import (
     Evaluation,
     Question,
     Questionnaire,
-    RatingAnswerCounter,
     TextAnswer,
     UserProfile,
 )
+from evap.evaluation.tests.tools import make_rating_answer_counters
 from evap.results.tools import (
     calculate_average_course_distribution,
     calculate_average_distribution,
@@ -29,6 +29,7 @@ from evap.results.tools import (
     textanswers_visible_to,
     unipolarized_distribution,
 )
+
 from evap.staff.tools import merge_users
 
 
@@ -85,11 +86,7 @@ class TestCalculateResults(TestCase):
             Contribution, contributor=contributor1, evaluation=evaluation, questionnaires=[questionnaire]
         )
 
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=1, count=5)
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=2, count=15)
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=3, count=40)
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=4, count=60)
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=5, count=30)
+        make_rating_answer_counters(question, contribution1, {1: 5, 2: 15, 3: 40, 4: 60, 5: 30})
 
         cache_results(evaluation)
         evaluation_results = get_results(evaluation)
@@ -119,13 +116,7 @@ class TestCalculateResults(TestCase):
             Contribution, contributor=contributor1, evaluation=evaluation, questionnaires=[questionnaire]
         )
 
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=-3, count=5)
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=-2, count=5)
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=-1, count=15)
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=0, count=30)
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=1, count=25)
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=2, count=15)
-        baker.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=3, count=10)
+        make_rating_answer_counters(question, contribution1, {-3: 5, -2: 5, -1: 15, 0: 30, 1: 25, 2: 15, 3: 10})
 
         cache_results(evaluation)
         evaluation_results = get_results(evaluation)
@@ -214,44 +205,15 @@ class TestCalculateAverageDistribution(TestCase):
     def test_average_grade(self):
         question_grade2 = baker.make(Question, questionnaire=self.questionnaire, type=Question.GRADE)
 
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution1, answer=2, count=1
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution2, answer=4, count=2
-        )
-        baker.make(RatingAnswerCounter, question=question_grade2, contribution=self.contribution1, answer=1, count=1)
-        baker.make(
-            RatingAnswerCounter, question=self.question_likert, contribution=self.contribution1, answer=3, count=4
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=self.question_likert,
-            contribution=self.general_contribution,
-            answer=5,
-            count=5,
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=self.question_likert_2,
-            contribution=self.general_contribution,
-            answer=3,
-            count=3,
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=self.question_bipolar,
-            contribution=self.general_contribution,
-            answer=3,
-            count=2,
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=self.question_bipolar_2,
-            contribution=self.general_contribution,
-            answer=-1,
-            count=4,
-        )
+        make_rating_answer_counters(self.question_grade, self.contribution1, {2: 1})
+        make_rating_answer_counters(self.question_grade, self.contribution2, {4: 2})
+        make_rating_answer_counters(question_grade2, self.contribution1, {1: 1})
+        make_rating_answer_counters(self.question_likert, self.contribution1, {3: 4})
+        make_rating_answer_counters(self.question_likert, self.general_contribution, {5: 5})
+        make_rating_answer_counters(self.question_likert_2, self.general_contribution, {3: 3})
+        make_rating_answer_counters(self.question_bipolar, self.general_contribution, {3: 2})
+        make_rating_answer_counters(self.question_bipolar_2, self.general_contribution, {-1: 4})
+
         cache_results(self.evaluation)
 
         contributor_weights_sum = (
@@ -289,38 +251,12 @@ class TestCalculateAverageDistribution(TestCase):
         GENERAL_NON_GRADE_QUESTIONS_WEIGHT=5,
     )
     def test_distribution_without_general_grade_question(self):
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution1, answer=1, count=1
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution1, answer=3, count=1
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution2, answer=4, count=1
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution2, answer=2, count=1
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_likert, contribution=self.contribution1, answer=3, count=3
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_likert, contribution=self.contribution1, answer=5, count=3
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=self.question_likert,
-            contribution=self.general_contribution,
-            answer=5,
-            count=5,
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=self.question_likert_2,
-            contribution=self.general_contribution,
-            answer=3,
-            count=3,
-        )
+        make_rating_answer_counters(self.question_grade, self.contribution1, {1: 1, 3: 1})
+        make_rating_answer_counters(self.question_grade, self.contribution2, {4: 1, 2: 1})
+        make_rating_answer_counters(self.question_likert, self.contribution1, {3: 3, 5: 3})
+        make_rating_answer_counters(self.question_likert, self.general_contribution, {5: 5})
+        make_rating_answer_counters(self.question_likert_2, self.general_contribution, {3: 3})
+
         cache_results(self.evaluation)
 
         # contribution1: 0.4 * (0.5, 0, 0.5, 0, 0) + 0.6 * (0, 0, 0.5, 0, 0.5) = (0.2, 0, 0.5, 0, 0.3)
@@ -346,45 +282,13 @@ class TestCalculateAverageDistribution(TestCase):
         GENERAL_NON_GRADE_QUESTIONS_WEIGHT=5,
     )
     def test_distribution_with_general_grade_question(self):
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution1, answer=1, count=1
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution1, answer=3, count=1
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution2, answer=4, count=1
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution2, answer=2, count=1
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_likert, contribution=self.contribution1, answer=3, count=3
-        )
-        baker.make(
-            RatingAnswerCounter, question=self.question_likert, contribution=self.contribution1, answer=5, count=3
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=self.question_likert,
-            contribution=self.general_contribution,
-            answer=5,
-            count=5,
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=self.question_likert_2,
-            contribution=self.general_contribution,
-            answer=3,
-            count=3,
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=self.question_grade,
-            contribution=self.general_contribution,
-            answer=2,
-            count=10,
-        )
+        make_rating_answer_counters(self.question_grade, self.contribution1, {1: 1, 3: 1})
+        make_rating_answer_counters(self.question_grade, self.contribution2, {4: 1, 2: 1})
+        make_rating_answer_counters(self.question_likert, self.contribution1, {3: 3, 5: 3})
+        make_rating_answer_counters(self.question_likert, self.general_contribution, {5: 5})
+        make_rating_answer_counters(self.question_likert_2, self.general_contribution, {3: 3})
+        make_rating_answer_counters(self.question_grade, self.general_contribution, {2: 10})
+
         cache_results(self.evaluation)
 
         # contributions and general_non_grade are as above
@@ -410,12 +314,8 @@ class TestCalculateAverageDistribution(TestCase):
             role=Contribution.Role.EDITOR,
             textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
         )
-        baker.make(
-            RatingAnswerCounter, question=questionnaire.questions.first(), contribution=contribution, answer=1, count=1
-        )
-        baker.make(
-            RatingAnswerCounter, question=questionnaire.questions.first(), contribution=contribution, answer=4, count=1
-        )
+        make_rating_answer_counters(questionnaire.questions.first(), contribution, {1: 1, 4: 1})
+
         cache_results(single_result_evaluation)
         distribution = calculate_average_distribution(single_result_evaluation)
         self.assertEqual(distribution, (0.5, 0, 0, 0.5, 0))
@@ -439,31 +339,16 @@ class TestCalculateAverageDistribution(TestCase):
         )
 
         evaluation.general_contribution.questionnaires.set([self.questionnaire])
-        baker.make(
-            RatingAnswerCounter,
-            question=self.question_grade,
-            contribution=evaluation.general_contribution,
-            answer=1,
-            count=1,
-        )
+        make_rating_answer_counters(self.question_grade, evaluation.general_contribution, {1: 1})
         cache_results(evaluation)
 
         distribution = calculate_average_distribution(evaluation)
         self.assertEqual(distribution[0], 1)
 
     def test_unipolarized_unipolar(self):
-        counts = (5, 3, 1, 1, 0)
-
-        answer_counters = [
-            baker.make(
-                RatingAnswerCounter,
-                question=self.question_likert,
-                contribution=self.general_contribution,
-                answer=answer,
-                count=count,
-            )
-            for answer, count in enumerate(counts, start=1)
-        ]
+        answer_counters = make_rating_answer_counters(
+            self.question_likert, self.general_contribution, {1: 5, 2: 3, 3: 1, 4: 1, 5: 0}
+        )
 
         result = RatingResult(self.question_likert, answer_counters)
         distribution = unipolarized_distribution(result)
@@ -474,18 +359,9 @@ class TestCalculateAverageDistribution(TestCase):
         self.assertAlmostEqual(distribution[4], 0.0)
 
     def test_unipolarized_bipolar(self):
-        counts = (0, 1, 4, 8, 2, 2, 3)
-
-        answer_counters = [
-            baker.make(
-                RatingAnswerCounter,
-                question=self.question_bipolar,
-                contribution=self.general_contribution,
-                answer=answer,
-                count=count,
-            )
-            for answer, count in enumerate(counts, start=-3)
-        ]
+        answer_counters = make_rating_answer_counters(
+            self.question_bipolar, self.general_contribution, {-3: 0, -2: 1, -1: 4, 0: 8, 1: 2, 2: 2, 3: 3}
+        )
 
         result = RatingResult(self.question_bipolar, answer_counters)
         distribution = unipolarized_distribution(result)
@@ -496,24 +372,8 @@ class TestCalculateAverageDistribution(TestCase):
         self.assertAlmostEqual(distribution[4], 0.15)
 
     def test_unipolarized_yesno(self):
-        counts = (57, 43)
         question_yesno = baker.make(Question, questionnaire=self.questionnaire, type=Question.POSITIVE_YES_NO)
-        answer_counters = [
-            baker.make(
-                RatingAnswerCounter,
-                question=question_yesno,
-                contribution=self.general_contribution,
-                answer=1,
-                count=counts[0],
-            ),
-            baker.make(
-                RatingAnswerCounter,
-                question=question_yesno,
-                contribution=self.general_contribution,
-                answer=5,
-                count=counts[1],
-            ),
-        ]
+        answer_counters = make_rating_answer_counters(question_yesno, self.general_contribution, {1: 57, 5: 43})
 
         result = RatingResult(question_yesno, answer_counters)
         distribution = unipolarized_distribution(result)
@@ -524,9 +384,7 @@ class TestCalculateAverageDistribution(TestCase):
         self.assertAlmostEqual(distribution[4], 0.43)
 
     def test_calculate_average_course_distribution(self):
-        baker.make(
-            RatingAnswerCounter, question=self.question_grade, contribution=self.contribution1, answer=1, count=2
-        )
+        make_rating_answer_counters(self.question_grade, self.contribution1, {1: 2})
 
         course = self.evaluation.course
         single_result = baker.make(
@@ -546,8 +404,7 @@ class TestCalculateAverageDistribution(TestCase):
         contribution = baker.make(
             Contribution, evaluation=single_result, contributor=None, questionnaires=[single_result_questionnaire]
         )
-        baker.make(RatingAnswerCounter, question=single_result_question, contribution=contribution, answer=2, count=1)
-        baker.make(RatingAnswerCounter, question=single_result_question, contribution=contribution, answer=3, count=1)
+        make_rating_answer_counters(single_result_question, contribution, {2: 1, 3: 1})
         cache_results(single_result)
         cache_results(self.evaluation)
 

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -221,7 +221,7 @@ class TestResultsViewContributionWarning(WebTest):
         cls.url = "/results/semester/%s/evaluation/%s" % (cls.semester.id, cls.evaluation.id)
 
     def test_many_answers_evaluation_no_warning(self):
-        make_rating_answer_counters(self.likert_question, self.contribution, {3: 10})
+        make_rating_answer_counters(self.likert_question, self.contribution, [0, 0, 10, 0, 0])
         cache_results(self.evaluation)
         page = self.app.get(self.url, user=self.manager, status=200)
         self.assertNotIn("Only a few participants answered these questions.", page)
@@ -232,7 +232,7 @@ class TestResultsViewContributionWarning(WebTest):
         self.assertNotIn("Only a few participants answered these questions.", page)
 
     def test_few_answers_evaluation_show_warning(self):
-        make_rating_answer_counters(self.likert_question, self.contribution, {3: 3})
+        make_rating_answer_counters(self.likert_question, self.contribution, [0, 0, 3, 0, 0])
         cache_results(self.evaluation)
         page = self.app.get(self.url, user=self.manager, status=200)
         self.assertIn("Only a few participants answered these questions.", page)
@@ -369,7 +369,7 @@ class TestResultsSemesterEvaluationDetailView(WebTestStaffMode):
         participants = baker.make(UserProfile, _bulk_create=True, _quantity=20)
         evaluation.participants.set(participants)
         evaluation.voters.set(participants)
-        make_rating_answer_counters(likert_question, evaluation.general_contribution, {1: 20})
+        make_rating_answer_counters(likert_question, evaluation.general_contribution, [20, 0, 0, 0, 0])
         cache_results(evaluation)
 
         url = f"/results/semester/{self.semester.id}/evaluation/{evaluation.id}"

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -20,11 +20,10 @@ from evap.evaluation.models import (
     Evaluation,
     Question,
     Questionnaire,
-    RatingAnswerCounter,
     Semester,
     UserProfile,
 )
-from evap.evaluation.tests.tools import let_user_vote_for_evaluation, make_manager
+from evap.evaluation.tests.tools import let_user_vote_for_evaluation, make_manager, make_rating_answer_counters
 from evap.results.exporters import TextAnswerExporter
 from evap.results.tools import cache_results
 from evap.results.views import get_evaluations_with_prefetched_data
@@ -222,9 +221,7 @@ class TestResultsViewContributionWarning(WebTest):
         cls.url = "/results/semester/%s/evaluation/%s" % (cls.semester.id, cls.evaluation.id)
 
     def test_many_answers_evaluation_no_warning(self):
-        baker.make(
-            RatingAnswerCounter, question=self.likert_question, contribution=self.contribution, answer=3, count=10
-        )
+        make_rating_answer_counters(self.likert_question, self.contribution, {3: 10})
         cache_results(self.evaluation)
         page = self.app.get(self.url, user=self.manager, status=200)
         self.assertNotIn("Only a few participants answered these questions.", page)
@@ -235,9 +232,7 @@ class TestResultsViewContributionWarning(WebTest):
         self.assertNotIn("Only a few participants answered these questions.", page)
 
     def test_few_answers_evaluation_show_warning(self):
-        baker.make(
-            RatingAnswerCounter, question=self.likert_question, contribution=self.contribution, answer=3, count=3
-        )
+        make_rating_answer_counters(self.likert_question, self.contribution, {3: 3})
         cache_results(self.evaluation)
         page = self.app.get(self.url, user=self.manager, status=200)
         self.assertIn("Only a few participants answered these questions.", page)
@@ -295,27 +290,9 @@ class TestResultsSemesterEvaluationDetailView(WebTestStaffMode):
         self.evaluation.general_contribution.questionnaires.set([top_questionnaire, bottom_questionnaire])
         self.contribution.questionnaires.set([contributor_questionnaire])
 
-        baker.make(
-            RatingAnswerCounter,
-            question=top_likert_question,
-            contribution=self.evaluation.general_contribution,
-            answer=2,
-            count=100,
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=contributor_likert_question,
-            contribution=self.contribution,
-            answer=1,
-            count=100,
-        )
-        baker.make(
-            RatingAnswerCounter,
-            question=bottom_likert_question,
-            contribution=self.evaluation.general_contribution,
-            answer=3,
-            count=100,
-        )
+        make_rating_answer_counters(top_likert_question, self.evaluation.general_contribution)
+        make_rating_answer_counters(contributor_likert_question, self.contribution)
+        make_rating_answer_counters(bottom_likert_question, self.evaluation.general_contribution)
 
         cache_results(self.evaluation)
 
@@ -343,7 +320,7 @@ class TestResultsSemesterEvaluationDetailView(WebTestStaffMode):
         contribution = baker.make(
             Contribution, evaluation=self.evaluation, questionnaires=[questionnaire], contributor=contributor
         )
-        baker.make(RatingAnswerCounter, question=likert_question, contribution=contribution, answer=3, count=100)
+        make_rating_answer_counters(likert_question, contribution)
 
         cache_results(self.evaluation)
 
@@ -392,13 +369,7 @@ class TestResultsSemesterEvaluationDetailView(WebTestStaffMode):
         participants = baker.make(UserProfile, _bulk_create=True, _quantity=20)
         evaluation.participants.set(participants)
         evaluation.voters.set(participants)
-        baker.make(
-            RatingAnswerCounter,
-            question=likert_question,
-            contribution=evaluation.general_contribution,
-            answer=1,
-            count=20,
-        )
+        make_rating_answer_counters(likert_question, evaluation.general_contribution, {1: 20})
         cache_results(evaluation)
 
         url = f"/results/semester/{self.semester.id}/evaluation/{evaluation.id}"

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -34,6 +34,7 @@ from evap.evaluation.tests.tools import (
     let_user_vote_for_evaluation,
     make_manager,
     create_evaluation_with_responsible_and_editor,
+    make_rating_answer_counters,
 )
 from evap.results.tools import cache_results, get_results
 from evap.rewards.models import SemesterActivation, RewardPointGranting
@@ -1836,17 +1837,7 @@ class TestSingleResultEditView(WebTestStaffModeWith200Check):
         contribution.save()
 
         question = Questionnaire.single_result_questionnaire().questions.get()
-        answer_counts = {1: 5, 2: 15, 3: 40, 4: 60, 5: 30}
-
-        baker.make(
-            RatingAnswerCounter,
-            question=question,
-            contribution=contribution,
-            _bulk_create=True,
-            _quantity=len(answer_counts),
-            answer=iter(answer_counts.keys()),
-            count=iter(answer_counts.values()),
-        )
+        make_rating_answer_counters(question, contribution, {1: 5, 2: 15, 3: 40, 4: 60, 5: 30})
 
 
 class TestEvaluationPreviewView(WebTestStaffModeWith200Check):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1837,7 +1837,7 @@ class TestSingleResultEditView(WebTestStaffModeWith200Check):
         contribution.save()
 
         question = Questionnaire.single_result_questionnaire().questions.get()
-        make_rating_answer_counters(question, contribution, {1: 5, 2: 15, 3: 40, 4: 60, 5: 30})
+        make_rating_answer_counters(question, contribution, [5, 15, 40, 60, 30])
 
 
 class TestEvaluationPreviewView(WebTestStaffModeWith200Check):


### PR DESCRIPTION
Admittedly, the syntax is not 100% intuitive. An alternative for the dict would be a list, instead of 
```
make_rating_answer_counters(rating_question, contribution, {1:15, 2:12, 4:100, 5:2})
make_rating_answer_counters(rating_question, contribution, {2:6})
make_rating_answer_counters(yesno_question, contribution, {1:15, 5:2})
make_rating_answer_counters(bipolar_question, contribution, {-3:20, -2:15, 0:1, 1:15, 3:2})
```
we could have 
```
make_rating_answer_counters(rating_question, contribution, [15, 12, 0, 100, 2])
make_rating_answer_counters(rating_question, contribution, [0, 6, 0, 0, 0])
make_rating_answer_counters(yesno_question, contribution, [15, 2])
make_rating_answer_counters(bipolar_question, contribution, [20, 15, 0, 1, 15, 0, 2])
```

Syntactically I like the lists a bit more, but one would always need to specify all answers (...but maybe that's an advantage actually?) and the helper method would require more code for knowing which question types need which answers, a different default argument per type, and for filtering out counters with zero answers. What do you think?