### PR TITLE
Fix csrf protection

### DIFF
--- a/evap/context_processors.py
+++ b/evap/context_processors.py
@@ -1,6 +1,7 @@
 import random
 
 from django.conf import settings
+from django.middleware.csrf import get_token
 from django.utils.translation import get_language
 
 
@@ -12,3 +13,11 @@ def slogan(request):
 
 def debug(request):
     return {"debug": settings.DEBUG}
+
+
+def set_csrf_cookie(request):
+    # this does not add anything to the context, but ensures that the
+    # csrf cookie is set in every view. It is only set if
+    # get_token is called, which we don't do in our templates anymore.
+    get_token(request)
+    return {}

--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -27,7 +27,6 @@
     </h3>
 
     <form method="POST" class="form-horizontal multiselect-form select2form" id="evaluation-form">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 <h5 class="card-title">{% trans 'Course data' %}</h5>

--- a/evap/contributor/templates/contributor_index.html
+++ b/evap/contributor/templates/contributor_index.html
@@ -222,7 +222,6 @@
             <div class="modal-dialog" role="document">
                 <div class="modal-content">
                     <form method="POST">
-                        {% csrf_token %}
                         <div class="modal-header">
                             <h5 class="modal-title" id="{{ modal_id }}Label">{% trans 'Delegate preparation' %}</h5>
                             <button class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>

--- a/evap/contributor/tests/test_forms.py
+++ b/evap/contributor/tests/test_forms.py
@@ -131,8 +131,6 @@ class ContributionFormsetTests(TestCase):
 
 
 class ContributionFormsetWebTests(WebTest):
