### PR TITLE
Make refresh_results_cache 6x faster

### DIFF
--- a/evap/evaluation/management/commands/anonymize.py
+++ b/evap/evaluation/management/commands/anonymize.py
@@ -1,7 +1,6 @@
 import itertools
 import os
 import random
-from collections import defaultdict
 from datetime import date, timedelta
 from math import floor
 
@@ -23,6 +22,7 @@ from evap.evaluation.models import (
     TextAnswer,
     UserProfile,
 )
+from evap.evaluation.tools import unordered_groupby
 
 
 class Command(BaseCommand):
@@ -233,9 +233,9 @@ class Command(BaseCommand):
             for contribution_counter, contribution in enumerate(contributions):
                 progress_bar.update(contribution_counter + 1)
 
-                counters_per_question = defaultdict(list)
-                for counter in contribution.ratinganswercounter_set.all():
-                    counters_per_question[counter.question].append(counter)
+                counters_per_question = unordered_groupby(
+                    (counter.question, counter) for counter in contribution.ratinganswercounter_set.all()
+                )
 
                 for question, counters in counters_per_question.items():
                     original_sum = sum(counter.count for counter in counters)

--- a/evap/evaluation/management/commands/refresh_results_cache.py
+++ b/evap/evaluation/management/commands/refresh_results_cache.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
 
         for counter, evaluation in enumerate(evaluations):
             progress_bar.update(counter + 1)
-            cache_results(evaluation)
+            cache_results(evaluation, refetch_related_objects=False)
 
         self.stdout.write("Prerendering result index page...\n")
 

--- a/evap/evaluation/management/commands/refresh_results_cache.py
+++ b/evap/evaluation/management/commands/refresh_results_cache.py
@@ -3,7 +3,12 @@ from django.core.management.base import BaseCommand
 from django.core.serializers.base import ProgressBar
 
 from evap.evaluation.models import Evaluation
-from evap.results.tools import STATES_WITH_RESULT_TEMPLATE_CACHING, STATES_WITH_RESULTS_CACHING, cache_results
+from evap.results.tools import (
+    GET_RESULTS_PREFETCH_LOOKUPS,
+    STATES_WITH_RESULT_TEMPLATE_CACHING,
+    STATES_WITH_RESULTS_CACHING,
+    cache_results,
+)
 from evap.results.views import warm_up_template_cache
 
 
@@ -19,8 +24,11 @@ class Command(BaseCommand):
         self.stdout.write("Calculating results for all evaluations...")
 
         self.stdout.ending = None
-        evaluations = Evaluation.objects.filter(state__in=STATES_WITH_RESULTS_CACHING)
+        evaluations = Evaluation.objects.filter(state__in=STATES_WITH_RESULTS_CACHING).prefetch_related(
+            *GET_RESULTS_PREFETCH_LOOKUPS,
+        )
         progress_bar = ProgressBar(self.stdout, evaluations.count())
+
         for counter, evaluation in enumerate(evaluations):
             progress_bar.update(counter + 1)
             cache_results(evaluation)

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -34,7 +34,7 @@ from evap.evaluation.tools import (
     clean_email,
     date_to_datetime,
     is_external_email,
-    is_prefetched,
+    is_m2m_prefetched,
     translate,
     vote_end_datetime,
 )
@@ -607,7 +607,7 @@ class Evaluation(LoggedModel):
         if self._participant_count is not None:
             return self._participant_count
 
-        if is_prefetched(self, "participants"):
+        if is_m2m_prefetched(self, "participants"):
             return len(self.participants.all())
 
         return self.participants.count()

--- a/evap/evaluation/models_logging.py
+++ b/evap/evaluation/models_logging.py
@@ -3,7 +3,6 @@ import threading
 from collections import defaultdict, namedtuple
 from datetime import date, datetime, time
 from enum import Enum
-from functools import partial
 from json import JSONEncoder
 
 from django.conf import settings
