### PR TITLE
Delete answers for removed questionnaires

### DIFF
--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -136,7 +136,14 @@ def evaluation_view(request, evaluation_id):
         for field in cform.fields.values():
             field.disabled = True
 
-    template_data = dict(form=form, formset=formset, evaluation=evaluation, editable=False)
+    template_data = dict(
+        form=form,
+        formset=formset,
+        evaluation=evaluation,
+        editable=False,
+        questionnaires_with_answers_per_contributor={},
+    )
+
     return render(request, "contributor_evaluation_form.html", template_data)
 
 
@@ -211,7 +218,12 @@ def evaluation_edit(request, evaluation_id):
 
     sort_formset(request, formset)
     template_data = dict(
-        form=evaluation_form, formset=formset, evaluation=evaluation, editable=True, preview_html=preview_html
+        form=evaluation_form,
+        formset=formset,
+        evaluation=evaluation,
+        editable=True,
+        preview_html=preview_html,
+        questionnaires_with_answers_per_contributor={},
     )
     return render(request, "contributor_evaluation_form.html", template_data)
 

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1056,6 +1056,11 @@ class Contribution(LoggedModel):
             return _("Contribution by {full_name}").format(full_name=self.contributor.full_name)
         return str(_("General Contribution"))
 
+    def remove_answers_to_questionnaires(self, questionnaires):
+        assert set(Answer.__subclasses__()) == {TextAnswer, RatingAnswerCounter}
+        TextAnswer.objects.filter(contribution=self, question__questionnaire__in=questionnaires).delete()
+        RatingAnswerCounter.objects.filter(contribution=self, question__questionnaire__in=questionnaires).delete()
+
 
 class Question(models.Model):
     """A question including a type."""

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1062,7 +1062,7 @@ class Contribution(LoggedModel):
         RatingAnswerCounter.objects.filter(contribution=self, question__questionnaire__in=questionnaires).delete()
 
 
-class Question(models.Model):
+class Question(models.Model):  # pylint: disable=no-init
     """A question including a type."""
 
     TEXT = 0

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -47,7 +47,7 @@
                         {% include 'bootstrap_form_errors.html' with errors=form.does_not_contribute.errors %}
                     </td>
                     <td>
-                        {% include 'questionnaires_widget.html' with field=form.questionnaires questionnaires_with_answers=questionnaires_with_answers_per_contributor|value_at:form.instance.contributor %}
+                        {% include 'questionnaires_widget.html' with field=form.questionnaires questionnaires_with_answers=questionnaires_with_answers_per_contributor|get:form.instance.contributor %}
                     </td>
                     <td>
                         {% trans 'Responsibility' %}:<br />

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -47,7 +47,7 @@
                         {% include 'bootstrap_form_errors.html' with errors=form.does_not_contribute.errors %}
                     </td>
                     <td>
-                        {% include 'questionnaires_widget.html' with field=form.questionnaires %}
+                        {% include 'questionnaires_widget.html' with field=form.questionnaires questionnaires_with_answers=questionnaires_with_answers_per_contributor|value_at:form.instance.contributor %}
                     </td>
                     <td>
                         {% trans 'Responsibility' %}:<br />

--- a/evap/evaluation/templates/evaluation_form_general_questionnaires.html
+++ b/evap/evaluation/templates/evaluation_form_general_questionnaires.html
@@ -1,3 +1,5 @@
+{% load evaluation_filters %}
+
 <fieldset>
     {% for field in evaluation_form %}
         {% if field == evaluation_form.general_questionnaires %}
@@ -5,7 +7,7 @@
                 {% include 'bootstrap_form_field_label.html' with field=field class='col-md-3 pe-4' %}
                 <div class="col-md-7{% if field.errors %} is-invalid{% endif %}">
                     {% include 'bootstrap_form_errors.html' with errors=field.errors %}
-                    {% include 'questionnaires_widget.html' with field=field %}
+                    {% include 'questionnaires_widget.html' with field=field questionnaires_with_answers=questionnaires_with_answers_per_contributor|value_at:None%}
                 </div>
             </div>
         {% else %}

