### PR TITLE
Tests - faster, better, stronger

### DIFF
--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -186,8 +186,7 @@ class TestContributorEvaluationEditView(WebTest):
         self.assertEqual(self.evaluation.state, Evaluation.State.EDITOR_APPROVED)
 
         # test what happens if the operation is not specified correctly
-        response = form.submit(expect_errors=True)
-        self.assertEqual(response.status_code, 403)
+        form.submit(status=403)
 
     def test_single_locked_questionnaire(self):
         locked_questionnaire = baker.make(

--- a/evap/evaluation/tests/test_auth.py
+++ b/evap/evaluation/tests/test_auth.py
@@ -133,7 +133,7 @@ class LoginTests(WebTest):
         page = self.app.get(location)
         # A GET here should then redirect to the users real start page.
         # This should be a 403 since the user is external and has no course participation
-        page = page.follow(expect_errors=True)
+        page = page.follow(status=403)
 
         # user should see the Logout button then.
         self.assertIn("Logout", page.body.decode())

--- a/evap/evaluation/tests/test_auth.py
+++ b/evap/evaluation/tests/test_auth.py
@@ -13,6 +13,7 @@ from evap.evaluation.models import Contribution, Evaluation, UserProfile
 from evap.evaluation.tests.tools import WebTest
 
 
+@override_settings(PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"])
 class LoginTests(WebTest):
     csrf_checks = False
 
@@ -139,6 +140,7 @@ class LoginTests(WebTest):
         self.assertIn("Logout", page.body.decode())
 
 
+@override_settings(PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"])
 class LoginTestsWithCSRF(WebTest):
     @classmethod
     def setUpTestData(cls):

--- a/evap/evaluation/tests/test_auth.py
+++ b/evap/evaluation/tests/test_auth.py
@@ -27,16 +27,11 @@ class LoginTests(WebTest):
         baker.make(
             Contribution,
             evaluation=evaluation,
-            contributor=cls.external_user,
+            contributor=iter([cls.external_user, cls.inactive_external_user]),
             role=Contribution.Role.EDITOR,
             textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
-        )
-        baker.make(
-            Contribution,
-            evaluation=evaluation,
-            contributor=cls.inactive_external_user,
-            role=Contribution.Role.EDITOR,
-            textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
+            _quantity=2,
+            _bulk_create=True,
         )
 
     @override_settings(PAGE_URL="https://example.com")

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -27,7 +27,7 @@ from evap.evaluation.models import (
     TextAnswer,
     UserProfile,
 )
-from evap.evaluation.tests.tools import make_manager
+from evap.evaluation.tests.tools import make_manager, make_rating_answer_counters
 
 
 class TestAnonymizeCommand(TestCase):
@@ -109,16 +109,14 @@ class TestAnonymizeCommand(TestCase):
         self.addCleanup(self.input_patch.stop)
 
     def test_no_empty_rating_answer_counters_left(self):
+        counters = []
         for question in chain(self.contributor_questions, self.general_questions):
-            choices = [choice for choice in CHOICES[question.type].values if choice != NO_ANSWER]
-            for answer in choices:
-                baker.make(
-                    RatingAnswerCounter, question=question, contribution=self.contribution, count=1, answer=answer
-                )
+            counts = [1 for choice in CHOICES[question.type].values if choice != NO_ANSWER]
+            counters.extend(make_rating_answer_counters(question, self.contribution, counts, False))
+        RatingAnswerCounter.objects.bulk_create(counters)
 
         old_count = RatingAnswerCounter.objects.count()
 
-        random.seed(0)
         management.call_command("anonymize", stdout=StringIO())
 
         new_count = RatingAnswerCounter.objects.count()
@@ -133,15 +131,13 @@ class TestAnonymizeCommand(TestCase):
 
     def test_answer_count_unchanged(self):
         answers_per_question = defaultdict(int)
-        random.seed(0)
+
+        counters = []
         for question in chain(self.contributor_questions, self.general_questions):
-            choices = [choice for choice in CHOICES[question.type].values if choice != NO_ANSWER]
-            for answer in choices:
-                count = random.randint(10, 100)  # nosec
-                baker.make(
-                    RatingAnswerCounter, question=question, contribution=self.contribution, count=count, answer=answer
-                )
-                answers_per_question[question] += count
+            counts = [random.randint(10, 100) for choice in CHOICES[question.type].values if choice != NO_ANSWER]
+            counters.extend(make_rating_answer_counters(question, self.contribution, counts, False))
+            answers_per_question[question] += sum(counts)
+        RatingAnswerCounter.objects.bulk_create(counters)
 
         management.call_command("anonymize", stdout=StringIO())
 
@@ -157,17 +153,10 @@ class TestAnonymizeCommand(TestCase):
 
         answer_count_before = 0
         choices = [choice for choice in CHOICES[question.type].values if choice != NO_ANSWER]
-        random.seed(0)
-        for answer in choices:
-            count = random.randint(50, 100)  # nosec
-            baker.make(
-                RatingAnswerCounter,
-                question=question,
-                contribution=single_result.general_contribution,
-                count=count,
-                answer=answer,
-            )
-            answer_count_before += count
+
+        answer_counts = [random.randint(50, 100) for answer in choices]
+        answer_count_before = sum(answer_counts)
+        make_rating_answer_counters(question, single_result.general_contribution, answer_counts)
 
         management.call_command("anonymize", stdout=StringIO())
 

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -328,22 +328,10 @@ class TestEvaluations(WebTest):
             TextAnswer,
             question=question,
             contribution=evaluation.general_contribution,
-            answer="hidden",
-            state=TextAnswer.State.HIDDEN,
-        )
-        baker.make(
-            TextAnswer,
-            question=question,
-            contribution=evaluation.general_contribution,
-            answer="published",
-            state=TextAnswer.State.PUBLISHED,
-        )
-        baker.make(
-            TextAnswer,
-            question=question,
-            contribution=evaluation.general_contribution,
-            answer="private",
-            state=TextAnswer.State.PRIVATE,
+            answer=iter(["hidden", "published", "private"]),
+            state=iter([TextAnswer.State.HIDDEN, TextAnswer.State.PUBLISHED, TextAnswer.State.PRIVATE]),
+            _quantity=3,
+            _bulk_create=True,
         )
 
         self.assertEqual(evaluation.textanswer_set.count(), 3)
@@ -630,35 +618,20 @@ class TestUserProfile(TestCase):
     def test_get_sorted_due_evaluations(self):
         student = baker.make(UserProfile, email="student@example.com")
         course = baker.make(Course)
-        evaluation1 = baker.make(
+
+        evaluations = baker.make(
             Evaluation,
             course=course,
-            name_en="C",
-            name_de="C",
-            vote_end_date=date.today(),
+            name_en=iter(["C", "B", "A"]),
+            name_de=iter(["C", "B", "A"]),
+            vote_end_date=iter([date.today(), date.today(), date.today() + timedelta(days=1)]),
             state=Evaluation.State.IN_EVALUATION,
             participants=[student],
+            _quantity=3,
         )
-        evaluation2 = baker.make(
-            Evaluation,
-            course=course,
-            name_en="B",
-            name_de="B",
-            vote_end_date=date.today(),
-            state=Evaluation.State.IN_EVALUATION,
-            participants=[student],
-        )
-        evaluation3 = baker.make(
-            Evaluation,
-            course=course,
-            name_en="A",
-            name_de="A",
-            vote_end_date=date.today() + timedelta(days=1),
-            state=Evaluation.State.IN_EVALUATION,
-            participants=[student],
-        )
+
         sorted_evaluations = student.get_sorted_due_evaluations()
-        self.assertEqual(sorted_evaluations, [(evaluation2, 0), (evaluation1, 0), (evaluation3, 1)])
+        self.assertEqual(sorted_evaluations, [(evaluations[1], 0), (evaluations[0], 0), (evaluations[2], 1)])
 
 
 class ParticipationArchivingTests(TestCase):

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -269,7 +269,7 @@ class TestEvaluations(WebTest):
 
         self.assertFalse(evaluation.can_publish_text_results)
 
-        let_user_vote_for_evaluation(self.app, student2, evaluation)
+        let_user_vote_for_evaluation(student2, evaluation)
         evaluation = Evaluation.objects.get(pk=evaluation.pk)
 
         self.assertTrue(evaluation.can_publish_text_results)

--- a/evap/evaluation/tests/test_views.py
+++ b/evap/evaluation/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import Group
 from django.core import mail
+from django.test import override_settings
 from django_webtest import WebTest
 from model_bakery import baker
 
@@ -8,6 +9,7 @@ from evap.evaluation.models import UserProfile
 from evap.evaluation.tests.tools import WebTestWith200Check, create_evaluation_with_responsible_and_editor
 
 
+@override_settings(PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"])
 class TestIndexView(WebTest):
     url = "/"
 

--- a/evap/evaluation/tests/test_views.py
+++ b/evap/evaluation/tests/test_views.py
@@ -18,9 +18,9 @@ class TestIndexView(WebTest):
         password_form = response.forms["email-login-form"]
         password_form["email"] = "password.user"
         password_form["password"] = "asd"  # nosec
-        self.assertEqual(password_form.submit().status_code, 200)
+        password_form.submit(status=200)
         password_form["password"] = "evap"  # nosec
-        self.assertEqual(password_form.submit().status_code, 302)
+        password_form.submit(status=302)
 
     def test_login_for_staff_users_correctly_redirects(self):
         """Regression test for #1523: Access denied on manager login"""

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -18,9 +18,9 @@ from evap.evaluation.models import (
     Evaluation,
     Questionnaire,
     RatingAnswerCounter,
+    TextAnswer,
     UserProfile,
 )
-from evap.student.tools import answer_field_id
 
 
 def to_querydict(dictionary):
@@ -45,18 +45,41 @@ class FuzzyInt(int):
         return "[%d..%d]" % (self.lowest, self.highest)
 
 
-def let_user_vote_for_evaluation(app, user, evaluation):
-    url = "/student/vote/{}".format(evaluation.id)
-    page = app.get(url, user=user, status=200)
-    form = page.forms["student-vote-form"]
-    for contribution in evaluation.contributions.all().prefetch_related("questionnaires", "questionnaires__questions"):
+def let_user_vote_for_evaluation(user, evaluation, create_answers=False):
+    evaluation.voters.add(user)
+    if evaluation.voters.count() >= 2:
+        evaluation.can_publish_text_results = True
+        evaluation.save()
+
+    if not create_answers:
+        return
+
+    new_textanswers = []
+    rac_by_contribution_question = {}
+    new_racs = []
+
+    for contribution in evaluation.contributions.all().prefetch_related(
+        "ratinganswercounter_set", "questionnaires", "questionnaires__questions"
+    ):
+        for rac in contribution.ratinganswercounter_set.all():
+            if rac.answer == 1:
+                rac_by_contribution_question[(contribution, rac.question)] = rac
+
         for questionnaire in contribution.questionnaires.all():
             for question in questionnaire.questions.all():
                 if question.is_text_question:
-                    form[answer_field_id(contribution, questionnaire, question)] = "Lorem ispum"
+                    new_textanswers.append(baker.prepare(TextAnswer, contribution=contribution, question=question))
                 elif question.is_rating_question:
-                    form[answer_field_id(contribution, questionnaire, question)] = 1
-    form.submit()
+                    if (contribution, question) not in rac_by_contribution_question:
+                        rac = baker.prepare(RatingAnswerCounter, contribution=contribution, question=question, answer=1)
+                        new_racs.append(rac)
+                        rac_by_contribution_question[(contribution, question)] = rac
+
+                    rac_by_contribution_question[(contribution, question)].count += 1
+
+    TextAnswer.objects.bulk_create(new_textanswers)
+    RatingAnswerCounter.objects.bulk_create(new_racs)
+    RatingAnswerCounter.objects.bulk_update(rac_by_contribution_question.values(), ["count"])
 
 
 def render_pages(test_item):

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -61,19 +61,17 @@ class GradeUploadTest(WebTest):
             user=self.grade_publisher,
             content_type="multipart/form-data",
             upload_files=upload_files,
-        ).follow()
+        ).follow(status=200)
         return response
 
     def helper_check_final_grade_upload(self, course, expected_number_of_emails):
         response = self.helper_upload_grades(course, final_grades=True)
-        self.assertEqual(response.status_code, 200)
         self.assertIn("Successfully", response)
         self.assertEqual(course.final_grade_documents.count(), 1)
         self.assertEqual(len(mail.outbox), expected_number_of_emails)
-        response = self.app.get(
-            "/grades/download/{}".format(course.final_grade_documents.first().id), user=self.student
+        self.app.get(
+            "/grades/download/{}".format(course.final_grade_documents.first().id), user=self.student, status=200
         )
-        self.assertEqual(response.status_code, 200)
 
         # tear down
         course.final_grade_documents.first().file.delete()
@@ -84,7 +82,6 @@ class GradeUploadTest(WebTest):
         self.assertEqual(self.course.midterm_grade_documents.count(), 0)
 
         response = self.helper_upload_grades(self.course, final_grades=False)
-        self.assertEqual(response.status_code, 200)
         self.assertIn("Successfully", response)
         self.assertEqual(self.course.midterm_grade_documents.count(), 1)
         self.assertEqual(len(mail.outbox), 0)
@@ -144,10 +141,12 @@ class GradeUploadTest(WebTest):
 
         self.assertFalse(evaluation.course.gets_no_grade_documents)
 
-        response = self.app.post(
-            "/grades/toggle_no_grades", params={"course_id": evaluation.course.id}, user=self.grade_publisher
+        self.app.post(
+            "/grades/toggle_no_grades",
+            params={"course_id": evaluation.course.id},
+            user=self.grade_publisher,
+            status=200,
         )
-        self.assertEqual(response.status_code, 200)
         evaluation = Evaluation.objects.get(id=evaluation.id)
         self.assertTrue(evaluation.course.gets_no_grade_documents)
         # evaluation should get published here
@@ -156,10 +155,12 @@ class GradeUploadTest(WebTest):
             len(mail.outbox), evaluation.num_participants + evaluation.contributions.exclude(contributor=None).count()
         )
 
-        response = self.app.post(
-            "/grades/toggle_no_grades", params={"course_id": evaluation.course.id}, user=self.grade_publisher
+        self.app.post(
+            "/grades/toggle_no_grades",
+            params={"course_id": evaluation.course.id},
+            user=self.grade_publisher,
+            status=200,
         )
-        self.assertEqual(response.status_code, 200)
         evaluation = Evaluation.objects.get(id=evaluation.id)
         self.assertFalse(evaluation.course.gets_no_grade_documents)
 

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -44,7 +44,7 @@ class TestExporters(TestCase):
         degree = baker.make(Degree)
         evaluation = baker.make(
             Evaluation,
-            course=baker.make(Course, degrees=[degree]),
+            course__degrees=[degree],
             state=Evaluation.State.PUBLISHED,
             _participant_count=2,
             _voter_count=2,
@@ -98,7 +98,7 @@ class TestExporters(TestCase):
         degree = baker.make(Degree)
         evaluation = baker.make(
             Evaluation,
-            course=baker.make(Course, degrees=[degree]),
+            course__degrees=[degree],
             state=Evaluation.State.PUBLISHED,
             _participant_count=2,
             _voter_count=2,
@@ -432,18 +432,16 @@ class TestExporters(TestCase):
     def test_course_grade(self):
         degree = baker.make(Degree)
         course = baker.make(Course, degrees=[degree])
-        evaluations = [
-            baker.make(
-                Evaluation,
-                course=course,
-                name_en=f"eval{i}",
-                name_de=f"eval{i}",
-                state=Evaluation.State.PUBLISHED,
-                _voter_count=5,
-                _participant_count=10,
-            )
-            for i in range(3)
-        ]
+        evaluations = baker.make(
+            Evaluation,
+            course=course,
+            name_en=iter(["eval0", "eval1", "eval2"]),
+            name_de=iter(["eval0", "eval1", "eval2"]),
+            state=Evaluation.State.PUBLISHED,
+            _voter_count=5,
+            _participant_count=10,
+            _quantity=3,
+        )
 
         grades_per_eval = [[1, 1, 0, 0, 0], [0, 1, 1, 0, 0], [1, 0, 1, 0, 0]]
         expected_average = 2.0
@@ -546,16 +544,22 @@ class TestExporters(TestCase):
 
     def test_text_answer_export(self):
         evaluation = baker.make(Evaluation, state=Evaluation.State.PUBLISHED, can_publish_text_results=True)
-        questions = [baker.make(Question, questionnaire__type=t, type=Question.TEXT) for t in Questionnaire.Type.values]
+        questions = baker.make(
+            Question,
+            questionnaire__type=iter(Questionnaire.Type.values),
+            type=Question.TEXT,
+            _quantity=len(Questionnaire.Type.values),
+            _bulk_create=True,
+        )
 
-        for idx in [0, 1, 2, 2, 0]:
-            baker.make(
-                TextAnswer,
-                question=questions[idx],
-                contribution__evaluation=evaluation,
-                contribution__questionnaires=[questions[idx].questionnaire],
-                state=TextAnswer.State.PUBLISHED,
-            )
+        baker.make(
+            TextAnswer,
+            question=iter(questions[idx] for idx in [0, 1, 2, 2, 0]),
+            contribution__evaluation=evaluation,
+            contribution__questionnaires=iter(questions[idx].questionnaire for idx in [0, 1, 2, 2, 0]),
+            state=TextAnswer.State.PUBLISHED,
+            _quantity=5,
+        )
 
         cache_results(evaluation)
         evaluation_result = get_results(evaluation)

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -6,7 +6,16 @@ from django.test import override_settings
 from django.test.testcases import TestCase
 from model_bakery import baker
 
-from evap.evaluation.models import Contribution, Course, Evaluation, Question, Questionnaire, TextAnswer, UserProfile
+from evap.evaluation.models import (
+    Contribution,
+    Course,
+    Evaluation,
+    Question,
+    Questionnaire,
+    RatingAnswerCounter,
+    TextAnswer,
+    UserProfile,
+)
 from evap.evaluation.tests.tools import make_rating_answer_counters
 from evap.results.tools import (
     RatingResult,
@@ -197,14 +206,21 @@ class TestCalculateAverageDistribution(TestCase):
     def test_average_grade(self):
         question_grade2 = baker.make(Question, questionnaire=self.questionnaire, type=Question.GRADE)
 
-        make_rating_answer_counters(self.question_grade, self.contribution1, [0, 1, 0, 0, 0])
-        make_rating_answer_counters(self.question_grade, self.contribution2, [0, 0, 0, 2, 0])
-        make_rating_answer_counters(question_grade2, self.contribution1, [1, 0, 0, 0, 0])
-        make_rating_answer_counters(self.question_likert, self.contribution1, [0, 0, 4, 0, 0])
-        make_rating_answer_counters(self.question_likert, self.general_contribution, [0, 0, 0, 0, 5])
-        make_rating_answer_counters(self.question_likert_2, self.general_contribution, [0, 0, 3, 0, 0])
-        make_rating_answer_counters(self.question_bipolar, self.general_contribution, [0, 0, 0, 0, 0, 0, 2])
-        make_rating_answer_counters(self.question_bipolar_2, self.general_contribution, [0, 0, 4, 0, 0, 0, 0])
+        counters = [
+            *make_rating_answer_counters(self.question_grade, self.contribution1, [0, 1, 0, 0, 0], False),
+            *make_rating_answer_counters(self.question_grade, self.contribution2, [0, 0, 0, 2, 0], False),
+            *make_rating_answer_counters(question_grade2, self.contribution1, [1, 0, 0, 0, 0], False),
+            *make_rating_answer_counters(self.question_likert, self.contribution1, [0, 0, 4, 0, 0], False),
+            *make_rating_answer_counters(self.question_likert, self.general_contribution, [0, 0, 0, 0, 5], False),
+            *make_rating_answer_counters(self.question_likert_2, self.general_contribution, [0, 0, 3, 0, 0], False),
+            *make_rating_answer_counters(
+                self.question_bipolar, self.general_contribution, [0, 0, 0, 0, 0, 0, 2], False
+            ),
+            *make_rating_answer_counters(
+                self.question_bipolar_2, self.general_contribution, [0, 0, 4, 0, 0, 0, 0], False
+            ),
+        ]
+        RatingAnswerCounter.objects.bulk_create(counters)
 
         cache_results(self.evaluation)
 
@@ -243,11 +259,14 @@ class TestCalculateAverageDistribution(TestCase):
         GENERAL_NON_GRADE_QUESTIONS_WEIGHT=5,
     )
     def test_distribution_without_general_grade_question(self):
-        make_rating_answer_counters(self.question_grade, self.contribution1, [1, 0, 1, 0, 0])
-        make_rating_answer_counters(self.question_grade, self.contribution2, [0, 1, 0, 1, 0])
-        make_rating_answer_counters(self.question_likert, self.contribution1, [0, 0, 3, 0, 3])
-        make_rating_answer_counters(self.question_likert, self.general_contribution, [0, 0, 0, 0, 5])
-        make_rating_answer_counters(self.question_likert_2, self.general_contribution, [0, 0, 3, 0, 0])
+        counters = [
+            *make_rating_answer_counters(self.question_grade, self.contribution1, [1, 0, 1, 0, 0], False),
+            *make_rating_answer_counters(self.question_grade, self.contribution2, [0, 1, 0, 1, 0], False),
+            *make_rating_answer_counters(self.question_likert, self.contribution1, [0, 0, 3, 0, 3], False),
+            *make_rating_answer_counters(self.question_likert, self.general_contribution, [0, 0, 0, 0, 5], False),
+            *make_rating_answer_counters(self.question_likert_2, self.general_contribution, [0, 0, 3, 0, 0], False),
+        ]
+        RatingAnswerCounter.objects.bulk_create(counters)
 
         cache_results(self.evaluation)
 
@@ -274,12 +293,15 @@ class TestCalculateAverageDistribution(TestCase):
         GENERAL_NON_GRADE_QUESTIONS_WEIGHT=5,
     )
     def test_distribution_with_general_grade_question(self):
-        make_rating_answer_counters(self.question_grade, self.contribution1, [1, 0, 1, 0, 0])
-        make_rating_answer_counters(self.question_grade, self.contribution2, [0, 1, 0, 1, 0])
-        make_rating_answer_counters(self.question_likert, self.contribution1, [0, 0, 3, 0, 3])
-        make_rating_answer_counters(self.question_likert, self.general_contribution, [0, 0, 0, 0, 5])
-        make_rating_answer_counters(self.question_likert_2, self.general_contribution, [0, 0, 3, 0, 0])
-        make_rating_answer_counters(self.question_grade, self.general_contribution, [0, 10, 0, 0, 0])
+        counters = [
+            *make_rating_answer_counters(self.question_grade, self.contribution1, [1, 0, 1, 0, 0], False),
+            *make_rating_answer_counters(self.question_grade, self.contribution2, [0, 1, 0, 1, 0], False),
+            *make_rating_answer_counters(self.question_likert, self.contribution1, [0, 0, 3, 0, 3], False),
+            *make_rating_answer_counters(self.question_likert, self.general_contribution, [0, 0, 0, 0, 5], False),
+            *make_rating_answer_counters(self.question_likert_2, self.general_contribution, [0, 0, 3, 0, 0], False),
+            *make_rating_answer_counters(self.question_grade, self.general_contribution, [0, 10, 0, 0, 0], False),
+        ]
+        RatingAnswerCounter.objects.bulk_create(counters)
 
         cache_results(self.evaluation)
 

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -596,7 +596,7 @@ class TestResultsSemesterEvaluationDetailViewFewVoters(WebTest):
         self.assertEqual(number_of_disabled_grade_badges, 1)
 
     def test_answer_visibility_one_voter(self):
-        let_user_vote_for_evaluation(self.app, self.student1, self.evaluation)
+        let_user_vote_for_evaluation(self.student1, self.evaluation)
         self.evaluation.end_evaluation()
         self.evaluation.end_review()
         self.evaluation.publish()
@@ -609,8 +609,8 @@ class TestResultsSemesterEvaluationDetailViewFewVoters(WebTest):
         self.helper_test_answer_visibility_one_voter("student@institution.example.com", expect_page_not_visible=True)
 
     def test_answer_visibility_two_voters(self):
-        let_user_vote_for_evaluation(self.app, self.student1, self.evaluation)
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student1, self.evaluation, create_answers=True)
+        let_user_vote_for_evaluation(self.student2, self.evaluation, create_answers=True)
         self.evaluation.end_evaluation()
         self.evaluation.end_review()
         self.evaluation.publish()

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -273,12 +273,12 @@ class TestResultsView(WebTest):
         published = baker.make(
             Evaluation,
             course=course,
-            name_en=iter(["ev1", "ev2", "ev3"]),
-            name_de=iter(["ev1", "ev2", "ev3"]),
+            name_en=iter(["evaluation_1", "evaluation_2", "evaluation_3"]),
             state=iter([Evaluation.State.NEW, Evaluation.State.PUBLISHED, Evaluation.State.PUBLISHED]),
             weight=iter([8, 3, 4]),
             is_single_result=True,
             _quantity=3,
+            _fill_optional=["name_de"],
         )[1:]
 
         contributions = [e.general_contribution for e in published]
@@ -288,8 +288,13 @@ class TestResultsView(WebTest):
         page = self.app.get(self.url, user=student)
         decoded = page.body.decode()
 
-        self.assertTrue(decoded.index("ev2") < decoded.index(" 20% ") < decoded.index("ev3") < decoded.index(" 26% "))
-        self.assertNotContains(page, " 53% ")
+        self.assertTrue(
+            decoded.index("evaluation_2")
+            < decoded.index("contributes 20% to")
+            < decoded.index("evaluation_3")
+            < decoded.index("contributes 26% to")
+        )
+        self.assertNotContains(page, "contributes 53% to")
 
 
 class TestGetEvaluationsWithPrefetchedData(TestCase):

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -329,14 +329,13 @@ class TestResultsViewContributionWarning(WebTest):
         contributor = baker.make(UserProfile)
 
         # Set up an evaluation with one question but no answers
-        student1 = baker.make(UserProfile)
-        student2 = baker.make(UserProfile)
+        students = list(baker.make(UserProfile, _quantity=2, _bulk_create=True))
         cls.evaluation = baker.make(
             Evaluation,
             state=Evaluation.State.PUBLISHED,
             course=baker.make(Course, semester=cls.semester),
-            participants=[student1, student2],
-            voters=[student1, student2],
+            participants=students,
+            voters=students,
         )
         questionnaire = baker.make(Questionnaire)
         cls.evaluation.general_contribution.questionnaires.set([questionnaire])

--- a/evap/rewards/tests/test_tools.py
+++ b/evap/rewards/tests/test_tools.py
@@ -16,8 +16,6 @@ from evap.rewards.tools import reward_points_of_user
     ]
 )
 class TestGrantRewardPoints(WebTest):
-    csrf_checks = False
-
     @classmethod
     def setUpTestData(cls):
         cls.student = baker.make(UserProfile, email="student@institution.example.com")

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -43,7 +43,6 @@ class TestEventDeleteView(WebTestStaffMode):
 
 class TestIndexView(WebTest):
     url = reverse("rewards:index")
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
@@ -96,7 +95,6 @@ class TestEventsView(WebTestStaffModeWith200Check):
 
 class TestEventCreateView(WebTestStaffMode):
     url = reverse("rewards:reward_point_redemption_event_create")
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):
@@ -119,7 +117,6 @@ class TestEventCreateView(WebTestStaffMode):
 
 class TestEventEditView(WebTestStaffMode):
     url = reverse("rewards:reward_point_redemption_event_edit", args=[1])
-    csrf_checks = False
 
     @classmethod
     def setUpTestData(cls):

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -27,8 +27,7 @@ class TestEventDeleteView(WebTestStaffMode):
 
     def test_deletion_success(self):
         event = baker.make(RewardPointRedemptionEvent)
-        response = self.app.post(self.url, params={"event_id": event.pk}, user=self.manager)
-        self.assertEqual(response.status_code, 200)
+        self.app.post(self.url, params={"event_id": event.pk}, user=self.manager, status=200)
         self.assertFalse(RewardPointRedemptionEvent.objects.filter(pk=event.pk).exists())
 
     def test_deletion_failure(self):
@@ -36,8 +35,7 @@ class TestEventDeleteView(WebTestStaffMode):
         event = baker.make(RewardPointRedemptionEvent)
         baker.make(RewardPointRedemption, value=1, event=event)
 
-        response = self.app.post(self.url, params={"event_id": event.pk}, user=self.manager, expect_errors=True)
-        self.assertEqual(response.status_code, 400)
+        self.app.post(self.url, params={"event_id": event.pk}, user=self.manager, status=400)
         self.assertTrue(RewardPointRedemptionEvent.objects.filter(pk=event.pk).exists())
 
 
@@ -58,7 +56,6 @@ class TestIndexView(WebTest):
         form.set("points-1", 2)
         form.set("points-2", 3)
         response = form.submit()
-        self.assertEqual(response.status_code, 200)
         self.assertContains(response, "You successfully redeemed your points.")
         self.assertEqual(0, reward_points_of_user(self.student))
 

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -392,13 +392,15 @@ try:
 except ImportError:
     pass
 
-TESTING = "test" in sys.argv
+TESTING = "test" in sys.argv or "pytest" in sys.modules
 
 # speed up tests
 if TESTING:
     # do not use ManifestStaticFilesStorage as it requires running collectstatic beforehand
     STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+
     logging.disable(logging.CRITICAL)  # disable logging, primarily to prevent console spam
+
     # use the database for caching. it's properly reset between tests in constrast to redis,
     # and does not change behaviour in contrast to disabling the cache entirely.
     CACHES = {

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -759,6 +759,7 @@ class CourseFormTests(TestCase):
             responsibles=[baker.make(UserProfile)],
             degrees=[baker.make(Degree)],
             _quantity=2,
+            _bulk_create=True,
         )
 
         form_data = get_form_data_from_instance(CourseForm, courses[1])

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -759,7 +759,6 @@ class CourseFormTests(TestCase):
             responsibles=[baker.make(UserProfile)],
             degrees=[baker.make(Degree)],
             _quantity=2,
-            _bulk_create=True,
         )
 
         form_data = get_form_data_from_instance(CourseForm, courses[1])

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -130,7 +130,9 @@ class TestUserIndexView(WebTestStaffMode):
             _participant_count=1,
             _voter_count=1,
         )
