### PR TITLE
Link to user edit pages in importer messages

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1062,7 +1062,7 @@ class Contribution(LoggedModel):
         RatingAnswerCounter.objects.filter(contribution=self, question__questionnaire__in=questionnaires).delete()
 
 
-class Question(models.Model):  # pylint: disable=no-init
+class Question(models.Model):
     """A question including a type."""
 
     TEXT = 0

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1062,7 +1062,7 @@ class Contribution(LoggedModel):
         RatingAnswerCounter.objects.filter(contribution=self, question__questionnaire__in=questionnaires).delete()
 
 
-class Question(models.Model):
+class Question(models.Model):  # pylint: disable=no-init
     """A question including a type."""
 
     TEXT = 0

--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -9,9 +9,9 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils.html import format_html, format_html_join
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
-from django.utils.safestring import mark_safe
 
 from evap.evaluation.models import Contribution, Course, CourseType, Degree, Evaluation, UserProfile
 from evap.evaluation.tools import clean_email, unordered_groupby

--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -324,15 +324,14 @@ class ExcelImporter:
             msg = format_html(_("The existing user would be overwritten with the following data:"))
         else:
             msg = format_html(_("The existing user was overwritten with the following data:"))
-        return (
-            msg
-            + format_html(
-                "<br /> - {} ({}) [{}]",
-                ExcelImporter._create_user_string(user),
-                _("existing"),
-                user_edit_link(user.pk),
-            )
-            + format_html("<br /> - {} ({})", ExcelImporter._create_user_string(user_data), _("new"))
+        return format_html(
+            "{}<br /> - {} ({}) [{}]<br /> - {} ({})",
+            msg,
+            ExcelImporter._create_user_string(user),
+            _("existing"),
+            user_edit_link(user.pk),
+            ExcelImporter._create_user_string(user_data),
+            _("new"),
         )
 
     @staticmethod

--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -14,7 +14,7 @@ from django.utils.translation import gettext_lazy
 
 from evap.evaluation.models import Contribution, Course, CourseType, Degree, Evaluation, UserProfile
 from evap.evaluation.tools import clean_email, unordered_groupby
-from evap.staff.tools import ImportType, create_user_list_html_string_for_message
+from evap.staff.tools import ImportType, create_user_list_html_string_for_message, user_edit_link
 
 
 def sorted_messages(messages):
@@ -326,7 +326,12 @@ class ExcelImporter:
             msg = format_html(_("The existing user was overwritten with the following data:"))
         return (
             msg
-            + format_html("<br /> - {} ({})", ExcelImporter._create_user_string(user), _("existing"))
+            + format_html(
+                "<br /> - {} ({}) [{}]",
+                ExcelImporter._create_user_string(user),
+                _("existing"),
+                user_edit_link(user.pk),
+            )
             + format_html("<br /> - {} ({})", ExcelImporter._create_user_string(user_data), _("new"))
         )
 
@@ -335,19 +340,26 @@ class ExcelImporter:
         user_string = ExcelImporter._create_user_string(user)
         if test_run:
             return format_html(
-                _("The following user is currently marked inactive and will be marked active upon importing: {}"),
+                _("The following user is currently marked inactive and will be marked active upon importing: {} [{}]"),
                 user_string,
+                user_edit_link(user.pk),
             )
 
         return format_html(
-            _("The following user was previously marked inactive and is now marked active upon importing: {}"),
+            _("The following user was previously marked inactive and is now marked active upon importing: {} [{}]"),
             user_string,
+            user_edit_link(user.pk),
         )
 
     def _create_user_name_collision_warning(self, user_data, users_with_same_names):
         warningstring = format_html(_("An existing user has the same first and last name as a new user:"))
         for user in users_with_same_names:
-            warningstring += format_html("<br /> - {} ({})", self._create_user_string(user), _("existing"))
+            warningstring += format_html(
+                "<br /> - {} ({}) [{}]",
+                self._create_user_string(user),
+                _("existing"),
+                user_edit_link(user.pk),
+            )
         warningstring += format_html("<br /> - {} ({})", self._create_user_string(user_data), _("new"))
 
         self.warnings[ImporterWarning.DUPL].append(warningstring)

--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -11,6 +11,7 @@ from django.db import transaction
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
+from django.utils.safestring import mark_safe
 
 from evap.evaluation.models import Contribution, Course, CourseType, Degree, Evaluation, UserProfile
 from evap.evaluation.tools import clean_email, unordered_groupby
@@ -321,9 +322,9 @@ class ExcelImporter:
     @staticmethod
     def _create_user_data_mismatch_warning(user, user_data, test_run):
         if test_run:
-            msg = format_html(_("The existing user would be overwritten with the following data:"))
+            msg = _("The existing user would be overwritten with the following data:")
         else:
-            msg = format_html(_("The existing user was overwritten with the following data:"))
+            msg = _("The existing user was overwritten with the following data:")
         return format_html(
             "{}<br /> - {} ({}) [{}]<br /> - {} ({})",
             msg,
@@ -351,7 +352,7 @@ class ExcelImporter:
         )
 
     def _create_user_name_collision_warning(self, user_data, users_with_same_names):
-        warningstring = format_html(_("An existing user has the same first and last name as a new user:"))
+        warningstring = mark_safe(_("An existing user has the same first and last name as a new user:"))
         for user in users_with_same_names:
             warningstring += format_html(
                 "<br /> - {} ({}) [{}]",

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -10,7 +10,7 @@ from model_bakery import baker
 import evap.staff.fixtures.excel_files_test_data as excel_data
 from evap.evaluation.models import Contribution, Course, CourseType, Degree, Evaluation, Semester, UserProfile
 from evap.staff.importers import EnrollmentImporter, ImporterError, ImporterWarning, PersonImporter, UserImporter
-from evap.staff.tools import ImportType
+from evap.staff.tools import ImportType, user_edit_link
 
 
 class TestUserImporter(TestCase):
@@ -71,7 +71,7 @@ class TestUserImporter(TestCase):
         self.assertTrue(UserProfile.objects.filter(email="bastius.quid@external.example.com").exists())
 
     def test_duplicate_warning(self):
-        baker.make(UserProfile, first_name="Lucilia", last_name="Manilium", email="luma@institution.example.com")
+        user = baker.make(UserProfile, first_name="Lucilia", last_name="Manilium", email="luma@institution.example.com")
 
         __, __, warnings_test, __ = UserImporter.process(self.valid_excel_content, test_run=True)
         __, __, warnings_no_test, __ = UserImporter.process(self.valid_excel_content, test_run=False)
@@ -81,8 +81,8 @@ class TestUserImporter(TestCase):
             warnings_test[ImporterWarning.DUPL],
             [
                 "An existing user has the same first and last name as a new user:<br />"
-                " -  Lucilia Manilium, luma@institution.example.com (existing)<br />"
-                " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)"
+                " -  Lucilia Manilium, luma@institution.example.com (existing) [{}]<br />"
+                " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)".format(user_edit_link(user.pk)),
             ],
         )
 
@@ -123,14 +123,14 @@ class TestUserImporter(TestCase):
         self.assertEqual(UserProfile.objects.count(), original_user_count)
 
     def test_import_makes_inactive_user_active(self):
-        baker.make(UserProfile, email="lucilia.manilium@institution.example.com", is_active=False)
+        user = baker.make(UserProfile, email="lucilia.manilium@institution.example.com", is_active=False)
 
         __, __, warnings_test, __ = UserImporter.process(self.valid_excel_content, test_run=True)
         self.assertEqual(
             warnings_test[ImporterWarning.INACTIVE],
             [
                 "The following user is currently marked inactive and will be marked active upon importing: "
-                " None None, lucilia.manilium@institution.example.com"
+                " None None, lucilia.manilium@institution.example.com [{}]".format(user_edit_link(user.pk)),
             ],
         )
 
@@ -139,7 +139,7 @@ class TestUserImporter(TestCase):
             warnings_no_test[ImporterWarning.INACTIVE],
             [
                 "The following user was previously marked inactive and is now marked active upon importing: "
-                " None None, lucilia.manilium@institution.example.com"
+                " None None, lucilia.manilium@institution.example.com [{}]".format(user_edit_link(user.pk))
             ],
         )
 

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -81,8 +81,8 @@ class TestUserImporter(TestCase):
             warnings_test[ImporterWarning.DUPL],
             [
                 "An existing user has the same first and last name as a new user:<br />"
-                " -  Lucilia Manilium, luma@institution.example.com (existing) [{}]<br />"
-                " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)".format(user_edit_link(user.pk)),
+                f" -  Lucilia Manilium, luma@institution.example.com (existing) [{user_edit_link(user.pk)}]<br />"
+                " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)",
             ],
         )
 