--- a/evap/evaluation/templates/evaluation_form_general_questionnaires.html
+++ b/evap/evaluation/templates/evaluation_form_general_questionnaires.html
@@ -7,7 +7,7 @@
                 {% include 'bootstrap_form_field_label.html' with field=field class='col-md-3 pe-4' %}
                 <div class="col-md-7{% if field.errors %} is-invalid{% endif %}">
                     {% include 'bootstrap_form_errors.html' with errors=field.errors %}
-                    {% include 'questionnaires_widget.html' with field=field questionnaires_with_answers=questionnaires_with_answers_per_contributor|value_at:None%}
+                    {% include 'questionnaires_widget.html' with field=field questionnaires_with_answers=questionnaires_with_answers_per_contributor|get:None%}
                 </div>
             </div>
         {% else %}

--- a/evap/evaluation/templates/questionnaires_widget.html
+++ b/evap/evaluation/templates/questionnaires_widget.html
@@ -29,7 +29,7 @@
             <input class="form-check-input" id="{{ choice.id_for_label }}" name="{{ choice.data.name }}" type="checkbox" value="{{ choice.data.value }}"
                 autocomplete="off"{% if choice.data.selected or questionnaire.is_locked and not manager and choice.data.value in field.initial %} checked{% endif %}
                     {% if field.field.disabled or questionnaire.is_locked and not manager %} disabled{% endif %} />
-            <label class="form-check-label" for="{{ choice.id_for_label }}">
+            <label class="form-check-label{% if questionnaire in questionnaires_with_answers %} badge bg-danger{% endif %}" for="{{ choice.id_for_label }}">
                 {{ choice.choice_label }}
             </label>
         </li>

--- a/evap/evaluation/templatetags/evaluation_filters.py
+++ b/evap/evaluation/templatetags/evaluation_filters.py
@@ -219,7 +219,5 @@ def order_by(iterable, attribute):
 
 
 @register.filter
-def value_at(dictionary, key):
-    if key in dictionary:
-        return dictionary[key]
-    return None
+def get(dictionary, key):
+    return dictionary.get(key)

--- a/evap/evaluation/templatetags/evaluation_filters.py
+++ b/evap/evaluation/templatetags/evaluation_filters.py
@@ -216,3 +216,10 @@ def has_nonresponsible_editor(evaluation):
 @register.filter
 def order_by(iterable, attribute):
     return sorted(iterable, key=lambda item: getattr(item, attribute))
+
+
+@register.filter
+def value_at(dictionary, key):
+    if dictionary and key in dictionary:
+        return dictionary[key]
+    return None

--- a/evap/evaluation/templatetags/evaluation_filters.py
+++ b/evap/evaluation/templatetags/evaluation_filters.py
@@ -220,6 +220,6 @@ def order_by(iterable, attribute):
 
 @register.filter
 def value_at(dictionary, key):
-    if dictionary and key in dictionary:
+    if key in dictionary:
         return dictionary[key]
     return None

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -453,12 +453,7 @@ class EvaluationForm(forms.ModelForm):
         removed_questionnaires = set(self.instance.general_contribution.questionnaires.all()) - set(
             selected_questionnaires
         )
-        TextAnswer.objects.filter(
-            contribution=evaluation.general_contribution, question__questionnaire__in=removed_questionnaires
-        ).delete()
-        RatingAnswerCounter.objects.filter(
-            contribution=evaluation.general_contribution, question__questionnaire__in=removed_questionnaires
-        ).delete()
+        evaluation.general_contribution.remove_answers_to_questionnaires(removed_questionnaires)
         evaluation.general_contribution.questionnaires.set(selected_questionnaires)
         if hasattr(self.instance, "old_course"):
             if self.instance.old_course != evaluation.course:
@@ -633,13 +628,7 @@ class ContributionForm(forms.ModelForm):
         if self.instance.pk:
             selected_questionnaires = self.cleaned_data.get("questionnaires")
             removed_questionnaires = set(self.instance.questionnaires.all()) - set(selected_questionnaires)