-        baker.make(UserProfile, _bulk_create=True, _quantity=num_users, evaluations_participating_in=[evaluation])
+        users = baker.make(UserProfile, _bulk_create=True, _quantity=num_users)
+        participations = [Evaluation.participants.through(evaluation=evaluation, userprofile=user) for user in users]
+        Evaluation.participants.through.objects.bulk_create(participations)
 
         with self.assertNumQueries(FuzzyInt(0, num_users - 1)):
             self.app.get(self.url, user=self.manager)

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2255,20 +2255,20 @@ class TestEvaluationTextAnswerView(WebTest):
             self.app.get(self.url, user=self.manager, status=403)
 
         # add additional voter
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
 
         # now it should work
         with run_in_staff_mode(self):
             self.app.get(self.url, user=self.manager, status=200)
 
     def test_textanswers_quick_view(self):
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
         with run_in_staff_mode(self):
             page = self.app.get(self.url, user=self.manager, status=200)
             self.assertContains(page, self.answer)
 
     def test_textanswers_full_view(self):
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
         with run_in_staff_mode(self):
             page = self.app.get(self.url + "?view=full", user=self.manager, status=200)
             self.assertContains(page, self.answer)
@@ -2276,7 +2276,7 @@ class TestEvaluationTextAnswerView(WebTest):
     # use offset of more than 25 hours to make sure the test doesn't fail even on combined time zone change and leap second
     @override_settings(EVALUATION_END_OFFSET_HOURS=26)
     def test_exclude_unfinished_evaluations(self):
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
         with run_in_staff_mode(self):
             page = self.app.get(self.url, user=self.manager, status=200)
             # evaluation2 is finished and should show up
