### PR TITLE
Remove `django-sendfile2` and use the builtin `FileResponse` instead

### DIFF
--- a/evap/grades/views.py
+++ b/evap/grades/views.py
@@ -1,11 +1,10 @@
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponse
+from django.http import FileResponse, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET, require_POST
-from django_sendfile import sendfile
 
 from evap.evaluation.auth import (
     grade_downloader_required,
@@ -152,7 +151,7 @@ def download_grades(request, grade_document_id):
     if grade_document.course.semester.grade_documents_are_deleted:
         raise PermissionDenied
 
-    return sendfile(request, grade_document.file.path, attachment=True, attachment_filename=grade_document.filename())
+    return FileResponse(grade_document.file.open(), filename=grade_document.filename(), as_attachment=True)
 
 
 @grade_publisher_required

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -328,11 +328,6 @@ STATIC_ROOT = os.path.join(BASE_DIR, "static_collected")
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 MEDIA_ROOT = os.path.join(BASE_DIR, "upload")
 
-# the backend used for downloading attachments
-# see https://github.com/moggers87/django-sendfile2 for further information
-SENDFILE_BACKEND = "django_sendfile.backends.simple"
-SENDFILE_ROOT = MEDIA_ROOT
-
 
 ### Slogans
 SLOGANS_DE = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 django-extensions==3.1.5
 django-fsm==2.8.0
-django-sendfile2==0.6.1
 django>=4.0,<4.1
 mozilla-django-oidc==2.0.0
 openpyxl==3.0.9


### PR DESCRIPTION
Supersedes #1791

We don't even remember why we used `sendfile` in the first place, it claims to be optimized for sending large files and has specialized backends, but we only send smallish grade documents and use the "simple" backend anyways. Content type detection works with `FileResponse` too, so there really seems to be no reason to have the dependency anymore.
