### PR TITLE
Pylint: Only allow pascal case with Formsets.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@ Vagrant.require_version ">= 1.8.1"
 
 Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |v, override|
+    v.memory = 2048
     override.vm.box = "ubuntu/focal64"
     override.vm.box_version = "= 20220426.0.0 "
     override.vm.provision "shell", path: "deployment/provision_vagrant_vm.sh"

--- a/evap/contributor/tests/test_forms.py
+++ b/evap/contributor/tests/test_forms.py
@@ -5,7 +5,7 @@ from model_bakery import baker
 from evap.contributor.forms import EditorContributionForm, EvaluationForm
 from evap.evaluation.models import Contribution, Degree, Evaluation, Questionnaire, UserProfile
 from evap.evaluation.tests.tools import WebTest, get_form_data_from_instance
-from evap.staff.forms import ContributionFormSet
+from evap.staff.forms import ContributionFormset
 
 
 class EvaluationFormTests(TestCase):
@@ -63,7 +63,7 @@ class ContributionFormsetTests(TestCase):
         )
 
         InlineContributionFormset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1
+            Evaluation, Contribution, formset=ContributionFormset, form=EditorContributionForm, extra=1
         )
         formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation})
 
@@ -75,7 +75,7 @@ class ContributionFormsetTests(TestCase):
         contribution1.questionnaires.set([questionnaire_managers_only])
 
         InlineContributionFormset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1
+            Evaluation, Contribution, formset=ContributionFormset, form=EditorContributionForm, extra=1
         )
         formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation})
 
@@ -130,7 +130,7 @@ class ContributionFormsetTests(TestCase):
         contribution1 = baker.make(Contribution, evaluation=evaluation, contributor=non_proxy_user, questionnaires=[])
 
         InlineContributionFormset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1
+            Evaluation, Contribution, formset=ContributionFormset, form=EditorContributionForm, extra=1
         )
         formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation})
 
@@ -141,7 +141,7 @@ class ContributionFormsetTests(TestCase):
         contribution1.save()
 
         InlineContributionFormset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1
+            Evaluation, Contribution, formset=ContributionFormset, form=EditorContributionForm, extra=1
         )
         formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation})
 

--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -27,7 +27,7 @@ from evap.evaluation.tools import (
 )
 from evap.results.exporters import ResultsExporter
 from evap.results.tools import annotate_distributions_and_grades, get_evaluations_with_course_result_attributes
-from evap.staff.forms import ContributionFormSet
+from evap.staff.forms import ContributionFormset
 from evap.student.views import get_valid_form_groups_or_render_vote_page
 
 
@@ -125,7 +125,7 @@ def evaluation_view(request, evaluation_id):
         raise PermissionDenied
 
     InlineContributionFormset = inlineformset_factory(
-        Evaluation, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=0
+        Evaluation, Contribution, formset=ContributionFormset, form=EditorContributionForm, extra=0
     )
 
     form = EvaluationForm(request.POST or None, instance=evaluation)
@@ -177,7 +177,7 @@ def evaluation_edit(request, evaluation_id):
     preview = post_operation == "preview"
 
     InlineContributionFormset = inlineformset_factory(
-        Evaluation, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1
+        Evaluation, Contribution, formset=ContributionFormset, form=EditorContributionForm, extra=1
     )
     evaluation_form = EvaluationForm(request.POST or None, instance=evaluation)
     formset = InlineContributionFormset(

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -454,7 +454,6 @@ class TestEvaluations(WebTest):
             caches["results"].get(get_evaluation_result_template_fragment_cache_key(evaluation.id, "de", False))
         )
 
