### PR TITLE
Pin `django-stubs` to version `1.10.1`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 black==22.3.0
 coverage[toml]
 django-debug-toolbar>=1.6
-django-stubs
+django-stubs==1.10.1
 django-webtest==1.9.10
 isort==5.10.1
 model-bakery==1.5.0


### PR DESCRIPTION
In version `1.11.0`, they introduced some mistakes that break our CI.
See https://github.com/typeddjango/django-stubs/issues/975.
