### PR TITLE
Prevent deleting contributors voted for in the form

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1046,9 +1046,10 @@ class Contribution(LoggedModel):
 
     @property
     def can_be_deleted(self):
-        return (
+        return (self.pk is None and self.is_general) or (
             not RatingAnswerCounter.objects.filter(contribution=self).exists()
             and not TextAnswer.objects.filter(contribution=self).exists()
+            and not self.is_general
         )
 
     @property

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1045,16 +1045,6 @@ class Contribution(LoggedModel):
         return self.contributor_id is None
 
     @property
-    def can_be_deleted(self):
-        if self.pk is None:
-            return True  # not stored in the DB. Required so temporary instances in the formset can be deleted.
-
-        if not self.ratinganswercounter_set.exists() and not self.textanswer_set.exists():
-            return True
-
-        return False
-
-    @property
     def object_to_attach_logentries_to(self):
         return Evaluation, self.evaluation_id
 

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1046,14 +1046,13 @@ class Contribution(LoggedModel):
 
     @property
     def can_be_deleted(self):
-        if self.is_general:
-            # The pk is used to distinct the general contribution of an evaluation from a new contribution in a ContributionFormset.
-            return self.pk is None
-        else:
-            return (
-                not RatingAnswerCounter.objects.filter(contribution=self).exists()
-                and not TextAnswer.objects.filter(contribution=self).exists()
-            )
+        if self.pk is None:
+            return True  # not stored in the DB. Required so temporary instances in the formset can be deleted.
+
+        if not self.ratinganswercounter_set.exists() and not self.textanswer_set.exists():
+            return True
+
+        return False
 
     @property
     def object_to_attach_logentries_to(self):

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1045,6 +1045,13 @@ class Contribution(LoggedModel):
         return self.contributor_id is None
 
     @property
+    def can_be_deleted(self):
+        return (
+            not RatingAnswerCounter.objects.filter(contribution=self).exists()
+            and not TextAnswer.objects.filter(contribution=self).exists()
+        )
+
+    @property
     def object_to_attach_logentries_to(self):
         return Evaluation, self.evaluation_id
 

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1046,11 +1046,14 @@ class Contribution(LoggedModel):
 
     @property
     def can_be_deleted(self):
-        return (self.pk is None and self.is_general) or (
-            not RatingAnswerCounter.objects.filter(contribution=self).exists()
-            and not TextAnswer.objects.filter(contribution=self).exists()
-            and not self.is_general
-        )
+        if self.is_general:
+            # The pk is used to distinct the general contribution of an evaluation from a new contribution in a ContributionFormset.
+            return self.pk is None
+        else:
+            return (
+                not RatingAnswerCounter.objects.filter(contribution=self).exists()
+                and not TextAnswer.objects.filter(contribution=self).exists()
+            )
 
     @property
     def object_to_attach_logentries_to(self):

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -66,7 +66,7 @@
                         {% include 'bootstrap_form_errors.html' with errors=form.label.errors %}
                     </td>
                     <td>
-                        {% if editable and form.instance.can_be_deleted %}
+                        {% if editable and form.show_delete_button %}
                             {% include 'bootstrap_form_field_widget.html' with field=form.DELETE class="d-none" %}
                         {% endif %}
                     </td>

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -66,7 +66,7 @@
                         {% include 'bootstrap_form_errors.html' with errors=form.label.errors %}
                     </td>
                     <td>
-                        {% if editable and form.is_deletable.value %}
+                        {% if editable and form.can_be_deleted %}
                             {% include 'bootstrap_form_field_widget.html' with field=form.DELETE class="d-none" %}
                         {% endif %}
                     </td>

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -66,7 +66,7 @@
                         {% include 'bootstrap_form_errors.html' with errors=form.label.errors %}
                     </td>
                     <td>
-                        {% if editable and form.can_be_deleted %}
+                        {% if editable and form.instance.can_be_deleted %}
                             {% include 'bootstrap_form_field_widget.html' with field=form.DELETE class="d-none" %}
                         {% endif %}
                     </td>

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -66,9 +66,9 @@
                         {% include 'bootstrap_form_errors.html' with errors=form.label.errors %}
                     </td>
                     <td>
-                    {% if editable %}
-                        {% include 'bootstrap_form_field_widget.html' with field=form.DELETE class="d-none" %}
-                    {% endif %}
+                        {% if editable and form.is_deletable.value %}
+                            {% include 'bootstrap_form_field_widget.html' with field=form.DELETE class="d-none" %}
+                        {% endif %}
                     </td>
                 </tr>
             {% endfor %}

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -495,7 +495,6 @@ class ContributionForm(forms.ModelForm):
 
         if self.instance.contributor:
             self.fields["contributor"].queryset |= UserProfile.objects.filter(pk=self.instance.contributor.pk)
-            self.fields["contributor"].initial = self.instance.contributor
 
         self.fields["questionnaires"].queryset = (
             Questionnaire.objects.contributor_questionnaires()
@@ -506,8 +505,6 @@ class ContributionForm(forms.ModelForm):
             )
             .distinct()
         )