@@ -2290,13 +2290,13 @@ class TestEvaluationTextAnswerView(WebTest):
             self.assertNotContains(page, self.evaluation2.full_name)
 
     def test_num_queries_is_constant(self):
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
         with run_in_staff_mode(self):
             with self.assertNumQueries(FuzzyInt(0, self.num_questions)):
                 self.app.get(self.url, user=self.manager)
 
     def test_published(self):
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
         with run_in_staff_mode(self):
             self.app.get(self.url, user=self.manager, status=200)
         Evaluation.objects.filter(id=self.evaluation.id).update(state=Evaluation.State.PUBLISHED)
@@ -2304,7 +2304,7 @@ class TestEvaluationTextAnswerView(WebTest):
             self.app.get(self.url, user=self.manager, status=403)
 
     def test_archived(self):
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
         with run_in_staff_mode(self):
             self.app.get(self.url, user=self.manager, status=200)
         Semester.objects.filter(id=self.evaluation.course.semester.id).update(results_are_archived=True)
@@ -2355,7 +2355,7 @@ class TestEvaluationTextAnswerEditView(WebTest):
             self.app.get(self.url, user=self.manager, status=403)
 
         # add additional voter
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
 
         # now it should work
         with run_in_staff_mode(self):
@@ -2736,7 +2736,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
             TextAnswer.State.NOT_REVIEWED, TextAnswer.State.PUBLISHED, "publish", expect_errors=True
         )
 
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
 
         # now reviewing should work
         self.helper_check_state(TextAnswer.State.NOT_REVIEWED, TextAnswer.State.PUBLISHED, "publish")
