### PR TITLE
Upgrade pylint

### DIFF
--- a/evap/evaluation/migrations/0061_editor_review_reminder_template.py
+++ b/evap/evaluation/migrations/0061_editor_review_reminder_template.py
@@ -16,7 +16,7 @@ def insert_emailtemplates(apps, _schema_editor):
 def remove_emailtemplates(apps, _schema_editor):
     EmailTemplate = apps.get_model("evaluation", "EmailTemplate")
 
-    for name, subject in emailtemplates:
+    for name, __ in emailtemplates:
         EmailTemplate.objects.filter(name=name).delete()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,15 @@ load-plugins = ["pylint_django"]
 django-settings-module = "evap.settings"
 
 [tool.pylint.basic]
-# snake_case, or PascalCaseFormset, because django does it that way
+# For most code: snake_case, or PascalCaseFormset, because django does it that way.
 # see https://docs.djangoproject.com/en/4.0/topics/forms/formsets/
-variable-rgx = "(^[a-z0-9_]*$)|(^[A-Za-z]*Formset$)"
-argument-rgx = "(^[a-z0-9_]*$)|(^[A-Za-z]*Formset$)"
+# For migrations, models are assigned as local variables. Until pylint supports configuration-per-directory, we also
+# need to allow that here (their issue 618)
+variable-rgx = "(^[a-z0-9_]+$)|(^[A-Za-z]+$)"
+argument-rgx = "(^[a-z0-9_]+$)|(^[A-Za-z]+$)"
+
+# Allow 4 leading digits for migrations
+module-rgx = "^([0-9]{4})?([a-z_][a-z0-9_]+)$"
 
 good-names = [ "i", "j", "k", "ex", "Run", "_", "__", "e", "logger", "setUpTestData", "setUp", "tearDown"]
 
@@ -41,6 +46,8 @@ disable = [
     "locally-disabled",               # we allow locally disabling some checks if we think it makes sense to do that.
     "suppressed-message",
     "line-too-long",                  # black does code formatting for us
+    "ungrouped-imports",              # isort
+    "wrong-import-order",             # isort
     "too-many-public-methods",        # reported for some models, that won't change
     "too-few-public-methods",         # noisy, e.g. exception classes, mixins etc
     "no-member",                      # false positives, deals badly with django classes
@@ -51,6 +58,7 @@ disable = [
     "too-many-lines",                 # we don't currently think that splitting up views.py or test_views.py creates any value
     "too-many-arguments",             # we can't determine a good limit here. reviews should spot bad cases of this.
     "duplicate-code",                 # Mostly imports and test setup.
+    "cyclic-import",                  # We use these inside methods that require models from multiple apps. Tests will catch actual errors.
 ]
 
 ##############################################

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,5 +10,5 @@ model-bakery==1.5.0
 mypy
 openpyxl-stubs==0.1.21
 pylint-django==2.5.3
-pylint==2.13.7
+pylint==2.14.0b1
 xlrd == 2.0.1


### PR DESCRIPTION
PyCQA removed the no-init check in issue 2409 / pr 6373 (claiming that it was never issued -- it's failing right now in #1758)

It seems that in #1756, the fact that pylint didn't check the migrations (which violate some of our rules from that PR) was simply a bug in pylint. With the newer version, it now triggers:
* invalid-name on all migration files (because their names start with numbers)
* invalid-name on all models inside migration files (because migrations do stuff like `Questionnaire = apps.get_model('evaluation', 'Questionnaire')`
* cyclic-import (This has always been flaky between single-threaded and multi-threaded) triggers for some of our in-function-imports.

We can't (yet) configure pylint per directory (-> so we can't have a special handling for migrations)
I'd simply allow leading numbers in module names, and PascalCase for variables for now.

For the cyclic imports: If these cause issues, I'd expect tests to fail (and not even start). Thus I'd just disable the pylint check.