-
-        self.can_be_deleted = self.instance.can_be_deleted and not self.instance.is_general
 
         if self.instance.pk:
             self.fields["does_not_contribute"].initial = not self.instance.questionnaires.exists()

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -507,6 +507,8 @@ class ContributionForm(forms.ModelForm):
             .distinct()
         )
 
+        self.can_be_deleted = self.instance.can_be_deleted and not self.instance.is_general
+
         if self.instance.pk:
             self.fields["does_not_contribute"].initial = not self.instance.questionnaires.exists()
 
@@ -654,21 +656,6 @@ class ContributionFormSet(BaseInlineFormSet):
         data = self.handle_moved_contributors(data, **kwargs)
         super().__init__(data, **kwargs)
         self.queryset = self.instance.contributions.exclude(contributor=None)
-
-    def add_fields(self, form, index):
-        super().add_fields(form, index)
-        contribution = (
-            Contribution.objects.get(
-                contributor=form.fields["contributor"].initial, evaluation=form.fields["evaluation"].initial
-            )
-            if form.fields["contributor"].initial
-            else None
-        )
-        form.fields["is_deletable"] = forms.BooleanField(
-            widget=forms.HiddenInput(),
-            disabled=True,
-            initial=contribution.can_be_deleted if contribution else True,
-        )
 
     def handle_deleted_and_added_contributions(self):
         """

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -517,6 +517,16 @@ class ContributionForm(forms.ModelForm):
         if not self.cleaned_data.get("does_not_contribute") and not self.cleaned_data.get("questionnaires"):
             self.add_error("does_not_contribute", _("Select either this option or at least one questionnaire!"))
 
+    @property
+    def show_delete_button(self):
+        if self.instance.pk is None:
+            return True  # not stored in the DB. Required so temporary instances in the formset can be deleted.
+
+        if not self.instance.ratinganswercounter_set.exists() and not self.instance.textanswer_set.exists():
+            return True
+
+        return False
+
 
 class ContributionCopyForm(ContributionForm):
     def __init__(self, data=None, instance=None, evaluation=None, **kwargs):

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -657,9 +657,13 @@ class ContributionFormSet(BaseInlineFormSet):
 
     def add_fields(self, form, index):
         super().add_fields(form, index)
-        contribution = Contribution.objects.filter(
-            contributor=form.fields["contributor"].initial, evaluation=form.fields["evaluation"].initial
-        ).first()
+        contribution = (
+            Contribution.objects.get(
+                contributor=form.fields["contributor"].initial, evaluation=form.fields["evaluation"].initial
+            )
+            if form.fields["contributor"].initial
+            else None
+        )
         form.fields["is_deletable"] = forms.BooleanField(
             widget=forms.HiddenInput(),
             disabled=True,

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -573,10 +573,11 @@ class ContributionFormsetTests(TestCase):
         baker.make(RatingAnswerCounter, contribution=contribution1)
 
         contribution_formset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0
+            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=1
         )
         formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation})
-        self.assertFalse(formset.forms[0].can_be_deleted)
+        self.assertFalse(formset.forms[0].instance.can_be_deleted)
+        self.assertTrue(formset.forms[1].instance.can_be_deleted)
 
 
 class ContributionFormset775RegressionTests(TestCase):

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -6,6 +6,7 @@ from model_bakery import baker
 
 from evap.contributor.forms import EvaluationForm as ContributorEvaluationForm
 from evap.evaluation.models import (
+    Answer,
     Contribution,
     Course,
     Degree,
@@ -13,10 +14,9 @@ from evap.evaluation.models import (
     Evaluation,
     Question,
     Questionnaire,
-    Answer,
     RatingAnswerCounter,
-    TextAnswer,
     Semester,
+    TextAnswer,
     UserProfile,
 )
 from evap.evaluation.tests.tools import (

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -567,15 +567,12 @@ class ContributionFormsetTests(TestCase):
             "This requires an update if a new answer type is added",
         )
         evaluation = baker.make(Evaluation)
-        user1 = baker.make(UserProfile)
-        questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
-        contribution1 = baker.make(
+        contribution = baker.make(
             Contribution,
             evaluation=evaluation,
-            contributor=user1,
             role=Contribution.Role.EDITOR,
             textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
-            questionnaires=[questionnaire],
+            _fill_optional=['contributor']
         )
 
         contribution_formset = inlineformset_factory(
@@ -585,7 +582,7 @@ class ContributionFormsetTests(TestCase):
         self.assertTrue(formset.forms[0].show_delete_button)
         self.assertTrue(formset.forms[1].show_delete_button)
 
-        baker.make(RatingAnswerCounter, contribution=contribution1)
+        baker.make(RatingAnswerCounter, contribution=contribution)
 
         self.assertFalse(formset.forms[0].show_delete_button)
         self.assertTrue(formset.forms[1].show_delete_button)

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -572,7 +572,7 @@ class ContributionFormsetTests(TestCase):
             evaluation=evaluation,
             role=Contribution.Role.EDITOR,
             textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
-            _fill_optional=['contributor']
+            _fill_optional=["contributor"],
         )
 
         contribution_formset = inlineformset_factory(

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -561,7 +561,11 @@ class ContributionFormsetTests(TestCase):
         """
         When answers for a contribution already exist, it should not be possible to remove that contribution.
         """
-        self.assertEqual(set(Answer.__subclasses__()), {RatingAnswerCounter, TextAnswer}, "This requires an update if a new answer type is added")
+        self.assertEqual(
+            set(Answer.__subclasses__()),
+            {RatingAnswerCounter, TextAnswer},
+            "This requires an update if a new answer type is added",
+        )
         evaluation = baker.make(Evaluation)
         user1 = baker.make(UserProfile)
         questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
@@ -573,7 +577,7 @@ class ContributionFormsetTests(TestCase):
             textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             questionnaires=[questionnaire],
         )
-        
+
         contribution_formset = inlineformset_factory(
             Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=1
         )

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -582,13 +582,13 @@ class ContributionFormsetTests(TestCase):
             Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=1
         )
         formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation})
-        self.assertTrue(formset.forms[0].instance.can_be_deleted)
-        self.assertTrue(formset.forms[1].instance.can_be_deleted)
+        self.assertTrue(formset.forms[0].show_delete_button)
+        self.assertTrue(formset.forms[1].show_delete_button)
 
         baker.make(RatingAnswerCounter, contribution=contribution1)
 
-        self.assertFalse(formset.forms[0].instance.can_be_deleted)
-        self.assertTrue(formset.forms[1].instance.can_be_deleted)
+        self.assertFalse(formset.forms[0].show_delete_button)
+        self.assertTrue(formset.forms[1].show_delete_button)
 
 
 class ContributionFormset775RegressionTests(TestCase):

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -573,12 +573,16 @@ class ContributionFormsetTests(TestCase):
             textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             questionnaires=[questionnaire],
         )
-        baker.make(RatingAnswerCounter, contribution=contribution1)
-
+        
         contribution_formset = inlineformset_factory(
             Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=1
         )
         formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation})
+        self.assertTrue(formset.forms[0].instance.can_be_deleted)
+        self.assertTrue(formset.forms[1].instance.can_be_deleted)
+
+        baker.make(RatingAnswerCounter, contribution=contribution1)
+
         self.assertFalse(formset.forms[0].instance.can_be_deleted)
         self.assertTrue(formset.forms[1].instance.can_be_deleted)
 

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -13,7 +13,9 @@ from evap.evaluation.models import (
     Evaluation,
     Question,
     Questionnaire,
+    Answer,
     RatingAnswerCounter,
+    TextAnswer,
     Semester,
     UserProfile,
 )
@@ -559,6 +561,7 @@ class ContributionFormsetTests(TestCase):
         """
         When answers for a contribution already exist, it should not be possible to remove that contribution.
         """
+        self.assertEqual(set(Answer.__subclasses__()), {RatingAnswerCounter, TextAnswer}, "This requires an update if a new answer type is added")
         evaluation = baker.make(Evaluation)
         user1 = baker.make(UserProfile)
         questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)


### PR DESCRIPTION
Fixes #1558

The delete button will not be displayed for contributions when editing an evaluation if they got voted for.