@@ -2746,7 +2746,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         self.helper_check_follow("textanswer_edit")
 
     def test_finishing_review_updates_results(self):
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation, create_answers=True)
         self.evaluation.end_evaluation()
         self.evaluation.can_publish_text_results = True
         self.evaluation.save()
@@ -2764,7 +2764,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         self.assertEqual(len(results.questionnaire_results[0].question_results[1].answers), 1)
 
     def test_published(self):
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
         self.helper_check_state(TextAnswer.State.NOT_REVIEWED, TextAnswer.State.PUBLISHED, "publish")
         Evaluation.objects.filter(id=self.evaluation.id).update(state=Evaluation.State.PUBLISHED)
         self.helper_check_state(
@@ -2772,7 +2772,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         )
 
     def test_archived(self):
-        let_user_vote_for_evaluation(self.app, self.student2, self.evaluation)
+        let_user_vote_for_evaluation(self.student2, self.evaluation)
         self.helper_check_state(TextAnswer.State.NOT_REVIEWED, TextAnswer.State.PUBLISHED, "publish")
         Semester.objects.filter(id=self.evaluation.course.semester.id).update(results_are_archived=True)
         self.helper_check_state(

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -39,7 +39,7 @@ from evap.evaluation.tests.tools import (
     make_rating_answer_counters,
     render_pages,
 )
-from evap.results.tools import cache_results, get_results
+from evap.results.tools import cache_results, get_results, TextResult
 from evap.rewards.models import RewardPointGranting, SemesterActivation
 from evap.staff.forms import ContributionCopyForm, ContributionCopyFormSet, CourseCopyForm, EvaluationCopyForm
 from evap.staff.tests.utils import (
@@ -2752,7 +2752,10 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         self.evaluation.save()
         results = get_results(self.evaluation)
 
-        self.assertEqual(len(results.questionnaire_results[0].question_results[1].answers), 0)
+        textresult = next(
+            (result for result in results.questionnaire_results[0].question_results if isinstance(result, TextResult))
+        )
+        self.assertEqual(len(textresult.answers), 0)
 
         textanswer = self.evaluation.unreviewed_textanswer_set[0]
         textanswer.state = TextAnswer.State.PUBLISHED
@@ -2761,7 +2764,10 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         self.evaluation.save()
         results = get_results(self.evaluation)
 
-        self.assertEqual(len(results.questionnaire_results[0].question_results[1].answers), 1)
+        textresult = next(
+            (result for result in results.questionnaire_results[0].question_results if isinstance(result, TextResult))
+        )
+        self.assertEqual(len(textresult.answers), 1)
 
     def test_published(self):
         let_user_vote_for_evaluation(self.student2, self.evaluation)

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -279,9 +279,7 @@ class TestUserBulkUpdateView(WebTestStaffMode):
         baker.make(UserProfile, is_active=False)
         users_before = set(UserProfile.objects.all())
 
-        reply = form.submit(name="operation", value="test")
-
-        self.assertEqual(reply.status_code, 200)
+        form.submit(name="operation", value="test", status=200)
         # No user got deleted.
         self.assertEqual(users_before, set(UserProfile.objects.all()))
 
@@ -401,8 +399,7 @@ class TestUserBulkUpdateView(WebTestStaffMode):
         page = self.app.get(self.url, user=self.manager)
         form = page.forms["user-bulk-update-form"]
         form["user_file"] = (self.filename_random,)
-        reply = form.submit(name="operation", value="test")
-        self.assertEqual(reply.status_code, 200)
+        reply = form.submit(name="operation", value="test", status=200)
         self.assertIn("An error happened when processing the file", reply)
 
         page = self.app.get(self.url, user=self.manager)
@@ -411,8 +408,7 @@ class TestUserBulkUpdateView(WebTestStaffMode):
             "test_enrollment_data.xls",
             excel_data.create_memory_excel_file(excel_data.test_enrollment_data_filedata),
         )
-        reply = form.submit(name="operation", value="test")
-        self.assertEqual(reply.status_code, 200)
+        reply = form.submit(name="operation", value="test", status=200)
         self.assertIn("An error happened when processing the file", reply)
 
 
@@ -501,10 +497,7 @@ class TestUserImportView(WebTestStaffMode):
         form = page.forms["user-import-form"]
         form["excel_file"] = (self.filename_valid,)
 
-        # Should throw SuspiciousOperation Exception.
-        reply = form.submit(name="operation", value="hackit", expect_errors=True)
-
-        self.assertEqual(reply.status_code, 400)
+        form.submit(name="operation", value="hackit", status=400)
 
     def test_invalid_upload_operation(self):
         page = self.app.get(self.url, user=self.manager)
@@ -519,9 +512,7 @@ class TestUserImportView(WebTestStaffMode):
         page = self.app.get(self.url, user=self.manager)
 
         form = page.forms["user-import-form"]
-        reply = form.submit(name="operation", value="import", expect_errors=True)
-
-        self.assertEqual(reply.status_code, 400)
+        form.submit(name="operation", value="import", status=400)
 
 
 # Staff - Semester Views
@@ -706,15 +697,13 @@ class TestSemesterDeleteView(WebTestStaffMode):
         )
         self.assertFalse(semester.can_be_deleted_by_manager)
 