-    # pylint: disable=invalid-name
     def assert_textanswer_review_state(
         self,
         evaluation,

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -117,9 +117,9 @@ class WebTestWith200Check(WebTest):
             self.app.get(self.url, user=user, status=200)
 
 
-def get_form_data_from_instance(FormClass, instance, **kwargs):
-    assert FormClass._meta.model == type(instance)
-    form = FormClass(instance=instance, **kwargs)
+def get_form_data_from_instance(form_cls, instance, **kwargs):
+    assert form_cls._meta.model == type(instance)
+    form = form_cls(instance=instance, **kwargs)
     return {field.html_name: field.value() for field in form}
 
 

--- a/evap/grades/models.py
+++ b/evap/grades/models.py
@@ -59,9 +59,9 @@ def delete_file_pre_save(instance, **_kwargs):
     if not instance.pk:  # We do not want to trigger document creation
         return
     try:
-        oldFile = GradeDocument.objects.get(pk=instance.pk).file
+        old_file = GradeDocument.objects.get(pk=instance.pk).file
     except GradeDocument.DoesNotExist:
         return
-    newFile = instance.file
-    if not oldFile == newFile:
-        oldFile.delete(False)
+    new_file = instance.file
+    if not old_file == new_file:
+        old_file.delete(False)

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -75,7 +75,7 @@ class BoundCharArrayField(forms.BoundField):
         return super().as_widget(widget, attrs, only_initial)
 
 
-class ModelWithImportNamesFormSet(forms.BaseModelFormSet):
+class ModelWithImportNamesFormset(forms.BaseModelFormSet):
     """
     A form set which validates that import names are not duplicated
     """
@@ -749,7 +749,7 @@ class QuestionnaireForm(forms.ModelForm):
         return questionnaire_instance
 
 
-class AtLeastOneFormSet(BaseInlineFormSet):
+class AtLeastOneFormset(BaseInlineFormSet):
     def clean(self):
         super().clean()
         count = 0
@@ -761,7 +761,7 @@ class AtLeastOneFormSet(BaseInlineFormSet):
             raise forms.ValidationError(_("You must have at least one of these."))
 
 
-class ContributionFormSet(BaseInlineFormSet):
+class ContributionFormset(BaseInlineFormSet):
     def __init__(self, data=None, **kwargs):
         data = self.handle_moved_contributors(data, **kwargs)
         super().__init__(data, **kwargs)
@@ -859,7 +859,7 @@ class ContributionFormSet(BaseInlineFormSet):
         super().clean()
 
 
-class ContributionCopyFormSet(ContributionFormSet):
+class ContributionCopyFormset(ContributionFormset):
     def __init__(self, data, instance, new_instance):
         # First, pass the old evaluation instance to create a ContributionCopyForm for each contribution
         super().__init__(data, instance=instance, form_kwargs={"evaluation": new_instance})

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -28,7 +28,7 @@ from evap.results.tools import cache_results, get_results
 from evap.staff.forms import (
     ContributionCopyForm,
     ContributionForm,
-    ContributionFormSet,
+    ContributionFormset,
     CourseCopyForm,
     CourseForm,
     EvaluationCopyForm,
@@ -270,7 +270,7 @@ class ContributionCopyFormTests(TestCase):
 
 
 class ContributionFormsetTests(TestCase):
-    def test_contribution_form_set(self):
+    def test_contribution_formset(self):
         """
         Tests the ContributionFormset with various input data sets.
         """
@@ -280,8 +280,8 @@ class ContributionFormsetTests(TestCase):
         baker.make(UserProfile)
         questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
 
-        ContributionFormset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0
+        InlineContributionFormset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=0
         )
 
         data = to_querydict(
@@ -298,14 +298,14 @@ class ContributionFormsetTests(TestCase):
         )
         # no contributor
         self.assertFalse(
-            ContributionFormset(
+            InlineContributionFormset(
                 instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data.copy()
             ).is_valid()
         )
         # valid
         data["contributions-0-contributor"] = user1.pk
         self.assertTrue(
-            ContributionFormset(
+            InlineContributionFormset(
                 instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data.copy()
             ).is_valid()
         )
@@ -316,7 +316,7 @@ class ContributionFormsetTests(TestCase):
         data["contributions-1-order"] = 1
         data["contributions-1-textanswer_visibility"] = Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS
         data["contributions-1-role"] = Contribution.Role.EDITOR
-        formset = ContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
         self.assertFalse(formset.is_valid())
         # regression for https://github.com/e-valuation/EvaP/issues/1082
         # assert same error message with and without questionnaire
@@ -326,7 +326,7 @@ class ContributionFormsetTests(TestCase):
         )
 
         data["contributions-1-questionnaires"] = questionnaire.pk
-        formset = ContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
         self.assertFalse(formset.is_valid())
         self.assertEqual(
             formset.non_form_errors(),
@@ -336,7 +336,7 @@ class ContributionFormsetTests(TestCase):
         # two contributors
         data["contributions-1-contributor"] = user2.pk
         self.assertTrue(
-            ContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data).is_valid()
+            InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data).is_valid()
         )
 
     def test_dont_validate_deleted_contributions(self):
@@ -350,8 +350,8 @@ class ContributionFormsetTests(TestCase):
         baker.make(UserProfile)
         questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
 
-        contribution_formset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0
+        InlineContributionFormset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=0
         )
 
         # Here we have two editors (one of them deleted with no questionnaires), and a deleted contributor with no questionnaires.
