### PR TITLE
Dependencies: Remove unused xlutils, replace codecov, update redis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -234,10 +234,10 @@ jobs:
         run: cp evap/settings_test.py evap/localsettings.py
       - name: Render pages
         run: coverage run manage.py ts render_pages
+      - name: Upload coverage
         uses: codecov/codecov-action@v2
         with:
           flags: render-pages
-      - name: Upload coverage
       - name: Store rendered pages
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -233,7 +233,11 @@ jobs:
       - name: Add localsettings
         run: cp evap/settings_test.py evap/localsettings.py
       - name: Render pages
-        run: coverage run manage.py ts render_pages && codecov -X gcov -F render-pages
+        run: coverage run manage.py ts render_pages
+        uses: codecov/codecov-action@v2
+        with:
+          flags: render-pages
+      - name: Upload coverage
       - name: Store rendered pages
         uses: actions/upload-artifact@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ module = [
     "model_bakery.*",
     "xlrd.*",
     "xlwt.*",
-    "xlutils.*",
 
     "evap.staff.fixtures.*",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 black==22.3.0
-codecov
 coverage[toml]
 django-debug-toolbar>=1.6
 django-stubs

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ mozilla-django-oidc==2.0.0
 openpyxl==3.0.9
 psycopg2-binary==2.9.3
 redis==4.2.2
-xlutils==2.0.0
 xlwt==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ django>=4.0,<4.1
 mozilla-django-oidc==2.0.0
 openpyxl==3.0.9
 psycopg2-binary==2.9.3
-redis==4.2.2
+redis==4.3.1
 xlwt==1.3.0


### PR DESCRIPTION
* `xlutils` was unused since #1703 
* codecov was replaced with the github action in #1746 [here](https://github.com/e-valuation/EvaP/pull/1746/commits/85e255d2bd7657a6d6ff559e0a907a3c42ccdf49), but only for the python tests. This also does it for the `render_pages` testrun, and removes the `codecov` dependency. (See #1723)
* redis was updated -- nothing should change here.