### PR TITLE
Fix bootstrap class for select fields

### DIFF
--- a/evap/evaluation/templates/django/forms/widgets/select.html
+++ b/evap/evaluation/templates/django/forms/widgets/select.html
@@ -1,4 +1,4 @@
-<select class="form-control" name="{{ widget.name }}"{% include 'django/forms/widgets/attrs.html' %}>
+<select class="form-select" name="{{ widget.name }}"{% include 'django/forms/widgets/attrs.html' %}>
     {% for group_name, group_choices, group_index in widget.optgroups %}
         {% if group_name %}
             <optgroup label="{{ group_name }}">

--- a/evap/results/templates/results_index.html
+++ b/evap/results/templates/results_index.html
@@ -91,7 +91,7 @@
                         <span class="fas fa-sort-alpha-up-alt"></span>
                     </label>
                 </div>
-                <select name="result-sort-column" class="form-control no-select2">
+                <select name="result-sort-column" class="form-select no-select2">
                     <option value="name-semester">{% trans 'Evaluation and semester' %}</option>
                     <option value="name">{% trans 'Evaluation' %}</option>
                     <option value="semester">{% trans 'Semester' %}</option>

--- a/evap/rewards/templates/rewards_index.html
+++ b/evap/rewards/templates/rewards_index.html
@@ -38,7 +38,7 @@
                                         <td>{{ event.name }}</td>
                                         <td>{{ event.redeem_end_date }}</td>
                                         <td class="text-end">
-                                            <select class="form-control" id="id_points-{{ event.id }}" name="points-{{ event.id }}" style="width:5em">
+                                            <select class="form-select" id="id_points-{{ event.id }}" name="points-{{ event.id }}" style="width:5em">
                                                 {% for p in point_selection %}
                                                     <option value="{{ p }}">{{ p }}</option>
                                                 {% endfor %}


### PR DESCRIPTION
see https://getbootstrap.com/docs/5.1/forms/select/
we used the wrong class before, resulting in a missing arrow in the dropdown (e.g. the order selection field on a narrow results index page).