### PR TITLE
Fix LoggedModel.thread.request not being cleared in failing tests

### DIFF
--- a/evap/evaluation/middleware.py
+++ b/evap/evaluation/middleware.py
@@ -19,9 +19,14 @@ class LoggingRequestMiddleware:
         LoggedModel.thread.request = request
         LoggedModel.thread.request_id = str(uuid.uuid4())
 
-        response = self.get_response(request)
-
-        del LoggedModel.thread.request
-        del LoggedModel.thread.request_id
+        try:
+            # django documentation says to just do this without the try, and that exceptions will be handled:
+            # https://docs.djangoproject.com/en/4.0/topics/http/middleware/#writing-your-own-middleware
+            # However, django-webtest sets DEBUG_PROPAGATE_EXCEPTIONS, and propagated exceptions caused our deletion to
+            # be skipped, leading to weird errors in the tests executed afterwards. See #1727.
+            response = self.get_response(request)
+        finally:
+            del LoggedModel.thread.request
+            del LoggedModel.thread.request_id
 
         return response


### PR DESCRIPTION
The deletion was not working for failing tests. This caused the setup logic for following tests to assume that the "old" `request.user` is responsible for the current change (usually a `baker.make()` call), while the user object didn't even exist in the database anymore. In consequence, it caused foreign key integrity errors for tests that are totally unrelated to the actual failure.

This is interesting because it contradicts (my interpretation) of the [django documentation](https://docs.djangoproject.com/en/4.0/topics/http/middleware/#writing-your-own-middleware), which reads as if just running teardown code after calling `self.get_response(request)` should be fine, because there should be some wrapper that catches exceptions and turns them into 400 or 500 responses. Maybe this does not apply when running tests with our setup so we can get meaningful stack traces?

Anyway, it doesn't look to me as if this would be critical for any other middleware. The language middleware might not correctly set the language cookie, but that shouldn't be an issue.