@@ -130,7 +130,7 @@ class TestUserImporter(TestCase):
             warnings_test[ImporterWarning.INACTIVE],
             [
                 "The following user is currently marked inactive and will be marked active upon importing: "
-                " None None, lucilia.manilium@institution.example.com [{}]".format(user_edit_link(user.pk)),
+                f" None None, lucilia.manilium@institution.example.com [{user_edit_link(user.pk)}]",
             ],
         )
 
@@ -139,7 +139,7 @@ class TestUserImporter(TestCase):
             warnings_no_test[ImporterWarning.INACTIVE],
             [
                 "The following user was previously marked inactive and is now marked active upon importing: "
-                " None None, lucilia.manilium@institution.example.com [{}]".format(user_edit_link(user.pk))
+                f" None None, lucilia.manilium@institution.example.com [{user_edit_link(user.pk)}]"
             ],
         )
 

--- a/evap/staff/tests/test_tools.py
+++ b/evap/staff/tests/test_tools.py
@@ -7,7 +7,12 @@ from model_bakery import baker
 from evap.evaluation.models import Contribution, Course, Evaluation, UserProfile
 from evap.evaluation.tests.tools import WebTest
 from evap.rewards.models import RewardPointGranting, RewardPointRedemption
-from evap.staff.tools import delete_navbar_cache_for_users, merge_users, remove_user_from_represented_and_ccing_users
+from evap.staff.tools import (
+    delete_navbar_cache_for_users,
+    merge_users,
+    remove_user_from_represented_and_ccing_users,
+    user_edit_link,
+)
 
 
 class NavbarCacheTest(WebTest):