-    csrf_checks = False
-
     def test_form_ordering(self):
         """
         Asserts that the contribution formset is correctly sorted,

--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -1,16 +1,13 @@
 from django.core import mail
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import Contribution, Course, Evaluation, Questionnaire, UserProfile
-from evap.evaluation.tests.tools import WebTestWith200Check, create_evaluation_with_responsible_and_editor
+from evap.evaluation.tests.tools import WebTest, WebTestWith200Check, create_evaluation_with_responsible_and_editor
 
 TESTING_EVALUATION_ID = 2
 
 
 class TestContributorDirectDelegationView(WebTest):
-    csrf_checks = False
-
     @classmethod
     def setUpTestData(cls):
         cls.evaluation = baker.make(Evaluation, state=Evaluation.State.PREPARED)

--- a/evap/evaluation/templates/external_user_confirm_login.html
+++ b/evap/evaluation/templates/external_user_confirm_login.html
@@ -16,7 +16,6 @@
                     {% trans 'By clicking this button, you will be logged in and your login link will be invalidated.' %}
                 </p>
                 <form class="d-flex flex-column" role="form" method="POST">
-                    {% csrf_token %}
                     <div class="d-flex justify-content-center">
                         <button type="submit" class="btn btn-primary login-button">{% blocktrans %}Login as {{ username }}{% endblocktrans %}</button>
                     </div>

--- a/evap/evaluation/templates/index.html
+++ b/evap/evaluation/templates/index.html
@@ -25,7 +25,6 @@
                         </p>
                         <form id="email-login-form" class="d-flex flex-column" role="form"
                             action="{% url 'evaluation:index' %}{% if 'next' in request.GET %}?next={{ request.GET.next }}{% endif %}" method="POST">
-                            {% csrf_token %}
                             <input type="hidden" name="submit_type" value="login_email" />
                             {% for field in login_email_form %}
                                 {% include 'bootstrap_form_field.html' with field=field wide=True %}
@@ -40,7 +39,6 @@
             <div class="card border-dark">
                 <form id="request-login-form" class="card-body d-flex flex-column"
                     action="{% url 'evaluation:index' %}{% if 'next' in request.GET %}?next={{ request.GET.next }}{% endif %}" method="POST">
-                    {% csrf_token %}
                     <input type="hidden" name="submit_type" value="new_key" />
                     <h4 class="card-title text-dark">
                         {% trans 'External and D-School users' %}

--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -97,7 +97,6 @@
                 <div class="btn-group">
                     {% for language_code, language_name in languages %}
                         <form class="d-flex" method="post" action="{% url 'evaluation:set_lang' %}">
-                            {% csrf_token %}
                             <input name="language" type="hidden" value="{{ language_code }}">
                             <button type="submit"{% if current_language == language_code %} disabled{% endif %} onclick="setSpinnerIcon('span-set-language-{{ language_code }}')"
                                 class="btn btn-sm btn-navbar{% if current_language == language_code %} active{% endif %}" title="{{ language_name }}">
@@ -112,13 +111,11 @@
                     <li class="nav-item btn-switch-navbar my-auto ps-2">
                         <div class="btn-group">
                             <form class="d-flex" method="post" action="{% url 'staff:exit_staff_mode' %}">
-                                {% csrf_token %}
                                 <button type="submit" {% if user.is_staff %}class="btn btn-sm btn-navbar"{% else %}class="btn btn-sm btn-navbar active" disabled{% endif %} data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Regular mode' %}" onclick="setSpinnerIcon('span-exit-staff-mode')">
                                     <span id="span-exit-staff-mode" class="fas fa-user"></span>
                                 </button>
                             </form>
                             <form id="enter-staff-mode-form" class="d-flex" method="post" action="{% url 'staff:enter_staff_mode' %}">
-                                {% csrf_token %}
                                 <button type="submit" {% if user.is_staff %}class="btn btn-sm btn-navbar active" disabled{% else %}class="btn btn-sm btn-navbar"{% endif %} data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Staff mode' %}" onclick="setSpinnerIcon('span-enter-staff-mode')">
                                     <span id="span-enter-staff-mode" class="fas fa-briefcase"></span>
                                 </button>

--- a/evap/evaluation/templates/profile.html
+++ b/evap/evaluation/templates/profile.html
@@ -58,7 +58,6 @@
         {% if user.is_editor %}
             <div class="col-6">
                 <form id="settings-form" method="POST" class="form-horizontal multiselect-form settings-form" enctype="multipart/form-data">
-                    {% csrf_token %}
                     {% include 'bootstrap_form_errors.html' with errors=form.non_field_errors %}
                     <div class="card">
                         <div class="card-body">

--- a/evap/evaluation/tests/test_auth.py
+++ b/evap/evaluation/tests/test_auth.py
@@ -13,8 +13,6 @@ from evap.evaluation.tests.tools import WebTest
 
 
 class LoginTests(WebTest):
-    csrf_checks = False
-
     @classmethod
     def setUpTestData(cls):
         cls.external_user = baker.make(UserProfile, email="extern@extern.com")

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -6,7 +6,6 @@ from django.core import mail
 from django.core.cache import caches
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import (
@@ -24,6 +23,7 @@ from evap.evaluation.models import (
     UserProfile,
 )
 from evap.evaluation.tests.tools import (
+    WebTest,
     let_user_vote_for_evaluation,
     make_contributor,
     make_editor,

--- a/evap/evaluation/tests/test_views.py
+++ b/evap/evaluation/tests/test_views.py
@@ -108,6 +108,17 @@ class TestChangeLanguageView(WebTest):
         self.assertEqual(user.language, "en")
 
 
+class TestCsrfVerification(WebTest):
+    url = "/set_lang"
+    csrf_checks = True
+
+    def test_post_fails(self):
+        user = baker.make(UserProfile, email="tester@institution.example.com", language="en")
+
+        response = self.app.post(self.url, params={"language": "en"}, user=user, status=403)
+        self.assertIn("CSRF verification failed", response.body.decode())
+
+
 class TestProfileView(WebTest):
     url = "/profile"
 

--- a/evap/evaluation/tests/test_views.py
+++ b/evap/evaluation/tests/test_views.py
@@ -1,11 +1,10 @@
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import Group
 from django.core import mail
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import UserProfile
-from evap.evaluation.tests.tools import WebTestWith200Check, create_evaluation_with_responsible_and_editor
+from evap.evaluation.tests.tools import WebTest, WebTestWith200Check, create_evaluation_with_responsible_and_editor
 
 
 class TestIndexView(WebTest):
@@ -86,8 +85,6 @@ class TestFAQView(WebTestWith200Check):
 
 
 class TestContactEmail(WebTest):
-    csrf_checks = False
-
     def test_sends_mail(self):
         user = baker.make(UserProfile, email="user@institution.example.com")
         self.app.post(
@@ -101,7 +98,6 @@ class TestContactEmail(WebTest):
 
 class TestChangeLanguageView(WebTest):
     url = "/set_lang"
-    csrf_checks = False
 
     def test_changes_language(self):
         user = baker.make(UserProfile, email="tester@institution.example.com", language="de")

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.http.request import QueryDict
 from django.utils import timezone
-from django_webtest import WebTest
+from django_webtest import WebTest as OriginalWebTest
 from model_bakery import baker
 
 from evap.evaluation.models import (
@@ -81,6 +81,10 @@ def render_pages(test_item):
                 html_file.write(content)
 
     return decorator
+
+
+class WebTest(OriginalWebTest):
+    csrf_checks = False
 
 
 class WebTestWith200Check(WebTest):

--- a/evap/evaluation/views.py
+++ b/evap/evaluation/views.py
@@ -16,7 +16,6 @@ from django.views.i18n import set_language
 from evap.evaluation.forms import DelegatesForm, LoginEmailForm, NewKeyForm
 from evap.evaluation.models import EmailTemplate, FaqSection, Semester
 from evap.middleware import no_login_required
-from evap.staff.tools import delete_navbar_cache_for_users
 
 logger = logging.getLogger(__name__)
 
@@ -95,9 +94,6 @@ def index(request):
             openid_active=settings.ACTIVATE_OPEN_ID_LOGIN,
         )
         return render(request, "index.html", template_data)
-
-    # the cached navbar might contain CSRF tokens that are invalid after a new login
-    delete_navbar_cache_for_users([request.user])
 
     # check for redirect variable
     redirect_to = request.GET.get("next", None)

--- a/evap/grades/templates/grades_upload_form.html
+++ b/evap/grades/templates/grades_upload_form.html
@@ -23,7 +23,6 @@
         {% endif %}
     </h3>
     <form method="POST" class="form-horizontal" enctype="multipart/form-data">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 {% include 'bootstrap_form.html' with form=form %}

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -2,16 +2,14 @@ from datetime import date, datetime, timedelta
 
 from django.contrib.auth.models import Group
 from django.core import mail
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import Contribution, Course, Evaluation, Questionnaire, Semester, UserProfile
+from evap.evaluation.tests.tools import WebTest
 from evap.grades.models import GradeDocument
 
 
 class GradeUploadTest(WebTest):
-    csrf_checks = False
-
     @classmethod
     def setUpTestData(cls):
         cls.grade_publisher = baker.make(

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -9,7 +9,6 @@ from django.db import connection
 from django.test import override_settings
 from django.test.testcases import TestCase
 from django.test.utils import CaptureQueriesContext
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import (
@@ -24,6 +23,7 @@ from evap.evaluation.models import (
     UserProfile,
 )
 from evap.evaluation.tests.tools import (
+    WebTest,
     let_user_vote_for_evaluation,
     make_manager,
     make_rating_answer_counters,

--- a/evap/rewards/templates/rewards_index.html
+++ b/evap/rewards/templates/rewards_index.html
@@ -20,7 +20,6 @@
             {% if total_points_available > 0 %}
                 {% if events %}
                     <form id="reward-redemption-form" action="#" method="POST" class="form-horizontal multiselect-form">
-                        {% csrf_token %}
 
                         <table class="table table-striped table-vertically-aligned mb-3">
                             <thead>

--- a/evap/rewards/templates/rewards_reward_point_redemption_event_form.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_event_form.html
@@ -9,7 +9,6 @@
 {% block content %}
     {{ block.super }}
     <form id="reward-point-redemption-event-form" method="POST" class="form-horizontal">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 {% include 'bootstrap_form.html' with form=form %}

--- a/evap/rewards/tests/test_tools.py
+++ b/evap/rewards/tests/test_tools.py
@@ -16,8 +16,6 @@ from evap.rewards.tools import reward_points_of_user
     ]
 )
 class TestGrantRewardPoints(WebTest):
-    csrf_checks = False
-
     @classmethod
     def setUpTestData(cls):
         cls.student = baker.make(UserProfile, email="student@institution.example.com")

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -2,11 +2,10 @@ from datetime import date, timedelta
 
 from django.test import override_settings
 from django.urls import reverse
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import Course, Evaluation, Semester, UserProfile
-from evap.evaluation.tests.tools import make_manager
+from evap.evaluation.tests.tools import WebTest, make_manager
 from evap.rewards.models import (
     RewardPointGranting,
     RewardPointRedemption,
@@ -19,7 +18,6 @@ from evap.staff.tests.utils import WebTestStaffMode, WebTestStaffModeWith200Chec
 
 class TestEventDeleteView(WebTestStaffMode):
     url = reverse("rewards:reward_point_redemption_event_delete")
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
@@ -43,7 +41,6 @@ class TestEventDeleteView(WebTestStaffMode):
 
 class TestIndexView(WebTest):
     url = reverse("rewards:index")
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
@@ -96,7 +93,6 @@ class TestEventsView(WebTestStaffModeWith200Check):
 
 class TestEventCreateView(WebTestStaffMode):
     url = reverse("rewards:reward_point_redemption_event_create")
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
@@ -119,7 +115,6 @@ class TestEventCreateView(WebTestStaffMode):
 
 class TestEventEditView(WebTestStaffMode):
     url = reverse("rewards:reward_point_redemption_event_edit", args=[1])
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
@@ -158,7 +153,6 @@ class TestExportView(WebTestStaffModeWith200Check):
 )
 class TestSemesterActivationView(WebTestStaffMode):
     url = "/rewards/reward_semester_activation/1/"
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -249,6 +249,7 @@ TEMPLATES = [
                 "django.template.context_processors.static",
                 "django.template.context_processors.request",
                 "django.contrib.messages.context_processors.messages",
+                "evap.context_processors.set_csrf_cookie",
                 "evap.context_processors.slogan",
                 "evap.context_processors.debug",
             ],
@@ -392,7 +393,7 @@ try:
 except ImportError:
     pass
 
-TESTING = "test" in sys.argv
+TESTING = "test" in sys.argv or "render_pages" in sys.argv
 
 # speed up tests
 if TESTING:

--- a/evap/staff/templates/staff_course_copyform.html
+++ b/evap/staff/templates/staff_course_copyform.html
@@ -6,7 +6,6 @@
         {% trans 'Create copy of course' %}
     </h3>
     <form id="course-form" method="POST" class="form-horizontal multiselect-form select2form">
-        {% csrf_token %}
 
         <div class="card mb-3">
             <div class="card-body">

--- a/evap/staff/templates/staff_course_form.html
+++ b/evap/staff/templates/staff_course_form.html
@@ -10,7 +10,6 @@
         {% endif %}
     </h3>
     <form id="course-form" method="POST" class="form-horizontal multiselect-form select2form">
-        {% csrf_token %}
 
         <div class="card mb-3">
             <div class="card-body">

--- a/evap/staff/templates/staff_course_type_index.html
+++ b/evap/staff/templates/staff_course_type_index.html
@@ -13,7 +13,6 @@
     </div>
 
     <form id="course-type-form" method="POST" enctype="multipart/form-data" class="form-horizontal select2form">
-        {% csrf_token %}
         {{ formset.management_form }}
 
         <div class="card mb-3">

--- a/evap/staff/templates/staff_course_type_merge.html
+++ b/evap/staff/templates/staff_course_type_merge.html
@@ -29,7 +29,6 @@
     </div>
 
     <form id="course-type-merge-form" method="POST" class="form-horizontal">
-        {% csrf_token %}
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
                 <button type="submit" class="btn btn-primary">{% trans 'Merge course types' %}</button>

--- a/evap/staff/templates/staff_course_type_merge_selection.html
+++ b/evap/staff/templates/staff_course_type_merge_selection.html
@@ -11,7 +11,6 @@
     <h3>{% trans 'Merge course types' %}</h3>
 
     <form id="course-type-merge-selection-form" method="POST" class="form-horizontal">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 <p>{% trans 'Select the course types you want to merge.' %}</p>

--- a/evap/staff/templates/staff_degree_index.html
+++ b/evap/staff/templates/staff_degree_index.html
@@ -9,7 +9,6 @@
     {{ block.super }}
 
     <form id="degree-form" method="POST" enctype="multipart/form-data" class="form-horizontal select2form">
-        {% csrf_token %}
         {{ formset.management_form }}
 
         <div class="card mb-3">

--- a/evap/staff/templates/staff_evaluation_email.html
+++ b/evap/staff/templates/staff_evaluation_email.html
@@ -8,7 +8,6 @@
         <div class="alert alert-danger" role="alert">{% blocktrans %}Please fill out all required fields and select at least one recipient group.{% endblocktrans %}</div>
     {% endif %}
     <form id="evaluation-email-form" method="POST" class="form-horizontal">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 <fieldset>

--- a/evap/staff/templates/staff_evaluation_form.html
+++ b/evap/staff/templates/staff_evaluation_form.html
@@ -20,7 +20,6 @@
         </div>
     {% endif %}
     <form id="evaluation-form" method="POST" class="form-horizontal multiselect-form select2form">
-        {% csrf_token %}
 
         <div class="card mb-3">
             <div class="card-body">

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -4,7 +4,6 @@
     {{ block.super }}
 
     <form id="evaluation-operation-form" method="POST" class="form-horizontal">
-        {% csrf_token %}
         {% for evaluation in evaluations %}
             <input type="hidden" name="evaluation" value="{{ evaluation.id }}" />
         {% endfor %}

--- a/evap/staff/templates/staff_evaluation_person_management.html
+++ b/evap/staff/templates/staff_evaluation_person_management.html
@@ -10,7 +10,6 @@
     <div class="row mb-3">
         <div class="col">
             <form id="participant-import-form" method="POST" enctype="multipart/form-data" class="form-vertical h-100">
-                {% csrf_token %}
                 <div class="card">
                     <div class="card-body h-100">
                         <h4 class="card-title">{% trans 'Import participants' %}</h4>
@@ -38,7 +37,6 @@
         </div>
         <div class="col">
             <form id="participant-copy-form" method="POST" enctype="multipart/form-data" class="form-vertical h-100">
-                {% csrf_token %}
                 <div class="card h-100">
                     <div class="card-body">
                         <h4 class="card-title">{% trans 'Copy participants' %}</h4>
@@ -58,7 +56,6 @@
     <div class="row mb-3">
         <div class="col">
             <form id="contributor-import-form" method="POST" enctype="multipart/form-data" class="form-vertical h-100">
-                {% csrf_token %}
                 <div class="card h-100">
                     <div class="card-body">
                         <h4 class="card-title">{% trans 'Import contributors' %}</h4>
@@ -87,7 +84,6 @@
         </div>
         <div class="col">
             <form id="contributor-copy-form" method="POST" enctype="multipart/form-data" class="form-vertical h-100">
-                {% csrf_token %}
                 <div class="card h-100">
                     <div class="card-body">
                         <h4 class="card-title">{% trans 'Copy contributors' %}</h4>
@@ -107,7 +103,6 @@
     <div class="row">
         <div class="col">
             <form id="login-key-export-form" method="POST" class="form-vertical" action="{% url 'staff:evaluation_login_key_export' semester.id evaluation.id %}">
-                {% csrf_token %}
                 <div class="card">
                     <div class="card-body">
                         <h4 class="card-title">{% trans 'Export login keys' %}</h4>

--- a/evap/staff/templates/staff_evaluation_textanswer_edit.html
+++ b/evap/staff/templates/staff_evaluation_textanswer_edit.html
@@ -10,7 +10,6 @@
     {{ block.super }}
     <h3>{% trans 'Text answer' %}</h3>
     <form id="textanswer-edit-form" method="POST" class="form-horizontal">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 {% include 'bootstrap_form.html' with form=form %}

--- a/evap/staff/templates/staff_faq_index.html
+++ b/evap/staff/templates/staff_faq_index.html
@@ -9,7 +9,6 @@
     {{ block.super }}
 
     <form method="POST" class="form-horizontal" enctype="multipart/form-data">
-        {% csrf_token %}
         {{ formset.management_form }}
 
         <div class="card mb-3">

--- a/evap/staff/templates/staff_faq_section.html
+++ b/evap/staff/templates/staff_faq_section.html
@@ -10,7 +10,6 @@
     {{ block.super }}
 
     <form method="POST" class="form-horizontal" enctype="multipart/form-data">
-        {% csrf_token %}
         {{ formset.management_form }}
 
         <div class="card mb-3">

--- a/evap/staff/templates/staff_questionnaire_form.html
+++ b/evap/staff/templates/staff_questionnaire_form.html
@@ -8,7 +8,6 @@
         </div>
     {% endif %}
     <form id="questionnaire-form" method="POST" class="form-horizontal select2form">
-        {% csrf_token %}
         <fieldset>
             <div class="card mb-3">
                 <div class="card-body">

--- a/evap/staff/templates/staff_semester_export.html
+++ b/evap/staff/templates/staff_semester_export.html
@@ -12,7 +12,6 @@
     <h3>{% trans 'Export' %} {{ semester.name }}</h3>
 
     <form id="semester-export-form" method="POST" class="form-horizontal multiselect-form">
-        {% csrf_token %}
 
         {{ formset.management_form }}
 

--- a/evap/staff/templates/staff_semester_form.html
+++ b/evap/staff/templates/staff_semester_form.html
@@ -3,7 +3,6 @@
 {% block content %}
     {{ block.super }}
     <form id="semester-form" method="POST" class="form-horizontal">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 {% include 'bootstrap_form.html' with form=form %}

--- a/evap/staff/templates/staff_semester_import.html
+++ b/evap/staff/templates/staff_semester_import.html
@@ -23,7 +23,6 @@
                         {% trans 'Copy headers to clipboard' %}</button>).
                     {% trans 'This will create all containing participants, contributors and courses and connect them. It will also set the entered values as default for all evaluations.' %}
                 </p>
-                {% csrf_token %}
                 {% include 'bootstrap_form.html' with form=excel_form %}
             </div>
         </div>

--- a/evap/staff/templates/staff_semester_questionnaire_assign_form.html
+++ b/evap/staff/templates/staff_semester_questionnaire_assign_form.html
@@ -10,7 +10,6 @@
     <h3>{% trans 'Assign questionnaires' %}</h3>
 
     <form id="questionnaire-assign-form" method="POST" class="form-horizontal multiselect-form">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 <p>{% trans 'Select the questionnaires which shall be assigned each of these course types and the contributors. This will only change evaluations in preparation. If you do select nothing, the currently applied questionnaires for the corresponding course type or contributor will not be changed.' %}</p>

--- a/evap/staff/templates/staff_semester_send_reminder.html
+++ b/evap/staff/templates/staff_semester_send_reminder.html
@@ -11,7 +11,6 @@
 {% block content %}
     {{ block.super }}
     <form id="send-reminder-form" method="POST" class="form-horizontal">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 <fieldset>

--- a/evap/staff/templates/staff_single_result_form.html
+++ b/evap/staff/templates/staff_single_result_form.html
@@ -10,7 +10,6 @@
         {% endif %}
     </h3>
     <form id="single-result-form" method="POST" class="form-horizontal multiselect-form">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 {% include 'bootstrap_form.html' with form=form %}

--- a/evap/staff/templates/staff_template_form.html
+++ b/evap/staff/templates/staff_template_form.html
@@ -12,7 +12,6 @@
     {{ block.super }}
 
     <form id="template-form" method="POST" enctype="multipart/form-data" class="form-horizontal multiselect-form">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body row">
                 <div class="col-9">

--- a/evap/staff/templates/staff_text_answer_warnings.html
+++ b/evap/staff/templates/staff_text_answer_warnings.html
@@ -12,7 +12,6 @@
     {{ block.super }}
 
     <form id="text-answer-warnings-form" method="POST" class="form-horizontal select2form">
-        {% csrf_token %}
         {{ formset.management_form }}
 
         <div class="card mb-3">

--- a/evap/staff/templates/staff_user_bulk_update.html
+++ b/evap/staff/templates/staff_user_bulk_update.html
@@ -11,7 +11,6 @@
     <h3>{% trans 'Bulk update users' %}</h3>
 
     <form id="user-bulk-update-form" enctype="multipart/form-data" method="POST" class="form-horizontal">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 <p>{% blocktrans %}Upload a text file containing one user per line formatted as "username,email". Users in this file will be updated or created. All users that are not in this file will be deleted if possible. If they can't be deleted they will be marked inactive.{% endblocktrans %}</p>

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -17,7 +17,6 @@
     <h3>{% if form.instance.id %}{% trans 'Edit user' %}{% else %}{% trans 'Create user' %}{% endif %}</h3>
 
     <form id="user-form" method="POST" enctype="multipart/form-data" class="form-horizontal multiselect-form">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 <div class="ms-auto col-sm-9 mb-3">

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -15,7 +15,6 @@
     {% include 'staff_message_rendering_template.html' with errors=errors warnings=warnings success_messages=success_messages %}
 
     <form id="user-import-form" method="POST" enctype="multipart/form-data" class="form-horizontal">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 <p>

--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -224,7 +224,6 @@
     </div>
 
     <form method="POST" class="form-horizontal">
-        {% csrf_token %}
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
                 {% if errors %}

--- a/evap/staff/templates/staff_user_merge_selection.html
+++ b/evap/staff/templates/staff_user_merge_selection.html
@@ -11,7 +11,6 @@
     <h3>{% trans 'Merge users' %}</h3>
 
     <form method="POST" class="form-horizontal">
-        {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
                 <p>{% trans 'Select the users you want to merge.' %}</p>

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -9,7 +9,6 @@ from django.core import mail
 from django.test import override_settings
 from django.test.testcases import TestCase
 from django.urls import reverse
-from django_webtest import WebTest
 from model_bakery import baker
 
 import evap.staff.fixtures.excel_files_test_data as excel_data
@@ -31,6 +30,7 @@ from evap.evaluation.models import (
 )
 from evap.evaluation.tests.tools import (
     FuzzyInt,
+    WebTest,
     create_evaluation_with_responsible_and_editor,
     let_user_vote_for_evaluation,
     make_manager,
@@ -685,7 +685,6 @@ class TestSemesterEditView(WebTestStaffMode):
 
 class TestSemesterDeleteView(WebTestStaffMode):
     url = "/staff/semester/delete"
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
@@ -794,7 +793,6 @@ class TestSemesterAssignView(WebTestStaffMode):
 
 class TestSemesterPreparationReminderView(WebTestStaffModeWith200Check):
     url = "/staff/semester/1/preparation_reminder"
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
@@ -2605,7 +2603,6 @@ class TestQuestionnaireCopyView(WebTestStaffMode):
 
 class TestQuestionnaireDeletionView(WebTestStaffMode):
     url = "/staff/questionnaire/delete"
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
@@ -2729,7 +2726,6 @@ class TestCourseTypeMergeView(WebTestStaffMode):
 
 class TestEvaluationTextAnswersUpdatePublishView(WebTest):
     url = reverse("staff:evaluation_textanswers_update_publish")
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
@@ -2825,8 +2821,6 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
 
 
 class TestEvaluationTextAnswersSkip(WebTestStaffMode):
-    csrf_checks = False
-
     def test_skip(self):
         manager = make_manager()
         evaluation = baker.make(
@@ -3028,7 +3022,6 @@ class TestSemesterQuestionnaireAssignment(WebTestStaffMode):
 
 class TestSemesterActiveStateBehaviour(WebTestStaffMode):
     url = "/staff/semester/make_active"
-    csrf_checks = False
 
     def test_make_other_semester_active(self):
         manager = make_manager()
@@ -3059,8 +3052,6 @@ class TestStaffMode(WebTest):
     url_exit = "/staff/exit_staff_mode"
 
     some_staff_url = "/staff/degrees/"
-
-    csrf_checks = False
 
     def test_staff_mode(self):
         manager = make_manager()

--- a/evap/staff/tests/utils.py
+++ b/evap/staff/tests/utils.py
@@ -2,9 +2,7 @@ import os
 import time
 from contextlib import contextmanager
 
-from django_webtest import WebTest
-
-from evap.evaluation.tests.tools import WebTestWith200Check
+from evap.evaluation.tests.tools import WebTest, WebTestWith200Check
 from evap.staff.tools import ImportType, generate_import_filename
 
 

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -2261,6 +2261,7 @@ def export_contributor_results_view(request, contributor_id):
 @staff_permission_required
 def enter_staff_mode(request):
     staff_mode.enter_staff_mode(request)
+    delete_navbar_cache_for_users([request.user])
     return redirect("evaluation:index")
 
 
@@ -2268,4 +2269,5 @@ def enter_staff_mode(request):
 @staff_permission_required
 def exit_staff_mode(request):
     staff_mode.exit_staff_mode(request)
+    delete_navbar_cache_for_users([request.user])
     return redirect("evaluation:index")

--- a/evap/static/ts/src/csrf-utils.ts
+++ b/evap/static/ts/src/csrf-utils.ts
@@ -35,25 +35,18 @@ $.ajaxSetup({
 // Add CSRF token to regular forms on submit.
 // This reduces boilerplate code in the templates and makes the form's HTML cacheable.
 for (const form of document.forms) {
+    let submitter: HTMLElement | null;
     form.addEventListener("submit", (ev: Event) => {
-        // in case a form gets submitted twice
-        if (form.querySelectorAll("input[name=csrfmiddlewaretoken]").length > 0) {
-            return;
-        }
-
-        const { submitter } = ev as SubmitEvent;
-        const action = submitter?.getAttribute("formaction") ?? form.getAttribute("action");
-        const method = submitter?.getAttribute("formmethod") ?? form.getAttribute("method");
+        submitter = (ev as SubmitEvent).submitter;
+    });
+    form.addEventListener("formdata", (ev: Event) => {
+        const action = submitter?.getAttribute("formaction") ?? form.action;
+        const method = submitter?.getAttribute("formmethod") ?? form.method;
 
         if (method && doesMethodRequireCsrfToken(method) && action && !isUrlCrossDomain(action)) {
-            const inputElement = document.createElement("input");
-            inputElement.setAttribute("type", "hidden");
-            inputElement.setAttribute("name", "csrfmiddlewaretoken");
-            inputElement.setAttribute("value", csrftoken);
-
-            form.insertAdjacentElement("afterbegin", inputElement);
+            (ev as FormDataEvent).formData.set("csrfmiddlewaretoken", csrftoken);
         }
-    });
+    })
 }
 
 export const testable = {

--- a/evap/static/ts/src/csrf-utils.ts
+++ b/evap/static/ts/src/csrf-utils.ts
@@ -28,6 +28,15 @@ $.ajaxSetup({
     },
 });
 
+const inputElement = document.createElement("input");
+inputElement.setAttribute("type", "hidden");
+inputElement.setAttribute("name", "csrfmiddlewaretoken");
+inputElement.setAttribute("value", csrftoken);
+
+for (const form of document.forms) {
+    form.insertAdjacentElement("afterbegin", inputElement.cloneNode() as Element);
+}
+
 export const testable = {
     getCookie,
     isMethodCsrfSafe,

--- a/evap/static/ts/tests/unit/csrf-utils.ts
+++ b/evap/static/ts/tests/unit/csrf-utils.ts
@@ -15,7 +15,7 @@ window.$ = require("../../../js/jquery-2.1.3.min");
 
 import { testable } from "src/csrf-utils";
 
-const { getCookie, isMethodCsrfSafe } = testable;
+const { getCookie, doesMethodRequireCsrfToken } = testable;
 
 test("parse cookie", () => {
     expect(getCookie("foo")).toBe("F00");
@@ -30,16 +30,17 @@ test.each([
     "HEAD",
     "OPTIONS",
     "TRACE",
-])("method %s is considered safe", method => {
-    expect(isMethodCsrfSafe(method)).toBe(true);
+])("method %s does not require CSRF token", method => {
+    expect(doesMethodRequireCsrfToken(method)).toBe(false);
 });
 
 test.each([
     "POST",
     "PUT",
     "DELETE",
-])("method %s is considered unsafe", method => {
-    expect(isMethodCsrfSafe(method)).toBe(false);
+    "PATCH",
+])("method %s does require CSRF token", method => {
+    expect(doesMethodRequireCsrfToken(method)).toBe(true);
 })
 
 test("send csrf token in request", () => {

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -38,7 +38,6 @@
     {% endif %}
     <h3 class="mb-3">{{ evaluation.full_name }} ({{ evaluation.course.semester.name }})</h3>
     <form id="student-vote-form" method="POST" class="form-horizontal">
-        {% csrf_token %}
 
         {% if small_evaluation_size_warning and not preview %}
             <div class="card card-outline-warning mb-3">

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -2,7 +2,6 @@ from functools import partial
 
 from django.test.utils import override_settings
 from django.urls import reverse
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import (
@@ -16,7 +15,7 @@ from evap.evaluation.models import (
     TextAnswer,
     UserProfile,
 )
-from evap.evaluation.tests.tools import FuzzyInt, WebTestWith200Check, render_pages
+from evap.evaluation.tests.tools import FuzzyInt, WebTest, WebTestWith200Check, render_pages
 from evap.student.tools import answer_field_id
 from evap.student.views import SUCCESS_MAGIC_STRING
 


### PR DESCRIPTION
This adds the CSRF token to all form via javascript instead of the templates, similar to how it's done already for all AJAX requests.

Fixes #1645. It became a bit hackier than I hoped and I don't mind if you reject this. Also you have to believe me I'm really not trying to save the navbar caching here :D 

The upside is that this removes a bunch of boilerplate code (in separate commits for easier review) (also it's caching-friendly, which might not count). The downside is that this prevents us from testing CSRF verification in our python tests, I had to remove a test that does this. As far as I understand, the TS tests we have cannot actually visit a page, interact with it, submit a form, and visit the redirect page. 

On the other hand, with this proposal, all previous breakages wouldn't have happened in the first place.

I believe we're not losing any security here as the validation is done on the server and that part is unchanged.