-        response = self.app.post(self.url, params={"semester_id": semester.pk}, user=self.manager, expect_errors=True)
-        self.assertEqual(response.status_code, 400)
+        self.app.post(self.url, params={"semester_id": semester.pk}, user=self.manager, status=400)
         self.assertTrue(Semester.objects.filter(pk=semester.pk).exists())
 
     def test_success_if_no_courses(self):
         semester = baker.make(Semester)
         self.assertTrue(semester.can_be_deleted_by_manager)
-        response = self.app.post(self.url, params={"semester_id": semester.pk}, user=self.manager)
-        self.assertEqual(response.status_code, 302)
+        self.app.post(self.url, params={"semester_id": semester.pk}, user=self.manager, status=302)
         self.assertFalse(Semester.objects.filter(pk=semester.pk).exists())
 
     def test_success_if_archived(self):
@@ -733,8 +722,7 @@ class TestSemesterDeleteView(WebTestStaffMode):
         semester.archive_results()
 
         self.assertTrue(semester.can_be_deleted_by_manager)
-        response = self.app.post(self.url, params={"semester_id": semester.pk}, user=self.manager)
-        self.assertEqual(response.status_code, 302)
+        self.app.post(self.url, params={"semester_id": semester.pk}, user=self.manager, status=302)
         self.assertFalse(Semester.objects.filter(pk=semester.pk).exists())
         self.assertFalse(Course.objects.filter(pk=course.pk).exists())
         self.assertFalse(Evaluation.objects.filter(pk=evaluation.pk).exists())