@@ -383,14 +383,14 @@ class ContributionFormsetTests(TestCase):
         )
 
         # Without deletion, this form should be invalid
-        formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
         self.assertFalse(formset.is_valid())
 
         data["contributions-0-DELETE"] = "on"
         data["contributions-2-DELETE"] = "on"
 
         # With deletion, it should be valid
-        formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
         self.assertTrue(formset.is_valid())
 
     @staticmethod
@@ -404,8 +404,8 @@ class ContributionFormsetTests(TestCase):
         user1 = baker.make(UserProfile)
         questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
 
-        contribution_formset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0
+        InlineContributionFormset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=0
         )
 
         data = to_querydict(
@@ -430,14 +430,14 @@ class ContributionFormsetTests(TestCase):
 
         # delete extra formset
         data["contributions-1-DELETE"] = "on"
-        formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
         formset.is_valid()
         data["contributions-1-DELETE"] = ""
 
         # delete first, change data in extra formset
         data["contributions-0-DELETE"] = "on"
         data["contributions-1-role"] = Contribution.Role.EDITOR
-        formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
         formset.is_valid()
 
     def test_take_deleted_contributions_into_account(self):
@@ -458,8 +458,8 @@ class ContributionFormsetTests(TestCase):
             questionnaires=[questionnaire],
         )
 
-        contribution_formset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0
+        InlineContributionFormset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=0
         )
 
         data = to_querydict(
@@ -485,7 +485,7 @@ class ContributionFormsetTests(TestCase):
             }
         )
 
-        formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
         self.assertTrue(formset.is_valid())
 
     def test_there_can_be_no_contributions(self):
