### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,23 @@ The easiest setup using [Vagrant](https://www.vagrantup.com) and [VirtualBox](ht
 
 1. Fork the Evap repository (using the Fork-button in the upper right corner on GitHub)
 
-2. If you're using Windows, you want to change git's autocrlf setting to "input" so git will not change line endings when checking out files, using this command:
+2. Windows users only (might not apply for the linux subsystem):
+   * Line endings: git's [`core.autocrlf` setting](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf) has to be `false` or `input` so git does not convert line endings on checkout, because the code will be used in a linux VM. We suggest using this command in Git Bash:
 
-        git config --global core.autocrlf input
+     ```bash
+     git config --global core.autocrlf input
+     ```
+
+   * Symlink Privileges: Our setup script for the VM creates symlinks in the repository folder. This requires either [explicitly allowing your user account to create symlinks](https://superuser.com/a/105381) or simply running the commands in step 3 as administrator. Thus, we suggest doing step 3 in a Git Bash that was started using "Run as administrator". Generally, this is only required for the first time executing `vagrant up`.
 
 3. Run the following commands on the command line to clone the repository, create the Vagrant VM and run the Django development server:
-
-        git clone --recurse-submodules https://github.com/<your_github_username>/EvaP.git
-        cd EvaP
-        vagrant up
-        vagrant ssh
-        ./manage.py run
+```bash
+git clone --recurse-submodules https://github.com/<your_github_username>/EvaP.git
+cd EvaP
+vagrant up
+vagrant ssh
+./manage.py run
+```
 
 4. Open your browser at http://localhost:8000/ and login with email ``evap@institution.example.com`` and password ``evap``
 


### PR DESCRIPTION
Related to #1648, but probably not a final solution(?)

It's a struggle to be as open/informing about what's happening on one side, but also keeping the text short and accessible to people that might be new to all this stuff, and might not know line endings or symlinks.

- Linux Subsystem on Windows: I don't know what steps are necessary there, but I'd guess, neither the git configuration nor the symlink privileges are required. We could test this if someone uses the subsystem by running `git config --global core.autocrlf` and `ln -s some_target some_source`.
- Technically, the symlink privileges will be required every time users use NPM inside the VM. That includes the first time setup or any later NPM usage. However, I think it's fair to only go into detail with this when users face this.