@@ -132,7 +131,7 @@ class LoggedModel(models.Model):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._logentry = None
-        self._m2m_changes = defaultdict(partial(defaultdict, list))  # partial so pickling works
+        self._m2m_changes = defaultdict(lambda: defaultdict(list))
 
     def _as_dict(self):
         """

--- a/evap/evaluation/models_logging.py
+++ b/evap/evaluation/models_logging.py
@@ -3,6 +3,7 @@ import threading
 from collections import defaultdict, namedtuple
 from datetime import date, datetime, time
 from enum import Enum
+from functools import partial
 from json import JSONEncoder
 
 from django.conf import settings
@@ -131,7 +132,7 @@ class LoggedModel(models.Model):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._logentry = None
-        self._m2m_changes = defaultdict(lambda: defaultdict(list))
+        self._m2m_changes = defaultdict(partial(defaultdict, list))  # partial so pickling works
 
     def _as_dict(self):
         """

--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -5,15 +5,20 @@ from uuid import UUID
 from django.conf import settings
 from django.core import management
 from django.core.exceptions import SuspiciousOperation
+from django.db.models import prefetch_related_objects
 from django.http import Http404
 from django.test.testcases import TestCase
 from django.urls import reverse
 from django.utils import translation
 from model_bakery import baker
 
-from evap.evaluation.models import Evaluation, TextAnswer, UserProfile
+from evap.evaluation.models import Contribution, Course, Evaluation, TextAnswer, UserProfile
 from evap.evaluation.tests.tools import WebTest
-from evap.evaluation.tools import get_object_from_dict_pk_entry_or_logged_40x
+from evap.evaluation.tools import (
+    discard_cached_related_objects,
+    get_object_from_dict_pk_entry_or_logged_40x,
+    is_m2m_prefetched,
+)
 
 
 class TestLanguageSignalReceiver(WebTest):
@@ -81,6 +86,99 @@ class TestPythonVersion(TestCase):
 
 
 class TestHelperMethods(WebTest):