@@ -494,8 +494,8 @@ class ContributionFormsetTests(TestCase):
         Regression test for #1347
         """
         evaluation = baker.make(Evaluation)
-        contribution_formset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0
+        InlineContributionFormset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=0
         )
 
         data = to_querydict(
@@ -506,7 +506,7 @@ class ContributionFormsetTests(TestCase):
             }
         )
 
-        formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
         self.assertTrue(formset.is_valid())
 
     def test_hidden_and_managers_only(self):
@@ -531,10 +531,10 @@ class ContributionFormsetTests(TestCase):
             Contribution, evaluation=evaluation, contributor=baker.make(UserProfile), questionnaires=[]
         )
 
-        inline_contribution_formset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=1
+        InlineContributionFormset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=1
         )
-        formset = inline_contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation})
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation})
 
         expected = {questionnaire, questionnaire_managers_only}
         self.assertEqual(expected, set(formset.forms[0].fields["questionnaires"].queryset))
@@ -543,10 +543,10 @@ class ContributionFormsetTests(TestCase):
         # Suppose we had a hidden questionnaire already selected, that should be shown as well.
         contribution1.questionnaires.set([questionnaire_hidden])
 
-        inline_contribution_formset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=1
+        InlineContributionFormset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=1
         )
-        formset = inline_contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation})
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation})
 
         expected = {questionnaire, questionnaire_managers_only, questionnaire_hidden}
         self.assertEqual(expected, set(formset.forms[0].fields["questionnaires"].queryset))
@@ -576,10 +576,10 @@ class ContributionFormsetTests(TestCase):
             _fill_optional=["contributor"],
         )
 
-        contribution_formset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=1
+        InlineContributionFormset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=1
         )
-        formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation})
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation})
         self.assertTrue(formset.forms[0].show_delete_button)
         self.assertTrue(formset.forms[1].show_delete_button)
 
@@ -624,8 +624,8 @@ class ContributionFormsetTests(TestCase):
             set(RatingAnswerCounter.objects.filter(contribution__evaluation=evaluation)), {rac_1, rac_2, rac_3, rac_4}
         )
 
-        contribution_formset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0
+        InlineContributionFormset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=0
         )
         data = to_querydict(
             {
@@ -648,7 +648,7 @@ class ContributionFormsetTests(TestCase):
                 "contributions-1-contributor": contribution_2.contributor.pk,
             }
         )
-        formset = contribution_formset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
+        formset = InlineContributionFormset(instance=evaluation, form_kwargs={"evaluation": evaluation}, data=data)
         formset.save()
 
         self.assertEqual(set(TextAnswer.objects.filter(contribution__evaluation=evaluation)), {ta_1, ta_2, ta_4})
@@ -678,8 +678,8 @@ class ContributionFormset775RegressionTests(TestCase):
         )
         cls.contribution2 = baker.make(Contribution, contributor=cls.user2, evaluation=cls.evaluation)
 
-        cls.contribution_formset = inlineformset_factory(
-            Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=0
+        cls.InlineContributionFormset = inlineformset_factory(
+            Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=0
         )
 
     def setUp(self):
@@ -706,7 +706,7 @@ class ContributionFormset775RegressionTests(TestCase):
         )
 
     def test_swap_contributors(self):
-        formset = self.contribution_formset(
+        formset = self.InlineContributionFormset(
             instance=self.evaluation, form_kwargs={"evaluation": self.evaluation}, data=self.data
         )
         self.assertTrue(formset.is_valid())
@@ -714,7 +714,7 @@ class ContributionFormset775RegressionTests(TestCase):
         # swap contributors, should still be valid
         self.data["contributions-0-contributor"] = self.user2.pk
         self.data["contributions-1-contributor"] = self.user1.pk
-        formset = self.contribution_formset(
+        formset = self.InlineContributionFormset(
             instance=self.evaluation, form_kwargs={"evaluation": self.evaluation}, data=self.data
         )
         self.assertTrue(formset.is_valid())
@@ -725,7 +725,7 @@ class ContributionFormset775RegressionTests(TestCase):
         self.data["contributions-0-contributor"] = self.user2.pk
         self.data["contributions-1-contributor"] = self.user2.pk
         self.data["contributions-1-DELETE"] = "on"
-        formset = self.contribution_formset(
+        formset = self.InlineContributionFormset(
             instance=self.evaluation, form_kwargs={"evaluation": self.evaluation}, data=self.data
         )
         self.assertTrue(formset.is_valid())
@@ -742,7 +742,7 @@ class ContributionFormset775RegressionTests(TestCase):
         self.data["contributions-2-order"] = -1
         self.data["contributions-2-role"] = Contribution.Role.CONTRIBUTOR
         self.data["contributions-2-textanswer_visibility"] = Contribution.TextAnswerVisibility.OWN_TEXTANSWERS
-        formset = self.contribution_formset(
+        formset = self.InlineContributionFormset(
             instance=self.evaluation, form_kwargs={"evaluation": self.evaluation}, data=self.data
         )
         self.assertTrue(formset.is_valid())
@@ -760,7 +760,7 @@ class ContributionFormset775RegressionTests(TestCase):
         self.data["contributions-1-role"] = Contribution.Role.CONTRIBUTOR
         self.data["contributions-1-textanswer_visibility"] = Contribution.TextAnswerVisibility.OWN_TEXTANSWERS
 
-        formset = self.contribution_formset(
+        formset = self.InlineContributionFormset(
             instance=self.evaluation, form_kwargs={"evaluation": self.evaluation}, data=self.data
         )
         self.assertTrue(formset.is_valid())
@@ -773,7 +773,7 @@ class ContributionFormset775RegressionTests(TestCase):
 
         questionnaire = baker.make(Questionnaire, type=Questionnaire.Type.CONTRIBUTOR)
         self.data.appendlist("contributions-0-questionnaires", questionnaire.pk)
-        formset = self.contribution_formset(
+        formset = self.InlineContributionFormset(
             instance=self.evaluation, form_kwargs={"evaluation": self.evaluation}, data=self.data
         )
         formset.save()

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -866,17 +866,17 @@ class EvaluationFormTests(TestCase):
         form = EvaluationForm(form_data, instance=evaluation1, semester=evaluation1.course.semester)
         self.assertFalse(form.is_valid())
 
-    def helper_date_validation(self, EvaluationFormClass, start_date, end_date, expected_result):
+    def helper_date_validation(self, evaluation_form_cls, start_date, end_date, expected_result):
         evaluation = Evaluation.objects.get()
 
-        form_data = get_form_data_from_instance(EvaluationFormClass, evaluation)
+        form_data = get_form_data_from_instance(evaluation_form_cls, evaluation)
         form_data["vote_start_datetime"] = start_date
         form_data["vote_end_date"] = end_date
 
-        if EvaluationFormClass == EvaluationForm:
+        if evaluation_form_cls == EvaluationForm:
             form = EvaluationForm(form_data, instance=evaluation, semester=evaluation.course.semester)
         else:
-            form = EvaluationFormClass(form_data, instance=evaluation)
+            form = evaluation_form_cls(form_data, instance=evaluation)
         self.assertEqual(form.is_valid(), expected_result)
 
     def test_contributor_evaluation_form_date_validation(self):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -44,7 +44,7 @@ from evap.evaluation.tests.tools import (
 from evap.grades.models import GradeDocument
 from evap.results.tools import TextResult, cache_results, get_results
 from evap.rewards.models import RewardPointGranting, SemesterActivation
-from evap.staff.forms import ContributionCopyForm, ContributionCopyFormSet, CourseCopyForm, EvaluationCopyForm
+from evap.staff.forms import ContributionCopyForm, ContributionCopyFormset, CourseCopyForm, EvaluationCopyForm
 from evap.staff.tests.utils import (
     WebTestStaffMode,
     WebTestStaffModeWith200Check,
@@ -1636,7 +1636,7 @@ class TestEvaluationCopyView(WebTestStaffMode):
     def test_copy_forms_are_used(self):
         response = self.app.get(self.url, user=self.manager, status=200)
         self.assertIsInstance(response.context["evaluation_form"], EvaluationCopyForm)
-        self.assertIsInstance(response.context["formset"], ContributionCopyFormSet)
+        self.assertIsInstance(response.context["formset"], ContributionCopyFormset)
         self.assertTrue(issubclass(response.context["formset"].form, ContributionCopyForm))
 
     def test_evaluation_copy(self):

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -56,11 +56,11 @@ from evap.rewards.models import RewardPointGranting
 from evap.rewards.tools import can_reward_points_be_used_by, is_semester_activated
 from evap.staff import staff_mode
 from evap.staff.forms import (
-    AtLeastOneFormSet,
+    AtLeastOneFormset,
     ContributionCopyForm,
-    ContributionCopyFormSet,
+    ContributionCopyFormset,
     ContributionForm,
-    ContributionFormSet,
+    ContributionFormset,
     CourseCopyForm,
     CourseForm,
     CourseTypeForm,
@@ -75,7 +75,7 @@ from evap.staff.forms import (
     FaqQuestionForm,
     FaqSectionForm,
     ImportForm,
-    ModelWithImportNamesFormSet,
+    ModelWithImportNamesFormset,
     QuestionForm,
     QuestionnaireForm,
     QuestionnairesAssignForm,
@@ -1049,7 +1049,7 @@ def evaluation_create(request, semester_id, course_id=None):
     if course_id:
         evaluation.course = get_object_or_404(Course, id=course_id)
     InlineContributionFormset = inlineformset_factory(
-        Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=1
+        Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=1
     )
 
     evaluation_form = EvaluationForm(request.POST or None, instance=evaluation, semester=semester)
@@ -1088,7 +1088,7 @@ def evaluation_copy(request, semester_id, evaluation_id):
     form = EvaluationCopyForm(request.POST or None, evaluation)
 
     InlineContributionFormset = inlineformset_factory(
-        Evaluation, Contribution, formset=ContributionCopyFormSet, form=ContributionCopyForm, extra=1
+        Evaluation, Contribution, formset=ContributionCopyFormset, form=ContributionCopyForm, extra=1
     )
     formset = InlineContributionFormset(request.POST or None, instance=evaluation, new_instance=form.instance)
 
@@ -1171,7 +1171,7 @@ def helper_evaluation_edit(request, semester, evaluation):
 
     editable = evaluation.can_be_edited_by_manager
     InlineContributionFormset = inlineformset_factory(
-        Evaluation, Contribution, formset=ContributionFormSet, form=ContributionForm, extra=1 if editable else 0
+        Evaluation, Contribution, formset=ContributionFormset, form=ContributionForm, extra=1 if editable else 0
     )
 
     evaluation_form = EvaluationForm(request.POST or None, instance=evaluation, semester=semester)
@@ -1646,7 +1646,7 @@ def questionnaire_view(request, questionnaire_id):
 def questionnaire_create(request):
     questionnaire = Questionnaire()
     InlineQuestionFormset = inlineformset_factory(
-        Questionnaire, Question, formset=AtLeastOneFormSet, form=QuestionForm, extra=1, exclude=("questionnaire",)
+        Questionnaire, Question, formset=AtLeastOneFormset, form=QuestionForm, extra=1, exclude=("questionnaire",)
     )
 
     form = QuestionnaireForm(request.POST or None, instance=questionnaire)
@@ -1684,7 +1684,7 @@ def make_questionnaire_edit_forms(request, questionnaire, editable):
     InlineQuestionFormset = inlineformset_factory(
         Questionnaire,
         Question,
-        formset=AtLeastOneFormSet,
+        formset=AtLeastOneFormset,
         form=QuestionForm,
         exclude=("questionnaire",),
         **formset_kwargs,
@@ -1735,7 +1735,7 @@ def get_identical_form_and_formset(questionnaire):
     specified in questionnaire_id. Used for copying and creating of new versions.
     """
     inline_question_formset = inlineformset_factory(
-        Questionnaire, Question, formset=AtLeastOneFormSet, form=QuestionForm, extra=1, exclude=("questionnaire",)
+        Questionnaire, Question, formset=AtLeastOneFormset, form=QuestionForm, extra=1, exclude=("questionnaire",)
     )
 
     form = QuestionnaireForm(instance=questionnaire)
