### PR TITLE
Fix wrong id_for_label usage in rendered evaluation edit form

### DIFF
--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -579,6 +579,9 @@ class ContributionForm(forms.ModelForm):
         fields = ("evaluation", "contributor", "questionnaires", "role", "textanswer_visibility", "label", "order")
         widgets = {
             "order": forms.HiddenInput(),
+            # RadioSelects are necessary so each value gets a id_for_label, see #1769.
+            "role": forms.RadioSelect(),
+            "textanswer_visibility": forms.RadioSelect(),
         }
 
     def __init__(self, *args, evaluation=None, **kwargs):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1756,6 +1756,8 @@ class TestCourseDeleteView(DeleteViewTestMixin, WebTestStaffMode):
     ]
 )
 class TestEvaluationEditView(WebTestStaffMode):
+    render_pages_url = f"/staff/semester/PK/evaluation/PK/edit"
+
     @classmethod
     def setUpTestData(cls):
         cls.manager = make_manager()
@@ -1796,6 +1798,12 @@ class TestEvaluationEditView(WebTestStaffMode):
         )
         cls.contribution1.questionnaires.set([cls.contributor_questionnaire])
         cls.contribution2.questionnaires.set([cls.contributor_questionnaire])
+
+    @render_pages
+    def render_pages(self):
+        return {
+            "normal": self.app.get(self.url, user=self.manager).content,
+        }
 
     def test_edit_evaluation(self):
         page = self.app.get(self.url, user=self.manager)

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1756,7 +1756,7 @@ class TestCourseDeleteView(DeleteViewTestMixin, WebTestStaffMode):
     ]
 )
 class TestEvaluationEditView(WebTestStaffMode):
-    render_pages_url = f"/staff/semester/PK/evaluation/PK/edit"
+    render_pages_url = "/staff/semester/PK/evaluation/PK/edit"
 
     @classmethod
     def setUpTestData(cls):

--- a/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
+++ b/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
@@ -9,7 +9,7 @@ test("changes form data", pageHandler(
     async page => {
         const managerId = await page.evaluate(() => {
             const tomselect = (document.getElementById("id_contributions-0-contributor") as any).tomselect;
-            const options = tomselect!.options;
+            const options = tomselect.options;
             const managerOption = Object.keys(options).find(key => options[key].text == "manager (manager)");
             tomselect.setValue(managerOption);
             return managerOption;

--- a/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
+++ b/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@jest/globals";
+
+import { pageHandler } from "../utils/page";
+
+interface TomSelectedHtmlSelectElement extends HTMLSelectElement {
+    tomselect: any;
+}
+
+test("copies header", pageHandler(
+    "/staff/semester/PK/evaluation/PK/edit/normal.html",
+    async page => {
+        const managerId = await page.evaluate(() => {
+            const tomselect = (document.getElementById("id_contributions-0-contributor") as TomSelectedHtmlSelectElement).tomselect;
+            const options = tomselect!.options;
+            const managerOption = Object.keys(options).find(key => options[key].text == "manager (manager)");
+            tomselect.setValue(managerOption);
+            return managerOption;
+        });
+        console.log("managerID: " + managerId);
+
+        const editorLabels = await page.$x("//label[contains(text(), 'Editor')]");
+        const ownAndGeneralLabels = await page.$x("//label[contains(text(), 'Own and general')]");
+        if (editorLabels.length < 1 || ownAndGeneralLabels.length < 1) {
+          throw new Error("Button group buttons not found.");
+        }
+
+        await (editorLabels[0] as any).click();
+        await (ownAndGeneralLabels[0] as any).click();
+
+        const formData = await page.evaluate(() => {
+            return new FormData(document.getElementById("evaluation-form") as HTMLFormElement);
+        });
+
+        console.log(formData);
+
+        expect(formData.get("contributions-0-contributor")).toBe(managerId);
+        // expect(formData.get("contributions-0-order")).toBe("0");
+        // expect(formData.get("contributions-0-role")).toBe("");
+        // expect(formData.get("contributions-0-textanswer_visibility")).toBe("OWN");
+    },
+));

--- a/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
+++ b/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
@@ -1,22 +1,19 @@
 import { test, expect } from "@jest/globals";
+import { ElementHandle } from "puppeteer";
 
 import { pageHandler } from "../utils/page";
 
-interface TomSelectedHtmlSelectElement extends HTMLSelectElement {
-    tomselect: any;
-}
-
-test("copies header", pageHandler(
+// regression test for #1769
+test("changes form data", pageHandler(
     "/staff/semester/PK/evaluation/PK/edit/normal.html",
     async page => {
         const managerId = await page.evaluate(() => {
-            const tomselect = (document.getElementById("id_contributions-0-contributor") as TomSelectedHtmlSelectElement).tomselect;
+            const tomselect = (document.getElementById("id_contributions-0-contributor") as any).tomselect;
             const options = tomselect!.options;
             const managerOption = Object.keys(options).find(key => options[key].text == "manager (manager)");
             tomselect.setValue(managerOption);
             return managerOption;
         });
-        console.log("managerID: " + managerId);
 
         const editorLabels = await page.$x("//label[contains(text(), 'Editor')]");
         const ownAndGeneralLabels = await page.$x("//label[contains(text(), 'Own and general')]");
@@ -24,18 +21,16 @@ test("copies header", pageHandler(
           throw new Error("Button group buttons not found.");
         }
 
-        await (editorLabels[0] as any).click();
-        await (ownAndGeneralLabels[0] as any).click();
+        await (editorLabels[0] as ElementHandle<Element>).click()
+        await (ownAndGeneralLabels[0] as ElementHandle<Element>).click();
 
         const formData = await page.evaluate(() => {
-            return new FormData(document.getElementById("evaluation-form") as HTMLFormElement);
+            return Object.fromEntries(new FormData(document.getElementById("evaluation-form") as HTMLFormElement));
         });
 
-        console.log(formData);
-
-        expect(formData.get("contributions-0-contributor")).toBe(managerId);
-        // expect(formData.get("contributions-0-order")).toBe("0");
-        // expect(formData.get("contributions-0-role")).toBe("");
-        // expect(formData.get("contributions-0-textanswer_visibility")).toBe("OWN");
+        expect(formData["contributions-0-contributor"]).toBe(managerId);
+        expect(formData["contributions-0-order"]).toBe("0");
+        expect(formData["contributions-0-role"]).toBe("1");
+        expect(formData["contributions-0-textanswer_visibility"]).toBe("GENERAL");
     },
 ));


### PR DESCRIPTION
Fixes #1769.

Our old code was broken and just happened to work accidentally before django 4: The default widget for a choice field is a [`Select` widget](https://docs.djangoproject.com/en/4.0/ref/forms/widgets/#django.forms.Select). With that, the rendering:
```html
<select id="test" name="test">
   <option>1</option>
   <option>2</option>
</select>
```
wouldn't require any `id_for_label` to be set for the individual values. However, before django 4, this happened to be set, and our code relied on that with no documented guarantee.

This PR changes the button groups to use `RadioSelect` widgets, which would be rendered as:
```html
<input type="radio" id="id_1" name="test" value="1"><label for="id_1">1</label>
<input type="radio" id="id_2" name="test" value="2"><label for="id_2">2</label>
```
i.e. here, every choice gets a seperate ID. This is also guaranteed [by the docs](https://docs.djangoproject.com/en/4.0/ref/forms/widgets/#radioselect):
> To get more granular, you can use each radio button’s tag, choice_label and id_for_label attributes

So this time, if anything changes, we should see an entry in the release notes.

Edit: We can probably make a front end test for this one, it should be detectable just from the rendered html