### PR TITLE
Fix codecov reporting status too early

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -8,6 +8,9 @@ coverage:
         target: auto
         threshold: 0.05%
         base: auto
+codecov:
+  notify:
+    after_n_builds: 2
 comment: false
 ignore:
   - "evap/development/views.py"


### PR DESCRIPTION
Currently, the coverage reports on github will report failure for the first few minutes after running the checks, because the coverage for render_pages was measured and reported.

This fixes it.