### PR TITLE
Send review reminders only when needed

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1992,15 +1992,7 @@ class EmailTemplate(models.Model):
             template.send_to_user(participant, {}, body_params, use_cc=True)
 
     @classmethod
-    def send_textanswer_reminder(cls):
+    def send_textanswer_reminder_to_user(cls, user: UserProfile, evaluations: List[Evaluation]):
+        body_params = {"user": user, "evaluations": evaluations}
         template = cls.objects.get(name=cls.TEXT_ANSWER_REVIEW_REMINDER)
-        evaluations = [
-            evaluation
-            for evaluation in Evaluation.objects.filter(state=Evaluation.State.EVALUATED)
-            if evaluation.textanswer_review_state == Evaluation.TextAnswerReviewState.REVIEW_URGENT
-        ]
-        evaluations = sorted(evaluations, key=lambda evaluation: evaluation.full_name)
-        managers = Group.objects.get(name="Manager").user_set.all()
-        for manager in managers:
-            body_params = {"user": manager, "evaluations": evaluations}
-            template.send_to_user(manager, {}, body_params, use_cc=False)
+        template.send_to_user(user, {}, body_params, use_cc=False)

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -392,3 +392,30 @@ class TestPrecommitCommand(TestCase):
         mock_call_command.assert_any_call("typecheck")
         mock_call_command.assert_any_call("lint")
         mock_call_command.assert_any_call("format")
+
+
+@override_settings(TEXTANSWER_REVIEW_REMINDER_WEEKDAYS=range(0, 7))
+class TestSendTextanswerRemindersCommand(TestCase):
+    def test_send_reminder(self):
+        make_manager()
+        evaluation = baker.make(
+            Evaluation,
+            state=Evaluation.State.EVALUATED,
+            wait_for_grade_upload_before_publishing=False,
+            can_publish_text_results=True,
+        )
+        baker.make(
+            TextAnswer,
+            contribution=evaluation.general_contribution,
+            state=TextAnswer.State.NOT_REVIEWED,
+        )
+
+        management.call_command("send_reminders")
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn(evaluation.name, mail.outbox[0].body)
+
+    def test_send_no_reminder_if_not_needed(self):
+        make_manager()
+        management.call_command("send_reminders")
+        self.assertEqual(len(mail.outbox), 0)


### PR DESCRIPTION
before, reminders were always sent. they had an empty list if no evaluations required urgent review.