-            TextAnswer.objects.filter(
-                contribution=self.instance, question__questionnaire__in=removed_questionnaires
-            ).delete()
-            RatingAnswerCounter.objects.filter(
-                contribution=self.instance, question__questionnaire__in=removed_questionnaires
-            ).delete()
-
+            self.instance.remove_answers_to_questionnaires(removed_questionnaires)
         return super().save(*args, **kwargs)
 
 

--- a/evap/staff/templates/staff_evaluation_form.html
+++ b/evap/staff/templates/staff_evaluation_form.html
@@ -36,6 +36,11 @@
         {% if editable %}
         <div class="card card-submit-area{% if state <= evaluation.State.EDITOR_APPROVED %} card-submit-area-2{% endif %} text-center mb-3">
             <div class="card-body">
+                {% if state >= evaluation.State.IN_EVALUATION %}
+                    {% if questionnaires_with_answers_per_contributor %}
+                        <div class="alert alert-danger">{% trans 'You are editing an evaluation, for which answers have already been received. If you remove any of the questionnaires highlighted in red above, all related answers will be permanently deleted.' %}</div>
+                    {% endif %}
+                {% endif %}
                 {% if state == evaluation.State.IN_EVALUATION %}
                     <div class="alert alert-warning">{% trans 'You are editing an evaluation, which is already running. Please note that only the participants who did not evaluate yet will see your changes.' %}</div>
                 {% endif %}

--- a/evap/staff/templates/staff_evaluation_form.html
+++ b/evap/staff/templates/staff_evaluation_form.html
@@ -36,10 +36,8 @@
         {% if editable %}
         <div class="card card-submit-area{% if state <= evaluation.State.EDITOR_APPROVED %} card-submit-area-2{% endif %} text-center mb-3">
             <div class="card-body">
-                {% if state >= evaluation.State.IN_EVALUATION %}
-                    {% if questionnaires_with_answers_per_contributor %}
-                        <div class="alert alert-danger">{% trans 'You are editing an evaluation, for which answers have already been received. If you remove any of the questionnaires highlighted in red above, all related answers will be permanently deleted.' %}</div>
-                    {% endif %}
+                {% if questionnaires_with_answers_per_contributor %}
+                    <div class="alert alert-danger">{% trans 'You are editing an evaluation, for which answers have already been received. If you remove any of the questionnaires highlighted in red above, all related answers will be permanently deleted.' %}</div>
                 {% endif %}
                 {% if state == evaluation.State.IN_EVALUATION %}
                     <div class="alert alert-warning">{% trans 'You are editing an evaluation, which is already running. Please note that only the participants who did not evaluate yet will see your changes.' %}</div>

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -590,12 +590,7 @@ class ContributionFormsetTests(TestCase):
 
     def test_answers_for_removed_questionnaires_deleted(self):
         # pylint: disable=too-many-locals
-        semester = baker.make(Semester)
-        evaluation = baker.make(
-            Evaluation,
-            course=baker.make(Course, semester=semester),
-        )
-        baker.make(Questionnaire, questions=[baker.make(Question)])
+        evaluation = baker.make(Evaluation)
         general_question_1 = baker.make(Question, type=Question.LIKERT)
         general_question_2 = baker.make(Question, type=Question.LIKERT)
         general_questionnaire_1 = baker.make(Questionnaire, questions=[general_question_1])
@@ -1029,12 +1024,7 @@ class EvaluationFormTests(TestCase):
 
     def test_answers_for_removed_questionnaires_deleted(self):
         # pylint: disable=too-many-locals
-        semester = baker.make(Semester)
-        evaluation = baker.make(
-            Evaluation,
-            course=baker.make(Course, semester=semester),
-        )
-        baker.make(Questionnaire, questions=[baker.make(Question)])
+        evaluation = baker.make(Evaluation)
         general_question_1 = baker.make(Question, type=Question.LIKERT)
         general_question_2 = baker.make(Question, type=Question.LIKERT)
         general_questionnaire_1 = baker.make(Questionnaire, questions=[general_question_1])