@@ -257,3 +262,9 @@ class RemoveUserFromRepresentedAndCCingUsersTest(TestCase):
         self.assertEqual([set(user1.delegates.all()), set(user1.cc_users.all())], [{delete_user}, {delete_user}])
         self.assertEqual([set(user2.delegates.all()), set(user2.cc_users.all())], [{delete_user}, {delete_user}])
         self.assertEqual(len(messages), 4)
+
+
+class UserEditLinkTest(TestCase):
+    def test_user_edit_link(self):
+        user = baker.make(UserProfile)
+        self.assertIn(f"/staff/user/{user.id}/edit", user_edit_link(user.id))

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -53,6 +53,7 @@ from evap.staff.tests.utils import (
     helper_set_dynamic_choices_field_value,
     run_in_staff_mode,
 )
+from evap.staff.tools import user_edit_link
 from evap.staff.views import get_evaluations_with_prefetched_data
 from evap.student.models import TextAnswerWarning
 
@@ -536,7 +537,7 @@ class TestUserImportView(WebTestStaffMode):
         """
         Tests whether warnings given from the importer are displayed
         """
-        baker.make(UserProfile, email="lucilia.manilium@institution.example.com")
+        user = baker.make(UserProfile, email="lucilia.manilium@institution.example.com")
 
         page = self.app.get(self.url, user=self.manager)
 
