### PR TITLE
Fix error on vote preview without any questionnaires assigned

### DIFF
--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -122,6 +122,11 @@ class TestContributorEvaluationPreviewView(WebTestWith200Check):
         self.evaluation.save()
         self.app.get(self.url, user=self.responsible, status=403)
 
+    def test_without_questionnaires_assigned(self):
+        # regression test for #1747
+        self.evaluation.general_contribution.questionnaires.set([])
+        self.app.get(self.url, user=self.responsible, status=200)
+
 
 class TestContributorEvaluationEditView(WebTest):
     @classmethod

--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -148,7 +148,6 @@ def evaluation_view(request, evaluation_id):
 
 
 def render_preview(request, formset, evaluation_form, evaluation):
-    # TODO: This vs evaluation_preview???
     # open transaction to not let any other requests see anything of what we're doing here
     try:
         with transaction.atomic():

--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -28,7 +28,7 @@ from evap.evaluation.tools import (
 from evap.results.exporters import ResultsExporter
 from evap.results.tools import annotate_distributions_and_grades, get_evaluations_with_course_result_attributes
 from evap.staff.forms import ContributionFormset
-from evap.student.views import get_valid_form_groups_or_render_vote_page
+from evap.student.views import render_vote_page
 
 
 @responsible_or_contributor_or_delegate_required
@@ -148,6 +148,7 @@ def evaluation_view(request, evaluation_id):
 
 
 def render_preview(request, formset, evaluation_form, evaluation):
+    # TODO: This vs evaluation_preview???
     # open transaction to not let any other requests see anything of what we're doing here
     try:
         with transaction.atomic():
@@ -155,9 +156,9 @@ def render_preview(request, formset, evaluation_form, evaluation):
             formset.save()
             request.POST = None  # this prevents errors rendered in the vote form
 
-            preview_response = get_valid_form_groups_or_render_vote_page(
+            preview_response = render_vote_page(
                 request, evaluation, preview=True, for_rendering_in_modal=True
-            )[1].content.decode()
+            ).content.decode()
             raise IntegrityError  # rollback transaction to discard the database writes
     except IntegrityError:
         pass
@@ -240,7 +241,7 @@ def evaluation_preview(request, evaluation_id):
     ):
         raise PermissionDenied
 
-    return get_valid_form_groups_or_render_vote_page(request, evaluation, preview=True)[1]
+    return render_vote_page(request, evaluation, preview=True)
 
 
 @require_POST

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1980,11 +1980,17 @@ class TestSingleResultEditView(WebTestStaffModeWith200Check):
 class TestEvaluationPreviewView(WebTestStaffModeWith200Check):
     @classmethod
     def setUpTestData(cls):
-        evaluation = baker.make(Evaluation)
-        evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
+        cls.evaluation = baker.make(Evaluation)
+        cls.evaluation.general_contribution.questionnaires.set([baker.make(Questionnaire)])
 
-        cls.test_users = [make_manager()]
-        cls.url = f"/staff/semester/{evaluation.course.semester.pk}/evaluation/{evaluation.pk}/preview"
+        cls.manager = make_manager()
+        cls.test_users = [cls.manager]
+        cls.url = f"/staff/semester/{cls.evaluation.course.semester.pk}/evaluation/{cls.evaluation.pk}/preview"
+
+    def test_without_questionnaires_assigned(self):
+        # regression test for #1747
+        self.evaluation.general_contribution.questionnaires.set([])
+        self.app.get(self.url, user=self.manager, status=200)
 
 
 class TestEvaluationImportPersonsView(WebTestStaffMode):

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -105,7 +105,7 @@ from evap.staff.tools import (
 )
 from evap.student.forms import QuestionnaireVotingForm
 from evap.student.models import TextAnswerWarning
-from evap.student.views import get_valid_form_groups_or_render_vote_page
+from evap.student.views import render_vote_page
 
 
 @manager_required
@@ -1601,7 +1601,7 @@ def evaluation_preview(request, semester_id, evaluation_id):
         raise PermissionDenied
     evaluation = get_object_or_404(Evaluation, id=evaluation_id, course__semester=semester)
 
-    return get_valid_form_groups_or_render_vote_page(request, evaluation, preview=True)[1]
+    return render_vote_page(request, evaluation, preview=True)
 
 
 @manager_required

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -133,6 +133,7 @@ def get_vote_page_form_groups(request, evaluation, preview):
         ]
     return form_groups
 
+
 def render_vote_page(request, evaluation, preview, for_rendering_in_modal=False):
     form_groups = get_vote_page_form_groups(request, evaluation, preview)
 
@@ -182,7 +183,7 @@ def render_vote_page(request, evaluation, preview, for_rendering_in_modal=False)
 
 @participant_required
 def vote(request, evaluation_id):
-    # pylint: disable=too-many-locals,too-many-nested-blocks,too-many-branches
+    # pylint: disable=too-many-nested-blocks,too-many-branches
     evaluation = get_object_or_404(Evaluation, id=evaluation_id)
     if not evaluation.can_be_voted_for_by(request.user):
         raise PermissionDenied

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -132,11 +132,10 @@ def get_valid_form_groups_or_render_vote_page(request, evaluation, preview, for_
             for questionnaire in questionnaires
         ]
 
-    if all(all(form.is_valid() for form in form_group) for form_group in form_groups.values()):
-        assert not preview
+    if not preview and all(all(form.is_valid() for form in form_group) for form_group in form_groups.values()):
         return form_groups, None
 
-    evaluation_form_group = form_groups.pop(evaluation.general_contribution)
+    evaluation_form_group = form_groups.pop(evaluation.general_contribution, default=[])
 
     contributor_form_groups = [
         (


### PR DESCRIPTION
Fixes #1747. The preview will just be empty:

<img src="https://user-images.githubusercontent.com/13838962/168891224-6b39d32b-13a5-4ce8-8eff-702284464a7a.png" width=600></img>

So far, we've always added the `regression test for issue ####` as a docstring. However, unittest will then use these docstrings when running the tests in verbose, instead of giving the module+class+method name, which is mildly annoying when trying to find out test order dependencies. Sample output with `-v 3`:
```
test_single_locked_questionnaire (evap.contributor.tests.test_views.TestContributorEvaluationEditView) ... ok
test_wrong_state (evap.contributor.tests.test_views.TestContributorEvaluationEditView)
Asserts that a contributor attempting to edit an evaluation ... ok
test_wrong_usergroup (evap.contributor.tests.test_views.TestContributorEvaluationEditView)
Asserts that a user who is not part of the usergroup ... ok
test_check_response_code_200 (evap.contributor.tests.test_views.TestContributorEvaluationPreviewView) ... ok
test_without_questionnaires_assigned (evap.contributor.tests.test_views.TestContributorEvaluationPreviewView) ... ok
Regression test for #846 ... ok
```

Based on that, I'd say we should maybe remove our docstrings, or replace them by usual comments. There is also a [way to tell unittest to not do that](https://stackoverflow.com/questions/12962772/how-to-stop-python-unittest-from-printing-test-docstring), but I think our docstrings often do not really add any value.