### PR TITLE
Don't wait for scss and ts compilation in `./manage.py run`

### DIFF
--- a/evap/development/management/commands/run.py
+++ b/evap/development/management/commands/run.py
@@ -1,4 +1,5 @@
 import sys
+from subprocess import Popen
 
 from django.core.management import execute_from_command_line
 from django.core.management.base import BaseCommand
@@ -10,9 +11,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.stdout.write('Executing "manage.py scss"')
-        execute_from_command_line(["manage.py", "scss"])
+        Popen(["./manage.py", "scss"])
         self.stdout.write('Executing "manage.py ts compile"')
-        execute_from_command_line(["manage.py", "ts", "compile"])
+        Popen(["./manage.py", "ts", "compile"])
         self.stdout.write('Executing "manage.py runserver 0.0.0.0:8000"')
         sys.argv = ["manage.py", "runserver", "0.0.0.0:8000"]
         execute_from_command_line(sys.argv)

--- a/evap/development/management/commands/run.py
+++ b/evap/development/management/commands/run.py
@@ -10,10 +10,8 @@ class Command(BaseCommand):
     help = 'Execute "runserver 0.0.0.0:8000"'
 
     def handle(self, *args, **options):
-        self.stdout.write('Executing "manage.py scss"')
-        Popen(["./manage.py", "scss"])
-        self.stdout.write('Executing "manage.py ts compile"')
-        Popen(["./manage.py", "ts", "compile"])
-        self.stdout.write('Executing "manage.py runserver 0.0.0.0:8000"')
-        sys.argv = ["manage.py", "runserver", "0.0.0.0:8000"]
-        execute_from_command_line(sys.argv)
+        self.stdout.write('Executing "manage.py scss" and "manage.py ts compile"')
+        with Popen(["./manage.py", "scss"]), Popen(["./manage.py", "ts", "compile"]):
+            self.stdout.write('Executing "manage.py runserver 0.0.0.0:8000"')
+            sys.argv = ["manage.py", "runserver", "0.0.0.0:8000"]
+            execute_from_command_line(sys.argv)

--- a/evap/development/management/commands/run.py
+++ b/evap/development/management/commands/run.py
@@ -1,5 +1,5 @@
 import sys
-from subprocess import Popen
+from subprocess import Popen  # nosec
 
 from django.core.management import execute_from_command_line
 from django.core.management.base import BaseCommand
@@ -11,7 +11,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.stdout.write('Executing "manage.py scss" and "manage.py ts compile"')
-        with Popen(["./manage.py", "scss"]), Popen(["./manage.py", "ts", "compile"]):
+        with Popen(["./manage.py", "scss"]), Popen(["./manage.py", "ts", "compile"]):  # nosec
             self.stdout.write('Executing "manage.py runserver 0.0.0.0:8000"')
             sys.argv = ["manage.py", "runserver", "0.0.0.0:8000"]
             execute_from_command_line(sys.argv)

--- a/evap/development/tests/test_commands.py
+++ b/evap/development/tests/test_commands.py
@@ -57,15 +57,17 @@ class TestReloadTestdataCommand(TestCase):
 
 
 class TestRunCommand(TestCase):
-    @staticmethod
-    def test_calls_runserver():
-        with patch("django.core.management.execute_from_command_line") as mock:
-            management.call_command("run", stdout=StringIO())
+    def test_calls_runserver(self):
+        with patch("django.core.management.execute_from_command_line") as execute_mock:
+            with patch("subprocess.Popen") as popen_mock:
+                management.call_command("run", stdout=StringIO())
 
-        mock.assert_has_calls(
+        execute_mock.assert_called_once_with(["manage.py", "runserver", "0.0.0.0:8000"])
+        self.assertEqual(popen_mock.call_count, 2)
+        popen_mock.assert_has_calls(
             [
-                call(["manage.py", "scss"]),
-                call(["manage.py", "ts", "compile"]),
-                call(["manage.py", "runserver", "0.0.0.0:8000"]),
-            ]
+                call(["./manage.py", "scss"]),
+                call(["./manage.py", "ts", "compile"]),
+            ],
+            any_order=True,
         )


### PR DESCRIPTION
Instead, the processes are started and left running while the server is
starting. They exit some time after the server has started.

Closes #1783