@@ -745,15 +733,7 @@ class TestSemesterDeleteView(WebTestStaffMode):
 
     def test_failure_if_active(self):
         semester = baker.make(Semester, is_active=True)
-        response = self.app.post(
-            self.url,
-            user=self.manager,
-            expect_errors=True,
-            params={
-                "semester_id": semester.id,
-            },
-        )
-        self.assertEqual(response.status_code, 400)
+        self.app.post(self.url, user=self.manager, status=400, params={"semester_id": semester.id})
 
 
 class TestSemesterAssignView(WebTestStaffMode):
@@ -841,8 +821,7 @@ class TestSemesterPreparationReminderView(WebTestStaffModeWith200Check):
         email_template_mock.objects.get.return_value = email_template_mock
         email_template_mock.EDITOR_REVIEW_REMINDER = EmailTemplate.EDITOR_REVIEW_REMINDER
 
-        response = self.app.post(self.url, user=self.manager)
-        self.assertEqual(response.status_code, 200)
+        self.app.post(self.url, user=self.manager, status=200)
 
         subject_params = {}
         body_params = {"user": user, "evaluations": [evaluation]}
@@ -1021,10 +1000,7 @@ class TestSemesterImportView(WebTestStaffMode):
             excel_data.create_memory_excel_file(excel_data.test_enrollment_data_filedata),
         )
 