@@ -547,8 +548,8 @@ class TestUserImportView(WebTestStaffMode):
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"
-            " -  None None, lucilia.manilium@institution.example.com (existing)<br />"
-            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)",
+            " -  None None, lucilia.manilium@institution.example.com (existing) [{}]<br />"
+            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)".format(user_edit_link(user.pk)),
         )
 
         helper_delete_all_import_files(self.manager.id)
@@ -1028,7 +1029,7 @@ class TestSemesterImportView(WebTestStaffMode):
         """
         Tests whether warnings given from the importer are displayed
         """
-        baker.make(UserProfile, email="lucilia.manilium@institution.example.com")
+        user = baker.make(UserProfile, email="lucilia.manilium@institution.example.com")
 
         page = self.app.get(self.url, user=self.manager)
 
@@ -1042,8 +1043,8 @@ class TestSemesterImportView(WebTestStaffMode):
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"
-            " -  None None, lucilia.manilium@institution.example.com (existing)<br />"
-            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)",
+            " -  None None, lucilia.manilium@institution.example.com (existing) [{}]<br />"
+            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)".format(user_edit_link(user.pk)),
         )
 
     def test_suspicious_operation(self):
@@ -2228,7 +2229,7 @@ class TestEvaluationImportPersonsView(WebTestStaffMode):
         """
         Tests whether warnings given from the importer are displayed
         """
-        baker.make(UserProfile, email="lucilia.manilium@institution.example.com")
+        user = baker.make(UserProfile, email="lucilia.manilium@institution.example.com")
 
         page = self.app.get(self.url, user=self.manager)
 
@@ -2239,8 +2240,8 @@ class TestEvaluationImportPersonsView(WebTestStaffMode):
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"
-            " -  None None, lucilia.manilium@institution.example.com (existing)<br />"
-            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)",
+            " -  None None, lucilia.manilium@institution.example.com (existing) [{}]<br />"
+            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)".format(user_edit_link(user.pk)),
         )
 
     def test_import_contributors_error_handling(self):
@@ -2262,7 +2263,7 @@ class TestEvaluationImportPersonsView(WebTestStaffMode):
         """
         Tests whether warnings given from the importer are displayed
         """
-        baker.make(UserProfile, email="lucilia.manilium@institution.example.com")
+        user = baker.make(UserProfile, email="lucilia.manilium@institution.example.com")
 
         page = self.app.get(self.url, user=self.manager)
 
@@ -2273,8 +2274,8 @@ class TestEvaluationImportPersonsView(WebTestStaffMode):
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"
-            " -  None None, lucilia.manilium@institution.example.com (existing)<br />"
-            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)",
+            " -  None None, lucilia.manilium@institution.example.com (existing) [{}]<br />"
+            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)".format(user_edit_link(user.pk)),
         )
 
     def test_suspicious_operation(self):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -548,8 +548,8 @@ class TestUserImportView(WebTestStaffMode):
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"
-            " -  None None, lucilia.manilium@institution.example.com (existing) [{}]<br />"
-            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)".format(user_edit_link(user.pk)),
+            f" -  None None, lucilia.manilium@institution.example.com (existing) [{user_edit_link(user.pk)}]<br />"
+            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)",
         )
 
         helper_delete_all_import_files(self.manager.id)
@@ -1043,8 +1043,8 @@ class TestSemesterImportView(WebTestStaffMode):
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"
-            " -  None None, lucilia.manilium@institution.example.com (existing) [{}]<br />"
-            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)".format(user_edit_link(user.pk)),
+            f" -  None None, lucilia.manilium@institution.example.com (existing) [{user_edit_link(user.pk)}]<br />"
+            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)",
         )
 
     def test_suspicious_operation(self):
@@ -2240,8 +2240,8 @@ class TestEvaluationImportPersonsView(WebTestStaffMode):
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"
-            " -  None None, lucilia.manilium@institution.example.com (existing) [{}]<br />"
-            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)".format(user_edit_link(user.pk)),
+            f" -  None None, lucilia.manilium@institution.example.com (existing) [{user_edit_link(user.pk)}]<br />"
+            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)",
         )
 
     def test_import_contributors_error_handling(self):
