### PR TITLE
Fix provision script calling compilemessages with wrong locale "de_DE" instead of "de"

### DIFF
--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -104,6 +104,6 @@ sudo -H -u $USER bash -c "source /home/$USER/.nvm/nvm.sh; nvm install --no-progr
 echo "nvm use node" >> /home/$USER/.bashrc
 sudo -H -u $USER $ENV_FOLDER/bin/python manage.py migrate --noinput
 sudo -H -u $USER $ENV_FOLDER/bin/python manage.py collectstatic --noinput
-sudo -H -u $USER $ENV_FOLDER/bin/python manage.py compilemessages --locale de_DE --locale en_US
+sudo -H -u $USER $ENV_FOLDER/bin/python manage.py compilemessages --locale de
 sudo -H -u $USER $ENV_FOLDER/bin/python manage.py loaddata test_data.json
 sudo -H -u $USER $ENV_FOLDER/bin/python manage.py refresh_results_cache


### PR DESCRIPTION
You can check using `-v 3` (verbosity level 3) that:
```bash
$ ./manage.py compilemessages -v 3 --locale de_DE  # doesn't actually do anything
$ ./manage.py compilemessages -v 3 --locale de
File “/evap/evap/locale/de/LC_MESSAGES/django.po” is already compiled and up to date.
```