+    def test_is_m2m_prefetched(self):
+        evaluation = baker.make(Evaluation)
+        baker.make(Contribution, evaluation=evaluation)
+
+        self.assertFalse(is_m2m_prefetched(evaluation, "contributions"))
+
+        prefetch_related_objects([evaluation], "contributions")
+        self.assertTrue(is_m2m_prefetched(evaluation, "contributions"))
+
+        evaluation.refresh_from_db(fields=["contributions"])
+        self.assertFalse(is_m2m_prefetched(evaluation, "contributions"))
+
+        evaluation = Evaluation.objects.filter(pk=evaluation.pk).prefetch_related("contributions").first()
+        self.assertTrue(is_m2m_prefetched(evaluation, "contributions"))
+
+    def test_discard_cached_related_objects_discards_cached_foreign_key_instances(self):
+        evaluation = baker.make(Evaluation, course__name_en="old_name")
+        discard_cached_related_objects(evaluation)
+
+        # Instances are implicitly cached on access
+        with self.assertNumQueries(1):
+            self.assertEqual(evaluation.course.name_en, "old_name")
+        Course.objects.filter(pk=evaluation.course.pk).update(name_en="new_name")
+        with self.assertNumQueries(0):
+            self.assertEqual(evaluation.course.name_en, "old_name")
+
+        # method drops that cache
+        discard_cached_related_objects(evaluation)
+        with self.assertNumQueries(1):
+            self.assertEqual(evaluation.course.name_en, "new_name")
+
+        # Explicitly cached FK-fields (through select_related) are discarded
+        evaluation = Evaluation.objects.filter(pk=evaluation.pk).select_related("course").first()
+        Course.objects.filter(pk=evaluation.course.pk).update(name_en="even_newer_name")
+        with self.assertNumQueries(0):
+            self.assertEqual(evaluation.course.name_en, "new_name")
+        discard_cached_related_objects(evaluation)
+        with self.assertNumQueries(1):
+            self.assertEqual(evaluation.course.name_en, "even_newer_name")
+
+    def test_discard_cached_related_objects_discards_cached_reverse_foreign_key_instances(self):
+        course = baker.make(Course)
+        baker.make(Evaluation, course=course)
+        discard_cached_related_objects(course)
+
+        # Reverse FK-relationships are not implicitly cached:
+        with self.assertNumQueries(1):
+            self.assertEqual(len(list(course.evaluations.all())), 1)
+        with self.assertNumQueries(1):
+            self.assertEqual(len(list(course.evaluations.all())), 1)
+
+        # Explicitly cached reverse FK-fields (through prefetch_related_objects) are discarded
+        prefetch_related_objects([course], "evaluations")
+        with self.assertNumQueries(0):
+            self.assertEqual(len(list(course.evaluations.all())), 1)
+        discard_cached_related_objects(course)
+        with self.assertNumQueries(1):
+            self.assertEqual(len(list(course.evaluations.all())), 1)
+
+        # Explicitly cached reverse FK-fields (through prefetch_related) are discarded
+        course = Course.objects.filter(pk=course.pk).prefetch_related("evaluations").first()
+        with self.assertNumQueries(0):
+            self.assertEqual(len(list(course.evaluations.all())), 1)
+        discard_cached_related_objects(course)
+        with self.assertNumQueries(1):
+            self.assertEqual(len(list(course.evaluations.all())), 1)
+
+    def test_discard_cached_related_objects_discards_cached_m2m_instances(self):
+        evaluation = baker.make(Evaluation)
+        baker.make(Contribution, evaluation=evaluation)
+
+        # M2M fields are not implicitly cached
+        with self.assertNumQueries(1):
+            self.assertEqual(len(list(evaluation.contributions.all())), 2)
+        with self.assertNumQueries(1):
+            self.assertEqual(len(list(evaluation.contributions.all())), 2)
+
+        # Explicitly cached M2M fields (through prefetch_related_objects) are discarded
+        prefetch_related_objects([evaluation], "contributions")
+        with self.assertNumQueries(0):
+            self.assertEqual(len(list(evaluation.contributions.all())), 2)
+        discard_cached_related_objects(evaluation)
+        with self.assertNumQueries(1):
+            self.assertEqual(len(list(evaluation.contributions.all())), 2)
+
+        # Explicitly cached M2M fields (through prefetch_related) are discarded
+        evaluation = Evaluation.objects.filter(pk=evaluation.pk).prefetch_related("contributions").first()
+        with self.assertNumQueries(0):
+            self.assertEqual(len(list(evaluation.contributions.all())), 2)
+        discard_cached_related_objects(evaluation)
+        with self.assertNumQueries(1):
+            self.assertEqual(len(list(evaluation.contributions.all())), 2)
+
     def test_get_object_from_dict_pk_entry_or_logged_40x_for_ints(self):
         # Invalid PKs
         with self.assertRaises(SuspiciousOperation):

