### PR TITLE
Enable `no-implicit-optional` option for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ omit = ["*/migrations/*", "*__init__.py"]
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]
 exclude = 'evap/.*/migrations/.*\.py$'
+no_implicit_optional = true
 
 [tool.django-stubs]
 django_settings_module = "evap.settings"


### PR DESCRIPTION
Before this, if we had

```python
def foo(x: int = None):
    pass
```

it would implicitly be

```python
def foo(x: Optional[int] = None):
    pass
```