-        # Should throw SuspiciousOperation Exception.
-        reply = form.submit(name="operation", value="hackit", expect_errors=True)
-
-        self.assertEqual(reply.status_code, 400)
+        form.submit(name="operation", value="hackit", status=400)
 
     def test_invalid_upload_operation(self):
         page = self.app.get(self.url, user=self.manager)
@@ -1040,9 +1016,7 @@ class TestSemesterImportView(WebTestStaffMode):
 
         form = page.forms["semester-import-form"]
         # invalid because no file has been uploaded previously (and the button doesn't even exist)
-        reply = form.submit(name="operation", value="import", expect_errors=True)
-
-        self.assertEqual(reply.status_code, 400)
+        form.submit(name="operation", value="import", status=400)
 
     def test_missing_evaluation_period(self):
         page = self.app.get(self.url, user=self.manager)
@@ -1359,9 +1333,7 @@ class TestEvaluationOperationView(WebTestStaffMode):
         evaluation = baker.make(Evaluation, state=Evaluation.State.APPROVED, course=self.course)
         urloptions = "?evaluation={}&target_state={}".format(evaluation.pk, Evaluation.State.IN_EVALUATION)
 
-        response = self.app.get(self.url + urloptions, user=self.manager)
-        self.assertEqual(response.status_code, 200, 'url "{}" failed with user "manager"'.format(self.url))
-
+        response = self.app.get(self.url + urloptions, user=self.manager, status=200)
         form = response.forms["evaluation-operation-form"]
         form.submit()
 
@@ -1372,8 +1344,7 @@ class TestEvaluationOperationView(WebTestStaffMode):
         evaluation = baker.make(Evaluation, state=Evaluation.State.NEW, course=self.course)
         urloptions = "?evaluation={}&target_state={}".format(evaluation.pk, Evaluation.State.PREPARED)
 
-        response = self.app.get(self.url + urloptions, user=self.manager)
-        self.assertEqual(response.status_code, 200, 'url "{}" failed with user "manager"'.format(self.url))
+        response = self.app.get(self.url + urloptions, user=self.manager, status=200)
         form = response.forms["evaluation-operation-form"]
         form.submit()
 
@@ -2158,10 +2129,7 @@ class TestEvaluationImportPersonsView(WebTestStaffMode):
         form = page.forms["participant-import-form"]
         form["pe-excel_file"] = (self.filename_valid,)
 
