### PR TITLE
Provision evap via vbox and docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ That's it!
 ### Docker
 We provide experimental support to run the development setup in a docker container using
 ```bash
-vagrant up --provider docker  # to start the container
-vagrant docker-exec -it -- /evap/deployment/provision_vagrant_vm.sh   # to set up the environment
-vagrant docker-exec -it -- sudo -H -u evap bash  # to run an interactive shell
+vagrant up --provider docker
+vagrant provision
+vagrant ssh
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ vagrant ssh
 That's it!
 
 
+### Docker
+We provide experimental support to run the development setup in a docker container using
+```bash
+vagrant up --provider docker  # to start the container
+vagrant docker-exec -it -- /evap/deployment/provision_vagrant_vm.sh   # to set up the environment
+vagrant docker-exec -it -- sudo -H -u evap bash  # to run an interactive shell
+```
+
+
 ## Contributing
 
 We'd love to see contributions, feel free to fork! You should probably branch off ``main``, the branch ``release`` is used for stable revisions.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,10 +17,18 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  config.vm.provider :docker do |d|
+  config.vm.provider :docker do |d, override|
     d.image = "ubuntu:bionic"
     # Docker container really are supposed to be used differently. Hacky way to make it into a "VM".
     d.cmd = ["tail", "-f", "/dev/null"]
+
+    # Workaround for no SSH server as long as https://github.com/hashicorp/vagrant/issues/8145 is still open
+    override.trigger.before :provision do |trigger|
+      trigger.ruby do |env, machine| system("vagrant docker-exec -it -- /evap/deployment/provision_vagrant_vm.sh") end
+    end
+    override.trigger.before :ssh do |trigger|
+      trigger.ruby do |env, machine| system("vagrant docker-exec -it -- sudo -H -u evap bash") end
+    end
   end
 
   # port forwarding

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,25 +4,29 @@
 Vagrant.require_version ">= 1.8.1"
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/bionic64"
-  config.vm.box_version = "= 20210928.0.0 "
+  config.vm.provider :virtualbox do |v, override|
+    override.vm.box = "ubuntu/bionic64"
+    override.vm.box_version = "= 20210928.0.0 "
+    override.vm.provision "shell", path: "deployment/provision_vagrant_vm.sh"
 
-  # port forwarding
-  config.vm.network :forwarded_port, guest: 8000, host: 8000 # django server
-  config.vm.network :forwarded_port, guest: 80, host: 8001 # apache
-  config.vm.network :forwarded_port, guest: 6379, host: 6379 # redis. helpful when developing on windows, for which redis is not available
-
-  config.vm.provider :virtualbox do |v, _override|
     # disable logfile
     if Vagrant::Util::Platform.windows?
       v.customize [ "modifyvm", :id, "--uartmode1", "file", "nul" ]
     else
       v.customize [ "modifyvm", :id, "--uartmode1", "file", "/dev/null" ]
     end
-
-    # show virtualbox gui, uncomment this to debug startup problems
-    #v.gui = true
   end
+
+  config.vm.provider :docker do |d|
+    d.image = "ubuntu:bionic"
+    # Docker container really are supposed to be used differently. Hacky way to make it into a "VM".
+    d.cmd = ["tail", "-f", "/dev/null"]
+  end
+
+  # port forwarding
+  config.vm.network :forwarded_port, guest: 8000, host: 8000 # django server
+  config.vm.network :forwarded_port, guest: 80, host: 8001 # apache
+  config.vm.network :forwarded_port, guest: 6379, host: 6379 # redis. helpful when developing on windows, for which redis is not available
 
   # override username to be evap instead of vagrant, just as it is on production.
   # This is necessary so management script can assume evap is the correct user to
@@ -34,6 +38,4 @@ Vagrant.configure("2") do |config|
   if ARGV[0] == "ssh" or ARGV[0] == "ssh-config"
     config.ssh.username = 'evap'
   end
-
-  config.vm.provision "shell", path: "deployment/provision_vagrant_vm.sh"
 end

--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -71,12 +71,15 @@ a2dissite 000-default.conf
 # see https://github.com/e-valuation/EvaP/issues/626
 # and https://docs.djangoproject.com/en/dev/howto/deployment/wsgi/modwsgi/#if-you-get-a-unicodeencodeerror
 sed -i s,\#.\ /etc/default/locale,.\ /etc/default/locale,g /etc/apache2/envvars
-systemctl reload apache2
+service apache2 reload
 
 cp /etc/skel/.bashrc /home/$USER/
 # auto cd into /$USER on login and activate venv
 echo "cd $REPO_FOLDER" >> /home/$USER/.bashrc
 echo "source $ENV_FOLDER/bin/activate" >> /home/$USER/.bashrc
+
+# required for docker (no-op if already started)
+echo "sudo service postgresql start && sudo service redis-server start" >> /home/$USER/.bashrc
 
 # install requirements
 sudo -H -u $USER $ENV_FOLDER/bin/pip install -r $REPO_FOLDER/requirements-dev.txt
@@ -96,7 +99,7 @@ wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh --no-verbos
 
 # setup evap
 cd "$MOUNTPOINT"
-git submodule update --init
+sudo -H -u $USER git submodule update --init
 sudo -H -u $USER bash -c "source /home/$USER/.nvm/nvm.sh; nvm install --no-progress node; npm ci"
 echo "nvm use node" >> /home/$USER/.bashrc
 sudo -H -u $USER $ENV_FOLDER/bin/python manage.py migrate --noinput


### PR DESCRIPTION
`vagrant` up --provider=docker` can now be used to provision docker on e.g. macOS Monterey (Intel and M1) where vbox can currently not run.