@@ -1749,7 +1749,7 @@ def questionnaire_copy(request, questionnaire_id):
     if request.method == "POST":
         questionnaire = Questionnaire()
         InlineQuestionFormset = inlineformset_factory(
-            Questionnaire, Question, formset=AtLeastOneFormSet, form=QuestionForm, extra=1, exclude=("questionnaire",)
+            Questionnaire, Question, formset=AtLeastOneFormset, form=QuestionForm, extra=1, exclude=("questionnaire",)
         )
 
         form = QuestionnaireForm(request.POST, instance=questionnaire)
@@ -1784,7 +1784,7 @@ def questionnaire_new_version(request, questionnaire_id):
     if request.method == "POST":
         questionnaire = Questionnaire()
         InlineQuestionFormset = inlineformset_factory(
-            Questionnaire, Question, formset=AtLeastOneFormSet, form=QuestionForm, extra=1, exclude=("questionnaire",)
+            Questionnaire, Question, formset=AtLeastOneFormset, form=QuestionForm, extra=1, exclude=("questionnaire",)
         )
 
         form = QuestionnaireForm(request.POST, instance=questionnaire)
@@ -1879,7 +1879,7 @@ def degree_index(request):
     degrees = Degree.objects.all()
 
     DegreeFormset = modelformset_factory(
-        Degree, form=DegreeForm, formset=ModelWithImportNamesFormSet, can_delete=True, extra=1
+        Degree, form=DegreeForm, formset=ModelWithImportNamesFormset, can_delete=True, extra=1
     )
     formset = DegreeFormset(request.POST or None, queryset=degrees)
 