-        # Should throw SuspiciousOperation Exception.
-        reply = form.submit(name="operation", value="hackit", expect_errors=True)
-
-        self.assertEqual(reply.status_code, 400)
+        form.submit(name="operation", value="hackit", status=400)
 
     def test_invalid_contributor_upload_operation(self):
         page = self.app.get(self.url, user=self.manager)
@@ -2186,18 +2154,14 @@ class TestEvaluationImportPersonsView(WebTestStaffMode):
 
         form = page.forms["contributor-import-form"]
         # invalid because no file has been uploaded previously (and the button doesn't even exist)
-        reply = form.submit(name="operation", value="import-contributors", expect_errors=True)
-
-        self.assertEqual(reply.status_code, 400)
+        form.submit(name="operation", value="import-contributors", status=400)
 
     def test_invalid_participant_import_operation(self):
         page = self.app.get(self.url, user=self.manager)
 
         form = page.forms["participant-import-form"]
         # invalid because no file has been uploaded previously (and the button doesn't even exist)
-        reply = form.submit(name="operation", value="import-participants", expect_errors=True)
-
-        self.assertEqual(reply.status_code, 400)
+        form.submit(name="operation", value="import-participants", status=400)
 
 
 class TestEvaluationEmailView(WebTestStaffMode):
@@ -2453,10 +2417,11 @@ class TestQuestionnaireNewVersionView(WebTestStaffMode):
 
         # Second try.
         new_questionnaire = Questionnaire.objects.get(name_de=self.name_de_orig)
-        page = self.app.get(url=f"/staff/questionnaire/{new_questionnaire.id}/new_version", user=self.manager)
+        page = self.app.get(
+            url=f"/staff/questionnaire/{new_questionnaire.id}/new_version", user=self.manager, status=302
+        )
 
         # We should get redirected back to the questionnaire index.
-        self.assertEqual(page.status_code, 302)
         self.assertEqual(page.location, "/staff/questionnaire/")
 
 
@@ -2742,12 +2707,12 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
     def helper_check_follow(self, action):
         with run_in_staff_mode(self):
             textanswer = baker.make(TextAnswer)
-            response = self.app.post(
+            self.app.post(
                 self.url,
                 params={"id": textanswer.id, "action": action, "evaluation_id": self.evaluation.pk},
                 user=self.manager,
+                status=200,
             )
-            self.assertEqual(response.status_code, 200)
 
     def helper_check_state(self, old_state, expected_new_state, action, expect_errors=False):
         with run_in_staff_mode(self):

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -35,20 +35,16 @@ class TestStudentIndexView(WebTestWith200Check):
     def test_num_queries_is_constant(self):
         semester1 = baker.make(Semester)
         semester2 = baker.make(Semester, participations_are_archived=True)
-        baker.make(
-            Evaluation,
-            course__semester=semester1,
-            state=Evaluation.State.PUBLISHED,
-            participants=[self.user],
-            _quantity=100,
-        )
-        baker.make(
-            Evaluation,
-            course__semester=semester2,
-            state=Evaluation.State.PUBLISHED,
-            participants=[self.user],
-            _quantity=100,
-        )
+
+        for semester in [semester1, semester2]:
+            baker.make(
+                Evaluation,
+                course__semester=semester,
+                state=Evaluation.State.PUBLISHED,
+                participants=[self.user],
+                _quantity=100,
+                _bulk_create=True,
+            )
 
         with self.assertNumQueries(FuzzyInt(0, 100)):
             self.app.get(self.url, user=self.user)

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -37,14 +37,15 @@ class TestStudentIndexView(WebTestWith200Check):
         semester2 = baker.make(Semester, participations_are_archived=True)
 
         for semester in [semester1, semester2]:
-            baker.make(
+            evaluations = baker.make(
                 Evaluation,
                 course__semester=semester,
                 state=Evaluation.State.PUBLISHED,
-                participants=[self.user],
                 _quantity=100,
                 _bulk_create=True,
             )
+            participations = [Evaluation.participants.through(evaluation=e, userprofile=self.user) for e in evaluations]
+            Evaluation.participants.through.objects.bulk_create(participations)
 
         with self.assertNumQueries(FuzzyInt(0, 100)):
             self.app.get(self.url, user=self.user)

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -201,8 +201,7 @@ class TestVoteView(WebTest):
         page = self.app.get(self.url, user=self.voting_user1.email, status=200)
         form = page.forms["student-vote-form"]
         self.fill_form(form, fill_general_complete=False)
-        response = form.submit()
-        self.assertEqual(response.status_code, 200)
+        response = form.submit(status=200)
         self.assertIn("vote for all rating questions", response)
 
         form = page.forms["student-vote-form"]
@@ -239,8 +238,7 @@ class TestVoteView(WebTest):
         page = self.app.get(self.url, user=self.voting_user1, status=200)
         form = page.forms["student-vote-form"]
         self.fill_form(form, fill_contributors_complete=False)
-        response = form.submit()
-        self.assertEqual(response.status_code, 200)
+        response = form.submit(status=200)
         self.assertIn("vote for all rating questions", response)
 
         form = page.forms["student-vote-form"]
@@ -386,8 +384,7 @@ class TestVoteView(WebTest):
         form = page.forms["student-vote-form"]
         self.fill_form(form)
         page = self.app.get(reverse("django-auth-logout"), user=self.voting_user1, status=302)
-        response = form.submit()
-        self.assertEqual(response.status_code, 302)
+        response = form.submit(status=302)
         self.assertNotIn(SUCCESS_MAGIC_STRING, response)
 
     def test_midterm_evaluation_warning(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,14 @@ module = [
     "evap.staff.fixtures.*",
 ]
 ignore_missing_imports = true
+
+##############################################
+
+[tool.pytest.ini_options]
+# We don't officially use pytest, but last time we wanted to, this worked for us with pytest-django
+# pytest-xdist worked for parallelizing tests.
+DJANGO_SETTINGS_MODULE = "evap.settings"
+python_files = ["tests.py", "test_*.py", "*_tests.py"]
+testpaths = ["evap"]
+norecursedirs=["locale", "logs", "static", "static_collected", "upload"]
+addopts = "--reuse-db"


### PR DESCRIPTION
Another pull request? This guy has to be mad.

Mainly interested in what you think about the ideas in each of these commits.

Total test runtime (1 thread) went from \~78s to \~61s (\~ -21%) for me. With `./manage.py test --keepdb --parallel`, the whole test suite runs in around 30 seconds in the VM with 2 threads for me.