@@ -2274,8 +2274,8 @@ class TestEvaluationImportPersonsView(WebTestStaffMode):
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"
-            " -  None None, lucilia.manilium@institution.example.com (existing) [{}]<br />"
-            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)".format(user_edit_link(user.pk)),
+            f" -  None None, lucilia.manilium@institution.example.com (existing) [{user_edit_link(user.pk)}]<br />"
+            " -  Lucilia Manilium, lucilia.manilium@institution.example.com (new)",
         )
 
     def test_suspicious_operation(self):

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -375,7 +375,7 @@ def remove_user_from_represented_and_ccing_users(user, ignored_users=None, test_
 
 def user_edit_link(user_id):
     return format_html(
-        '<a href="{}" target=_blank><span class="fas fa-user-pen"> {}</span></a>',
+        '<a href="{}" target=_blank><span class="fas fa-user-pen"></span> {}</a>',
         reverse("staff:user_edit", kwargs={"user_id": user_id}),
         _("edit user"),
     )

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -10,6 +10,7 @@ from django.core.cache.utils import make_template_fragment_key
 from django.core.exceptions import SuspiciousOperation
 from django.db import transaction
 from django.db.models import Count
+from django.urls import reverse
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext_lazy as _
 
@@ -370,3 +371,11 @@ def remove_user_from_represented_and_ccing_users(user, ignored_users=None, test_
             cc_user.cc_users.remove(user)
             remove_messages.append(_("Removed {} from the CC users of {}.").format(user.full_name, cc_user.full_name))
     return remove_messages
+
+
+def user_edit_link(user_id):
+    return format_html(
+        '<a href="{}" target=_blank>edit user <span class="fas fa-external-link-alt"></span></a>'.format(
+            reverse("staff:user_edit", kwargs={"user_id": user_id})
+        )
+    )

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -375,7 +375,8 @@ def remove_user_from_represented_and_ccing_users(user, ignored_users=None, test_
 
 def user_edit_link(user_id):
     return format_html(
-        '<a href="{}" target=_blank><span class="fas fa-user-pen"> edit user</span></a>'.format(
-            reverse("staff:user_edit", kwargs={"user_id": user_id})
+        '<a href="{}" target=_blank><span class="fas fa-user-pen"> {}</span></a>'.format(
+            reverse("staff:user_edit", kwargs={"user_id": user_id}),
+            _("edit user"),
         )
     )

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -375,7 +375,7 @@ def remove_user_from_represented_and_ccing_users(user, ignored_users=None, test_
 
 def user_edit_link(user_id):
     return format_html(
-        '<a href="{}" target=_blank>edit user <span class="fas fa-external-link-alt"></span></a>'.format(
+        '<a href="{}" target=_blank><span class="fas fa-user-pen"> edit user</span></a>'.format(
             reverse("staff:user_edit", kwargs={"user_id": user_id})
         )
     )

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -375,8 +375,7 @@ def remove_user_from_represented_and_ccing_users(user, ignored_users=None, test_
 
 def user_edit_link(user_id):
     return format_html(
-        '<a href="{}" target=_blank><span class="fas fa-user-pen"> {}</span></a>'.format(
-            reverse("staff:user_edit", kwargs={"user_id": user_id}),
-            _("edit user"),
-        )
+        '<a href="{}" target=_blank><span class="fas fa-user-pen"> {}</span></a>',
+        reverse("staff:user_edit", kwargs={"user_id": user_id}),
+        _("edit user"),
     )


### PR DESCRIPTION
Closes #1679

Preview:
![grafik](https://user-images.githubusercontent.com/45318735/160471468-d5cad756-0fbe-48d6-b689-0713582d40b8.png)

First I had `user_edit_link` in the importer but then recognised that it is a pain forming the strings in the tests, so I moved it into tools. But im not sure if that is the right place for it