### PR TITLE
Add button to participate in evaluation from semester list

### DIFF
--- a/evap/student/templates/student_index_semester_evaluations_list.html
+++ b/evap/student/templates/student_index_semester_evaluations_list.html
@@ -65,7 +65,9 @@
                             {% endif %}
                             {% for evaluation in evaluations|dictsort:"name" %}
                                 <tr {# staff users should be able to access evaluations through the student index only if it actually has published results #}
-                                    {% if evaluation.state == evaluation.State.PUBLISHED and evaluation.can_publish_rating_results and not semester.results_are_archived and evaluation|can_results_page_be_seen_by:request.user %}
+                                    {% if evaluation.state == evaluation.State.IN_EVALUATION and evaluation.participates_in and not evaluation.voted_for and evaluation.is_in_evaluation_period %}
+                                        class="hover-row hover-row-info" data-url="{% url 'student:vote' evaluation.id %}"
+                                    {% elif evaluation.state == evaluation.State.PUBLISHED and evaluation.can_publish_rating_results and not semester.results_are_archived and evaluation|can_results_page_be_seen_by:request.user %}
                                         class="{% if course.evaluation_count > 1 %}evaluation-row{% else %}heading-row{% endif %} hover-row results-row" data-url="{% url 'results:evaluation_detail' semester.id evaluation.id %}"
                                     {% else %}
                                         class="{% if course.evaluation_count > 1 %}evaluation-row{% else %}heading-row{% endif %}"
@@ -78,7 +80,7 @@
                                                 {% if evaluation.state > evaluation.State.IN_EVALUATION %}
                                                     <span class="text text-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'You did not take part in this evaluation.' %}"><span class="far fa-fw fa-frown" aria-hidden="true"></span></span>
                                                 {% elif evaluation.state == evaluation.State.IN_EVALUATION %}
-                                                    <span class="text text-primary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'You can take part in this evaluation above.' %}"><span class="fas fa-fw fa-arrow-up" aria-hidden="true"></span></span>
+                                                    <span class="text text-primary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'You can take part in this evaluation.' %}"><span class="fas fa-fw fa-arrow-right" aria-hidden="true"></span></span>
                                                 {% else %}
                                                     <span class="text text-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'This evaluation will start in the future.' %}"><span class="far fa-fw fa-clock" aria-hidden="true"></span></span>
                                                 {% endif %}
@@ -154,7 +156,9 @@
                                     </td>
                                     <td class="text-end">
                                         {% if not semester.results_are_archived %}
-                                            {% if evaluation.state == evaluation.State.PUBLISHED %}
+                                            {% if evaluation.state == evaluation.State.IN_EVALUATION and evaluation.participates_in and not evaluation.voted_for and evaluation.is_in_evaluation_period  %}
+                                                <a class="btn btn-sm btn-primary btn-row-hover" href="{% url 'student:vote' evaluation.id %}">{% trans 'Evaluate' %}</a>
+                                            {% elif evaluation.state == evaluation.State.PUBLISHED %}
                                                 {% include 'evaluation_result_widget.html' with course_or_evaluation=evaluation %}
                                             {% elif not evaluation.participates_in or evaluation.voted_for and evaluation.State.IN_EVALUATION <= evaluation.state and evaluation.state <= evaluation.State.REVIEWED %}
                                                 <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% if evaluation|weight_info %}{% blocktrans with percentage=evaluation|weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktrans %} {% endif %}{% trans 'The results have not been published yet.' %}{% if evaluation.participates_in %} {% trans 'You will receive an email when the results are published.' %}{% endif %}">


### PR DESCRIPTION
adds a button to allow students to open the questionnaire of a currently running evaluation from the semester list on the student index page.
until now we had an arrow pointing up to lead to the list of open and upcoming evaluations, an unnecessary indirection.

![image](https://user-images.githubusercontent.com/1781719/154838446-c2c66e1a-8d10-43dd-8088-48ddcbd287c7.png)