--- a/evap/evaluation/tools.py
+++ b/evap/evaluation/tools.py
@@ -22,7 +22,6 @@ def get_object_from_dict_pk_entry_or_logged_40x(model_cls: Type[M], dict_obj: Ma
         raise SuspiciousOperation from e
 
 
-# TODO: Test
 def is_m2m_prefetched(instance, attribute_name):
     """
     Is the given M2M-attribute prefetched? Can be used to do ordering or counting
@@ -31,7 +30,6 @@ def is_m2m_prefetched(instance, attribute_name):
     return hasattr(instance, "_prefetched_objects_cache") and attribute_name in instance._prefetched_objects_cache
 
 
-# TODO: Test
 def discard_cached_related_objects(instance):
     """
     Discard all cached related objects (for ForeignKey and M2M Fields). Useful

--- a/evap/evaluation/tools.py
+++ b/evap/evaluation/tools.py
@@ -22,9 +22,10 @@ def get_object_from_dict_pk_entry_or_logged_40x(model_cls: Type[M], dict_obj: Ma
         raise SuspiciousOperation from e
 
 
-def is_prefetched(instance, attribute_name):
+# TODO: Test
+def is_m2m_prefetched(instance, attribute_name):
     """
-    Is the given attribute prefetched? Can be used to do ordering or counting
+    Is the given M2M-attribute prefetched? Can be used to do ordering or counting
     in python and avoid additional database queries
     """
     return hasattr(instance, "_prefetched_objects_cache") and attribute_name in instance._prefetched_objects_cache

--- a/evap/evaluation/tools.py
+++ b/evap/evaluation/tools.py
@@ -1,6 +1,7 @@
 import datetime
 from abc import ABC, abstractmethod
-from typing import Any, Mapping, Optional, Type, TypeVar
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Type, TypeVar
 from urllib.parse import quote
 
 import xlwt
@@ -12,6 +13,22 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import get_language
 
 M = TypeVar("M", bound=Model)
+Key = TypeVar("Key")
+Value = TypeVar("Value")
+
+
+def unordered_groupby(key_value_pairs: Iterable[Tuple[Key, Value]]) -> Dict[Key, List[Value]]:
+    """
+    We need this in several places: Take list of (key, value) pairs and make
+    them into the aggregated all-values-of-every-unique-key dict. Note that
+    this slightly differs from itertools.groupby (and uniq), as we don't
+    require anything to be sorted and you get a dict as return value.
+    """
+    result = defaultdict(list)
+    for key, value in key_value_pairs:
+        result[key].append(value)
+
+    return dict(result)
 
 
 def get_object_from_dict_pk_entry_or_logged_40x(model_cls: Type[M], dict_obj: Mapping[str, Any], key: str) -> M:

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -530,7 +530,7 @@ class TestTextAnswerVisibilityInfo(TestCase):
     def test_text_answer_visible_to_non_contributing_responsible(self):
         self.assertIn(
             self.responsible_without_contribution,
-            textanswers_visible_to(self.general_contribution_textanswer.contribution)[0],
+            textanswers_visible_to(self.general_contribution_textanswer.contribution).visible_by_contribution,
         )
 
     def test_contributors_and_delegate_count_in_textanswer_visibility_info(self):
@@ -555,7 +555,7 @@ class TestTextAnswerVisibilityInfo(TestCase):
                         users_seeing_contribution[i][1].add(user)
 
         for i in range(len(textanswers)):
-            self.assertCountEqual(visible_to[i][0], users_seeing_contribution[i][0])
+            self.assertCountEqual(visible_to[i].visible_by_contribution, users_seeing_contribution[i][0])
 
         expected_delegate_counts = [
             2,  # delegate1, delegate2
@@ -567,4 +567,8 @@ class TestTextAnswerVisibilityInfo(TestCase):
         ]
 
         for i in range(len(textanswers)):
-            self.assertTrue(visible_to[i][1] == len(users_seeing_contribution[i][1]) == expected_delegate_counts[i])
+            self.assertTrue(
+                visible_to[i].visible_by_delegation_count
+                == len(users_seeing_contribution[i][1])
+                == expected_delegate_counts[i]
+            )

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -433,16 +433,19 @@ class TestTextAnswerVisibilityInfo(TestCase):
     def setUpTestData(cls):
         cls.delegate1 = baker.make(UserProfile, email="delegate1@institution.example.com")
         cls.delegate2 = baker.make(UserProfile, email="delegate2@institution.example.com")
+        cls.shared_delegate = baker.make(UserProfile, email="shared_delegate@institution.example.com")
         cls.contributor_own = baker.make(
-            UserProfile, email="contributor_own@institution.example.com", delegates=[cls.delegate1]
+            UserProfile, email="contributor_own@institution.example.com", delegates=[cls.delegate1, cls.shared_delegate]
         )
         cls.contributor_general = baker.make(
-            UserProfile, email="contributor_general@institution.example.com", delegates=[cls.delegate2]
+            UserProfile,
+            email="contributor_general@institution.example.com",
+            delegates=[cls.delegate2, cls.shared_delegate],
         )
         cls.responsible1 = baker.make(
             UserProfile,
             email="responsible1@institution.example.com",
-            delegates=[cls.delegate1, cls.contributor_general],
+            delegates=[cls.delegate1, cls.contributor_general, cls.shared_delegate],
         )
         cls.responsible2 = baker.make(UserProfile, email="responsible2@institution.example.com")
         cls.responsible_without_contribution = baker.make(
@@ -558,12 +561,12 @@ class TestTextAnswerVisibilityInfo(TestCase):
             self.assertCountEqual(visible_to[i].visible_by_contribution, users_seeing_contribution[i][0])
 
         expected_delegate_counts = [
-            2,  # delegate1, delegate2
-            2,  # delegate1, contributor_general
-            2,  # delegate1, contributor_general
+            3,  # delegate1, delegate2, shared_delegate
+            3,  # delegate1, contributor_general, shared_delegate
+            3,  # delegate1, contributor_general, shared_delegate
             0,
-            1,  # delegate1
-            1,  # delegate2
+            2,  # delegate1, shared_delegate
+            2,  # delegate2, shared_delegate
         ]
 
         for i in range(len(textanswers)):

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -1,6 +1,7 @@
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import OrderedDict, defaultdict
+from copy import copy
 from math import ceil, modf
-from typing import Dict, List, Tuple, cast
+from typing import Dict, Iterable, List, Optional, Tuple, Union, cast
 
 from django.conf import settings
 from django.core.cache import caches
@@ -16,7 +17,9 @@ from evap.evaluation.models import (
     Questionnaire,
     RatingAnswerCounter,
     TextAnswer,
+    UserProfile,
 )
+from evap.evaluation.tools import discard_cached_related_objects
 
 STATES_WITH_RESULTS_CACHING = {Evaluation.State.EVALUATED, Evaluation.State.REVIEWED, Evaluation.State.PUBLISHED}
 STATES_WITH_RESULT_TEMPLATE_CACHING = {Evaluation.State.PUBLISHED}
@@ -31,45 +34,16 @@ GRADE_COLORS = {
 }
 
 
-class EvaluationResult:
-    def __init__(self, contribution_results):
-        self.contribution_results = contribution_results
-
-    @property
-    def questionnaire_results(self):
-        return [
-            questionnaire_result
-            for contribution_result in self.contribution_results
-            for questionnaire_result in contribution_result.questionnaire_results
-        ]
-
-
-class ContributionResult:
-    def __init__(self, contributor, label, questionnaire_results):
-        self.contributor = contributor
-        self.label = label
-        self.questionnaire_results = questionnaire_results
-
-    @property
-    def has_answers(self):
-        for questionnaire_result in self.questionnaire_results:
-            for question_result in questionnaire_result.question_results:
-                question = question_result.question
-                if question.is_text_question or question.is_rating_question and question_result.has_answers:
-                    return True
-        return False
-
-
-class QuestionnaireResult:
-    def __init__(self, questionnaire, question_results):
-        self.questionnaire = questionnaire
-        self.question_results = question_results
+class TextAnswerVisibility:
+    def __init__(self, visible_by_contribution: Iterable[UserProfile], visible_by_delegation_count: int):
+        self.visible_by_contribution = [discard_cached_related_objects(copy(user)) for user in visible_by_contribution]
+        self.visible_by_delegation_count = visible_by_delegation_count
 
 
 class RatingResult:
     def __init__(self, question, answer_counters, additional_text_result=None):
         assert question.is_rating_question
-        self.question = question
+        self.question = discard_cached_related_objects(copy(question))
         self.additional_text_result = additional_text_result
 
         if answer_counters is not None:
@@ -85,49 +59,98 @@ class RatingResult:
         return CHOICES[self.question.type]
 
     @property
-    def count_sum(self):
+    def count_sum(self) -> Optional[int]:
         if not self.is_published:
             return None
         return sum(self.counts)
 
     @property
-    def minus_balance_count(self):
+    def minus_balance_count(self) -> float:
         assert self.question.is_bipolar_likert_question
         portion_left = sum(self.counts[:3]) + self.counts[3] / 2
         return (self.count_sum - portion_left) / 2
 
     @property
-    def approval_count(self):
+    def approval_count(self) -> Optional[int]:
         assert self.question.is_yes_no_question
         if not self.is_published:
             return None
         return self.counts[0] if self.question.is_positive_yes_no_question else self.counts[1]
 
     @property
-    def average(self):
+    def average(self) -> Optional[float]:
         if not self.has_answers:
             return None
-        return sum(grade * count for count, grade in zip(self.counts, self.choices.grades)) / self.count_sum
+        return sum(grade * count for count, grade in zip(self.counts, self.choices.grades)) / self.count_sum  # type: ignore
 
     @property
-    def has_answers(self):
+    def has_answers(self) -> bool:
         return self.is_published and any(count != 0 for count in self.counts)
 
     @property
-    def is_published(self):
+    def is_published(self) -> bool:
         return self.counts is not None
 
 
 class TextResult:
-    def __init__(self, question, answers, answers_visible_to=None):
+    def __init__(
+        self,
+        question: Question,
+        answers: Iterable[TextAnswer],
+        answers_visible_to: Optional[TextAnswerVisibility] = None,
+    ):
         assert question.can_have_textanswers
-        self.question = question
-        self.answers = answers
+        self.question = discard_cached_related_objects(copy(question))
+        self.answers = [discard_cached_related_objects(copy(answer)) for answer in answers]
         self.answers_visible_to = answers_visible_to
 
 
-HeadingResult = namedtuple("HeadingResult", ("question"))
-TextAnswerVisibility = namedtuple("TextAnswerVisibility", ("visible_by_contribution", "visible_by_delegation_count"))
+class HeadingResult:
+    def __init__(self, question: Question):
+        self.question = discard_cached_related_objects(copy(question))
+
+
+QuestionResult = Union[RatingResult, TextResult, HeadingResult]
+
+
+class QuestionnaireResult:
+    def __init__(self, questionnaire: Questionnaire, question_results: List[QuestionResult]):
+        self.questionnaire = discard_cached_related_objects(copy(questionnaire))
+        self.question_results = question_results
+
+
+class ContributionResult:
+    def __init__(
+        self, contributor: Optional[UserProfile], label: Optional[str], questionnaire_results: List[QuestionnaireResult]
+    ):
+        self.contributor = discard_cached_related_objects(copy(contributor)) if contributor is not None else None
+        self.label = label
+        self.questionnaire_results = questionnaire_results
+
+    @property
+    def has_answers(self) -> bool:
+        for questionnaire_result in self.questionnaire_results:
+            for question_result in questionnaire_result.question_results:
+                question = question_result.question
+                if question.is_text_question:
+                    return True
+                if question.is_rating_question:
+                    assert isinstance(question_result, RatingResult)
+                    return question_result.has_answers
+        return False
+
+
+class EvaluationResult:
+    def __init__(self, contribution_results: List[ContributionResult]):
+        self.contribution_results = contribution_results
+
+    @property
+    def questionnaire_results(self) -> List[QuestionnaireResult]:
+        return [
+            questionnaire_result
+            for contribution_result in self.contribution_results
+            for questionnaire_result in contribution_result.questionnaire_results
+        ]
 
 
 def get_single_result_rating_result(evaluation):
@@ -144,10 +167,10 @@ def get_results_cache_key(evaluation):
     return f"evap.staff.results.tools.get_results-{evaluation.id:d}"
 
 
-def cache_results(evaluation):
+def cache_results(evaluation, *, refetch_related_objects=True):
     assert evaluation.state in STATES_WITH_RESULTS_CACHING
     cache_key = get_results_cache_key(evaluation)
-    caches["results"].set(cache_key, _get_results_impl(evaluation))
+    caches["results"].set(cache_key, _get_results_impl(evaluation, refetch_related_objects=refetch_related_objects))
 
 
 def get_results(evaluation):
@@ -171,27 +194,30 @@ GET_RESULTS_PREFETCH_LOOKUPS = [
 ]
 
 
-def _get_results_impl(evaluation: Evaluation):
+def _get_results_impl(evaluation: Evaluation, *, refetch_related_objects: bool = True):
+    # pylint: disable=too-many-branches, too-many-locals, invalid-name
+    if refetch_related_objects:
+        discard_cached_related_objects(evaluation)
+
     prefetch_related_objects([evaluation], *GET_RESULTS_PREFETCH_LOOKUPS)
 
-    # pylint: disable=too-many-branches
     shown_textanswer_states = [TextAnswer.State.PRIVATE, TextAnswer.State.PUBLISHED]
-    textanswers_per_contribution_question: Dict[(int, int), List[TextAnswer]] = defaultdict(list)
+    textanswers_per_contribution_question: Dict[Tuple[int, int], List[TextAnswer]] = defaultdict(list)
     for contribution in evaluation.contributions.all():
-        for answer in contribution.textanswer_set.all():
-            if answer.state in shown_textanswer_states:
-                textanswers_per_contribution_question[answer.contribution_id, answer.question_id].append(answer)
+        for ta in contribution.textanswer_set.all():
+            if ta.state in shown_textanswer_states:
+                textanswers_per_contribution_question[ta.contribution_id, ta.question_id].append(ta)
 
-    ratinganswercounters_per_contribution_question: Dict[(int, int), List[RatingAnswerCounter]] = defaultdict(list)
+    ratinganswercounters_per_contribution_question: Dict[Tuple[int, int], List[RatingAnswerCounter]] = defaultdict(list)
     for contribution in evaluation.contributions.all():
-        for answer in contribution.ratinganswercounter_set.all():
-            ratinganswercounters_per_contribution_question[answer.contribution_id, answer.question_id].append(answer)
+        for rac in contribution.ratinganswercounter_set.all():
+            ratinganswercounters_per_contribution_question[rac.contribution_id, rac.question_id].append(rac)
 
     contributor_contribution_results = []
     for contribution in evaluation.contributions.all():
         questionnaire_results = []
         for questionnaire in contribution.questionnaires.all():
-            results = []
+            results: List[Union[HeadingResult, TextResult, RatingResult]] = []
             for question in questionnaire.questions.all():
                 if question.is_heading_question:
                     results.append(HeadingResult(question=question))
@@ -209,7 +235,9 @@ def _get_results_impl(evaluation: Evaluation):
                         answer_counters = None
                     results.append(RatingResult(question, answer_counters, additional_text_result=text_result))
                 elif question.is_text_question and evaluation.can_publish_text_results:
+                    assert text_result is not None
                     results.append(text_result)
+
             questionnaire_results.append(QuestionnaireResult(questionnaire, results))
         contributor_contribution_results.append(
             ContributionResult(contribution.contributor, contribution.label, questionnaire_results)

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -13,7 +13,7 @@ from django.utils import translation
 
 from evap.evaluation.auth import internal_required
 from evap.evaluation.models import Course, CourseType, Degree, Evaluation, Semester, UserProfile
-from evap.evaluation.tools import FileResponse
+from evap.evaluation.tools import FileResponse, unordered_groupby
 from evap.results.exporters import TextAnswerExporter
 from evap.results.tools import (
     STATES_WITH_RESULT_TEMPLATE_CACHING,
@@ -157,10 +157,7 @@ def index(request):
     # this dict is sorted by course.pk (important for the zip below)
     # (this relies on python 3.7's guarantee that the insertion order of the dict is preserved)
     evaluations.sort(key=lambda evaluation: evaluation.course.pk)
-
-    courses_and_evaluations = defaultdict(list)
-    for evaluation in evaluations:
-        courses_and_evaluations[evaluation.course].append(evaluation)
+    courses_and_evaluations = unordered_groupby((evaluation.course, evaluation) for evaluation in evaluations)
 
     course_pks = [course.pk for course in courses_and_evaluations.keys()]
 

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -237,23 +237,32 @@ MIDDLEWARE = [
     "evap.evaluation.middleware.LoggingRequestMiddleware",
 ]
 
+_TEMPLATE_OPTIONS = {
+    "context_processors": [
+        "django.contrib.auth.context_processors.auth",
+        "django.template.context_processors.debug",
+        "django.template.context_processors.i18n",
+        "django.template.context_processors.static",
+        "django.template.context_processors.request",
+        "django.contrib.messages.context_processors.messages",
+        "evap.context_processors.slogan",
+        "evap.context_processors.debug",
+    ],
+    "builtins": ["django.templatetags.i18n"],
+}
+
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "APP_DIRS": True,
-        "OPTIONS": {
-            "context_processors": [
-                "django.contrib.auth.context_processors.auth",
-                "django.template.context_processors.debug",
-                "django.template.context_processors.i18n",
-                "django.template.context_processors.static",
-                "django.template.context_processors.request",
-                "django.contrib.messages.context_processors.messages",
-                "evap.context_processors.slogan",
-                "evap.context_processors.debug",
-            ],
-            "builtins": ["django.templatetags.i18n"],
-        },
+        "OPTIONS": _TEMPLATE_OPTIONS,
+        "NAME": "MainEngine",
+    },
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+        "OPTIONS": dict(**_TEMPLATE_OPTIONS, debug=False),
+        "NAME": "CachedEngine",  # used for bulk-filling caches
     },
 ]
 

--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -13,7 +13,7 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
 from evap.evaluation.models import Contribution, Course, CourseType, Degree, Evaluation, UserProfile
-from evap.evaluation.tools import clean_email
+from evap.evaluation.tools import clean_email, unordered_groupby
 from evap.staff.tools import ImportType, create_user_list_html_string_for_message
 
 
@@ -537,10 +537,8 @@ class EnrollmentImporter(ExcelImporter):
             )
 
     def check_enrollment_data_sanity(self):
-        enrollments_per_user = defaultdict(list)
-        for enrollment in self.enrollments:
-            index = enrollment[1].email
-            enrollments_per_user[index].append(enrollment)
+        enrollments_per_user = unordered_groupby((enrollment[1].email, enrollment) for enrollment in self.enrollments)
+
         for email, enrollments in enrollments_per_user.items():
             if len(enrollments) > settings.IMPORTER_MAX_ENROLLMENTS:
                 self.warnings[ImporterWarning.MANY].append(


### PR DESCRIPTION
Initially, `./manage.py refresh_results_cache` took approximately 42 seconds for our test data on my machine.

* Prefetching on the `refresh_results_cache` management command brought it down to around 14 seconds (we had around 20'000 db queries) in the process
* Caching the template fragments (the same few fragments were loaded from disk once per render call, totalling in ~9000 file system accesses) brought it down to around 6 seconds (only noticable with DEBUG=True. With debug enabled, this was already cached).

Related to a discussion in #1280:
> you asked me to remind you to keep refresh_results_cache in mind. it currently needs a lot of time on production - so during the update the server is down for several minutes.

6x doesn't sound that impressive, but in comparison, this just flies away:

<img width=50% src="https://user-images.githubusercontent.com/13838962/162849125-4114a84b-0d40-40e8-8c9f-bf87df66faad.gif"/>

<img width=50% src="https://user-images.githubusercontent.com/13838962/162849135-551672f4-0bd1-496e-a091-ada9a7dadfb0.gif"/>

Edit: Current state is even more faster (x8, 4.7s for `refresh_results_cache`)