@@ -1896,7 +1896,7 @@ def course_type_index(request):
     course_types = CourseType.objects.all()
 
     CourseTypeFormset = modelformset_factory(
-        CourseType, form=CourseTypeForm, formset=ModelWithImportNamesFormSet, can_delete=True, extra=1
+        CourseType, form=CourseTypeForm, formset=ModelWithImportNamesFormset, can_delete=True, extra=1
     )
     formset = CourseTypeFormset(request.POST or None, queryset=course_types)
 
@@ -1945,10 +1945,10 @@ def course_type_merge(request, main_type_id, other_type_id):
 def text_answer_warnings_index(request):
     text_answer_warnings = TextAnswerWarning.objects.all()
 
-    TextAnswerWarningFormSet = modelformset_factory(
+    TextAnswerWarningFormset = modelformset_factory(
         TextAnswerWarning, form=TextAnswerWarningForm, can_delete=True, extra=1
     )
-    formset = TextAnswerWarningFormSet(request.POST or None, queryset=text_answer_warnings)
+    formset = TextAnswerWarningFormset(request.POST or None, queryset=text_answer_warnings)
 
     if formset.is_valid():
         formset.save()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ django-settings-module = "evap.settings"
 [tool.pylint.basic]
 # snake_case, or PascalCaseFormset, because django does it that way
 # see https://docs.djangoproject.com/en/4.0/topics/forms/formsets/
-variable-rgx = "(^[a-z0-9_]*)$|(^[A-Za-z]*Formset$)"
-argument-rgx = "(^[a-z0-9_]*)$|(^[A-Za-z]*Formset$)"
+variable-rgx = "(^[a-z0-9_]*$)|(^[A-Za-z]*Formset$)"
+argument-rgx = "(^[a-z0-9_]*$)|(^[A-Za-z]*Formset$)"
 
 good-names = [ "i", "j", "k", "ex", "Run", "_", "__", "e", "logger", "setUpTestData", "setUp", "tearDown"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,16 +25,10 @@ load-plugins = ["pylint_django"]
 django-settings-module = "evap.settings"
 
 [tool.pylint.basic]
-variable-rgx = "[A-Za-z_][A-Za-z0-9_]{2,60}$"
-argument-rgx = "[A-Za-z_][A-Za-z0-9_]{0,40}$"
-function-rgx = "[a-z_][a-z0-9_]{2,60}$"
-attr-rgx = "[a-z_][a-z0-9_]{1,60}$"
-
-# Allow longer names in tests as test_* methods are usually named a bit more verbose
-method-rgx = "([a-z_][a-z0-9_]{2,60}$)|(test_[a-z0-9_]{2,80}$)"
-
-# allowing exactly four digits at the beginning for migrations
-module-rgx = "([0-9]{4})?([a-z_][a-z0-9_]*)$"
+# snake_case, or PascalCaseFormset, because django does it that way
+# see https://docs.djangoproject.com/en/4.0/topics/forms/formsets/
+variable-rgx = "(^[a-z0-9_]*)$|(^[A-Za-z]*Formset$)"
+argument-rgx = "(^[a-z0-9_]*)$|(^[A-Za-z]*Formset$)"
 
 good-names = [ "i", "j", "k", "ex", "Run", "_", "__", "e", "logger", "setUpTestData", "setUp", "tearDown"]
 


### PR DESCRIPTION
Fixes #1748 

I also increased the default VM memory size to 2GB, since we ran out of memory with pylint in some situations.