@@ -1068,9 +1058,9 @@ class EvaluationFormTests(TestCase):
             set(RatingAnswerCounter.objects.filter(contribution__evaluation=evaluation)), {rac_1, rac_2, rac_3, rac_4}
         )
 
-        form_data = get_form_data_from_instance(EvaluationForm, evaluation, semester=semester)
+        form_data = get_form_data_from_instance(EvaluationForm, evaluation, semester=evaluation.course.semester)
         form_data["general_questionnaires"] = [general_questionnaire_1]  # remove one of the questionnaires
-        form = EvaluationForm(form_data, instance=evaluation, semester=semester)
+        form = EvaluationForm(form_data, instance=evaluation, semester=evaluation.course.semester)
         form.save()
 
         self.assertEqual(set(TextAnswer.objects.filter(contribution__evaluation=evaluation)), {ta_1, ta_3, ta_4})

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -588,6 +588,79 @@ class ContributionFormsetTests(TestCase):
         self.assertFalse(formset.forms[0].show_delete_button)
         self.assertTrue(formset.forms[1].show_delete_button)
 
+    def test_answers_for_removed_questionnaires_deleted(self):
+        # pylint: disable=too-many-locals
+        semester = baker.make(Semester)
+        evaluation = baker.make(
+            Evaluation,
+            course=baker.make(Course, semester=semester),
+        )
+        baker.make(Questionnaire, questions=[baker.make(Question)])
+        general_question_1 = baker.make(Question, type=Question.LIKERT)
+        general_question_2 = baker.make(Question, type=Question.LIKERT)
+        general_questionnaire_1 = baker.make(Questionnaire, questions=[general_question_1])
+        general_questionnaire_2 = baker.make(Questionnaire, questions=[general_question_2])
+        evaluation.general_contribution.questionnaires.set([general_questionnaire_1, general_questionnaire_2])
+        contributor_question = baker.make(Question, type=Question.LIKERT)
+        contributor_questionnaire = baker.make(
+            Questionnaire,
+            type=Questionnaire.Type.CONTRIBUTOR,
+            questions=[contributor_question],
+        )
+        contribution_1 = baker.make(Contribution, evaluation=evaluation, contributor=baker.make(UserProfile))
+        contribution_2 = baker.make(Contribution, evaluation=evaluation, contributor=baker.make(UserProfile))
+        contribution_1.questionnaires.set([contributor_questionnaire])
+        contribution_2.questionnaires.set([contributor_questionnaire])
+        ta_1 = baker.make(TextAnswer, contribution=evaluation.general_contribution, question=general_question_1)
+        ta_2 = baker.make(TextAnswer, contribution=evaluation.general_contribution, question=general_question_2)
+        ta_3 = baker.make(TextAnswer, contribution=contribution_1, question=contributor_question)
+        ta_4 = baker.make(TextAnswer, contribution=contribution_2, question=contributor_question)
+        rac_1 = baker.make(
+            RatingAnswerCounter, contribution=evaluation.general_contribution, question=general_question_1
+        )
+        rac_2 = baker.make(
+            RatingAnswerCounter, contribution=evaluation.general_contribution, question=general_question_2
+        )
+        rac_3 = baker.make(RatingAnswerCounter, contribution=contribution_1, question=contributor_question)
+        rac_4 = baker.make(RatingAnswerCounter, contribution=contribution_2, question=contributor_question)
+
+        self.assertEqual(set(TextAnswer.objects.filter(contribution__evaluation=evaluation)), {ta_1, ta_2, ta_3, ta_4})
+        self.assertEqual(
+            set(RatingAnswerCounter.objects.filter(contribution__evaluation=evaluation)), {rac_1, rac_2, rac_3, rac_4}
+        )
+
+        contribution_formset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0
+        )
+        data = to_querydict(
+            {
+                "contributions-TOTAL_FORMS": 2,
+                "contributions-INITIAL_FORMS": 2,
+                "contributions-MAX_NUM_FORMS": 2,
+                "contributions-0-id": contribution_1.pk,
+                "contributions-0-evaluation": evaluation.pk,
+                "contributions-0-does_not_contribute": "on",  # remove questionnaire for one contributor
+                "contributions-0-order": 0,
+                "contributions-0-role": Contribution.Role.EDITOR,
+                "contributions-0-textanswer_visibility": Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
+                "contributions-0-contributor": contribution_1.contributor.pk,
+                "contributions-1-id": contribution_2.pk,
+                "contributions-1-evaluation": evaluation.pk,
+                "contributions-1-questionnaires": contributor_questionnaire.pk,
+                "contributions-1-order": 1,
+                "contributions-1-role": Contribution.Role.EDITOR,
+                "contributions-1-textanswer_visibility": Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
+                "contributions-1-contributor": contribution_2.contributor.pk,
+            }
+        )
+        formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
+        formset.save()
+
+        self.assertEqual(set(TextAnswer.objects.filter(contribution__evaluation=evaluation)), {ta_1, ta_2, ta_4})
+        self.assertEqual(
+            set(RatingAnswerCounter.objects.filter(contribution__evaluation=evaluation)), {rac_1, rac_2, rac_4}
+        )
+
 
 class ContributionFormset775RegressionTests(TestCase):
     """
@@ -953,6 +1026,57 @@ class EvaluationFormTests(TestCase):
 
         form = EvaluationForm(instance=evaluation, semester=evaluation.course.semester)
         self.assertIn(questionnaire, form.fields["general_questionnaires"].queryset)
+
+    def test_answers_for_removed_questionnaires_deleted(self):
+        # pylint: disable=too-many-locals
+        semester = baker.make(Semester)
+        evaluation = baker.make(
+            Evaluation,
+            course=baker.make(Course, semester=semester),
+        )
+        baker.make(Questionnaire, questions=[baker.make(Question)])
+        general_question_1 = baker.make(Question, type=Question.LIKERT)
+        general_question_2 = baker.make(Question, type=Question.LIKERT)
+        general_questionnaire_1 = baker.make(Questionnaire, questions=[general_question_1])
+        general_questionnaire_2 = baker.make(Questionnaire, questions=[general_question_2])
+        evaluation.general_contribution.questionnaires.set([general_questionnaire_1, general_questionnaire_2])
+        contributor_question = baker.make(Question, type=Question.LIKERT)
+        contributor_questionnaire = baker.make(
+            Questionnaire,
+            type=Questionnaire.Type.CONTRIBUTOR,
+            questions=[contributor_question],
+        )
+        contribution_1 = baker.make(Contribution, evaluation=evaluation, contributor=baker.make(UserProfile))
+        contribution_2 = baker.make(Contribution, evaluation=evaluation, contributor=baker.make(UserProfile))
+        contribution_1.questionnaires.set([contributor_questionnaire])
+        contribution_2.questionnaires.set([contributor_questionnaire])
+        ta_1 = baker.make(TextAnswer, contribution=evaluation.general_contribution, question=general_question_1)
+        ta_2 = baker.make(TextAnswer, contribution=evaluation.general_contribution, question=general_question_2)
+        ta_3 = baker.make(TextAnswer, contribution=contribution_1, question=contributor_question)
+        ta_4 = baker.make(TextAnswer, contribution=contribution_2, question=contributor_question)
+        rac_1 = baker.make(
+            RatingAnswerCounter, contribution=evaluation.general_contribution, question=general_question_1
+        )
+        rac_2 = baker.make(
+            RatingAnswerCounter, contribution=evaluation.general_contribution, question=general_question_2
+        )
+        rac_3 = baker.make(RatingAnswerCounter, contribution=contribution_1, question=contributor_question)
+        rac_4 = baker.make(RatingAnswerCounter, contribution=contribution_2, question=contributor_question)
+
+        self.assertEqual(set(TextAnswer.objects.filter(contribution__evaluation=evaluation)), {ta_1, ta_2, ta_3, ta_4})
+        self.assertEqual(
+            set(RatingAnswerCounter.objects.filter(contribution__evaluation=evaluation)), {rac_1, rac_2, rac_3, rac_4}
+        )
+
+        form_data = get_form_data_from_instance(EvaluationForm, evaluation, semester=semester)
+        form_data["general_questionnaires"] = [general_questionnaire_1]  # remove one of the questionnaires
+        form = EvaluationForm(form_data, instance=evaluation, semester=semester)
+        form.save()
+
+        self.assertEqual(set(TextAnswer.objects.filter(contribution__evaluation=evaluation)), {ta_1, ta_3, ta_4})
+        self.assertEqual(
+            set(RatingAnswerCounter.objects.filter(contribution__evaluation=evaluation)), {rac_1, rac_3, rac_4}
+        )
 
     def test_inactive_participants_remain(self):
         student = baker.make(UserProfile, is_active=False)

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -26,6 +26,7 @@ from django.views.decorators.http import require_POST
 from evap.contributor.views import export_contributor_results
 from evap.evaluation.auth import manager_required, reviewer_required, staff_permission_required
 from evap.evaluation.models import (
+    Answer,
     Contribution,
     Course,
     CourseType,
@@ -1213,6 +1214,7 @@ def helper_evaluation_edit(request, semester, evaluation):
 
         return redirect("staff:semester_view", semester.id)
 
+    assert set(Answer.__subclasses__()) == {TextAnswer, RatingAnswerCounter}
     contributor_questionnaire_pairs = [
         (answer.contribution.contributor, answer.question.questionnaire)
         for answer_cls in [TextAnswer, RatingAnswerCounter]

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1068,7 +1068,13 @@ def evaluation_create(request, semester_id, course_id=None):
         request,
         "staff_evaluation_form.html",
         dict(
-            semester=semester, evaluation_form=evaluation_form, formset=formset, manager=True, editable=True, state=""
+            semester=semester,
+            evaluation_form=evaluation_form,
+            formset=formset,
+            manager=True,
+            editable=True,
+            state="",
+            questionnaires_with_answers_per_contributor={},
         ),
     )
 
@@ -1103,6 +1109,7 @@ def evaluation_copy(request, semester_id, evaluation_id):
             manager=True,
             editable=True,
             state="",
+            questionnaires_with_answers_per_contributor={},
         ),
     )
 

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1206,6 +1206,15 @@ def helper_evaluation_edit(request, semester, evaluation):
 
         return redirect("staff:semester_view", semester.id)
 
+    questionnaires_with_answers_per_contributor = {}
+    for contribution in evaluation.contributions.all():
+        questionnaires = Questionnaire.objects.filter(
+            Q(questions__textanswer__contribution=contribution)
+            | Q(questions__ratinganswercounter__contribution=contribution)
+        ).distinct()
+        if questionnaires.count() > 0:
+            questionnaires_with_answers_per_contributor[contribution.contributor] = questionnaires
+
     if evaluation_form.errors or formset.errors:
         messages.error(request, _("The form was not saved. Please resolve the errors shown below."))
     sort_formset(request, formset)
@@ -1217,6 +1226,7 @@ def helper_evaluation_edit(request, semester, evaluation):
         manager=True,
         state=evaluation.state,
         editable=editable,
+        questionnaires_with_answers_per_contributor=questionnaires_with_answers_per_contributor,
     )
     return render(request, "staff_evaluation_form.html", template_data)
 

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1219,7 +1219,7 @@ def helper_evaluation_edit(request, semester, evaluation):
             Q(questions__textanswer__contribution=contribution)
             | Q(questions__ratinganswercounter__contribution=contribution)
         ).distinct()
-        if questionnaires.count() > 0:
+        if len(questionnaires) > 0:
             questionnaires_with_answers_per_contributor[contribution.contributor] = questionnaires
 
     if evaluation_form.errors or formset.errors:


### PR DESCRIPTION
fix #1716
adds danger warnings in staff evaluation form for those questionnaires that already have answers for questions in these questionnaires and deletes these answers if the questionnaires are removed.