### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 Please do not open GitHub issues for anything you think might have a security implication.
 
-Security issues and bugs should be reported privately by emailing any of the e-valuation members at https://github.com/orgs/e-valuation/people.
+Security issues and bugs should be reported privately by emailing any of the [organization members](https://github.com/orgs/e-valuation/people).
 
 We will try to acknowledge your messages within 48 hours.
 If for some reason you do not receive an acknowledgement, please follow up to ensure we received your original message.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Please do not open GitHub issues for anything you think might have a security implication.
+
+Security issues and bugs should be reported privately by emailing any of the e-valuation members at https://github.com/orgs/e-valuation/people.
+
+We will try to acknowledge your messages within 48 hours.
+If for some reason you do not receive an acknowledgement, please follow up to ensure we received your original message.


### PR DESCRIPTION
This is a minimum version right now.

We could add more (for example any of the following) if we wanted, but would it help?
* ("Disclosure") We will track security-relevant changes in the changelog (would wait with that until we have a changelog set up).
    * Might be worth adding: Vulnerability Information will be made public after patches have been applied to production -- but it's kind of pointless without specifying, where exactly it will be made public?
* ("Supported version") - We do not officially give any warranty or support (license already says that -- but most open source projects have similar licenses, yet try to offer supported versions of some kind)