### PR TITLE
Fix contact modal error (fixes #1803)

### DIFF
--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -64,13 +64,13 @@
                     <h5 class="card-title me-auto">{% trans 'Evaluation data' %}</h5>
                     {% if evaluation.allow_editors_to_edit %}
                         <div>
-                            <button type="button" class="btn btn-sm btn-light mb-3" onclick="createAccountRequestModalShow();">
+                            <button type="button" class="btn btn-sm btn-light mb-3 createAccountRequestModalShowButton">
                                 {% trans 'Request creation of new account' %}
                             </button>
                         </div>
                     {% else %}
                         <div>
-                            <button type="button" class="btn btn-sm btn-light" onclick="changeEvaluationRequestModalShow();">
+                            <button type="button" class="btn btn-sm btn-light changeEvaluationRequestModalShowButton">
                                 {% trans 'Request changes' %}
                             </button>
                         </div>

--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -3,7 +3,7 @@ from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import Contribution, Course, Evaluation, Questionnaire, UserProfile
-from evap.evaluation.tests.tools import WebTestWith200Check, create_evaluation_with_responsible_and_editor
+from evap.evaluation.tests.tools import WebTestWith200Check, create_evaluation_with_responsible_and_editor, render_pages
 
 
 class TestContributorDirectDelegationView(WebTest):
@@ -129,6 +129,8 @@ class TestContributorEvaluationPreviewView(WebTestWith200Check):
 
 
 class TestContributorEvaluationEditView(WebTest):
+    render_pages_url = "/contributor/evaluation/PK/edit"
+
     @classmethod
     def setUpTestData(cls):
         result = create_evaluation_with_responsible_and_editor()
@@ -136,6 +138,23 @@ class TestContributorEvaluationEditView(WebTest):
         cls.editor = result["editor"]
         cls.evaluation = result["evaluation"]
         cls.url = f"/contributor/evaluation/{cls.evaluation.pk}/edit"
+
+    @render_pages
+    def render_pages(self):
+        self.evaluation.allow_editors_to_edit = False
+        self.evaluation.save()
+
+        content_without_allow_editors_to_edit = self.app.get(self.url, user=self.editor).content
+
+        self.evaluation.allow_editors_to_edit = True
+        self.evaluation.save()
+
+        content_with_allow_editors_to_edit = self.app.get(self.url, user=self.editor).content
+
+        return {
+            "normal": content_without_allow_editors_to_edit,
+            "allow_editors_to_edit": content_with_allow_editors_to_edit,
+        }
 
     def test_not_authenticated(self):
         """

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -5,7 +5,7 @@
         <h5 class="card-title me-auto">{% trans 'Contributors' %}</h5>
         {% if not manager %}
             <div>
-                <button type="button" class="btn btn-sm btn-light" onclick="createAccountRequestModalShow();">
+                <button type="button" class="btn btn-sm btn-light" id="createAccountRequestModalShowButton">
                     {% trans 'Request creation of new account' %}
                 </button>
             </div>

--- a/evap/evaluation/templates/profile.html
+++ b/evap/evaluation/templates/profile.html
@@ -49,7 +49,7 @@
                     </table>
                 </div>
                 <div class="card-footer text-center">
-                    <button type="button" class="btn btn-light" onclick="changeRequestModalShow();">
+                    <button type="button" class="btn btn-light" id="changeRequestModalShowButton">
                         {% trans 'Request changes' %}
                     </button>
                 </div>

--- a/evap/static/ts/src/contact_modal.ts
+++ b/evap/static/ts/src/contact_modal.ts
@@ -10,7 +10,7 @@ export class ContactModalLogic {
     private readonly successMessageModal: bootstrap.Modal;
     private readonly actionButtonElement: HTMLButtonElement;
     private readonly messageTextElement: HTMLInputElement;
-    private readonly showButtonElements: NodeListOf<HTMLElement>;
+    private readonly showButtonElements: Array<HTMLElement>;
     private readonly title: string;
 
     // may be null if anonymous feedback is not enabled
@@ -23,7 +23,7 @@ export class ContactModalLogic {
         this.actionButtonElement = selectOrError("#" + modalId + "ActionButton");
         this.messageTextElement = selectOrError("#" + modalId + "MessageText");
         this.anonymousRadioElement = document.querySelector<HTMLInputElement>("#" + modalId + "AnonymousName");
-        this.showButtonElements = document.querySelectorAll(`#${modalId}ShowButton, .${modalId}ShowButton`);
+        this.showButtonElements = Array.from(document.querySelectorAll(`#${modalId}ShowButton, .${modalId}ShowButton`));
     }
 
     public attach = (): void => {

--- a/evap/static/ts/src/contact_modal.ts
+++ b/evap/static/ts/src/contact_modal.ts
@@ -10,7 +10,7 @@ export class ContactModalLogic {
     private readonly successMessageModal: bootstrap.Modal;
     private readonly actionButtonElement: HTMLButtonElement;
     private readonly messageTextElement: HTMLInputElement;
-    private readonly showButtonElement: HTMLElement;
+    private readonly showButtonElements: NodeListOf<HTMLElement>;
     private readonly title: string;
 
     // may be null if anonymous feedback is not enabled
@@ -23,7 +23,7 @@ export class ContactModalLogic {
         this.actionButtonElement = selectOrError("#" + modalId + "ActionButton");
         this.messageTextElement = selectOrError("#" + modalId + "MessageText");
         this.anonymousRadioElement = document.querySelector<HTMLInputElement>("#" + modalId + "AnonymousName");
-        this.showButtonElement = selectOrError("#" + modalId + "ShowButton");
+        this.showButtonElements = document.querySelectorAll(`#${modalId}ShowButton, .${modalId}ShowButton`);
     }
 
     public attach = (): void => {
@@ -60,8 +60,10 @@ export class ContactModalLogic {
             this.actionButtonElement.disabled = false;
         });
 
-        this.showButtonElement.addEventListener("click", () => {
-            this.modal.show();
-        });
+        this.showButtonElements.forEach(button =>
+            button.addEventListener("click", () => {
+                this.modal.show();
+            }),
+        );
     };
 }

--- a/evap/static/ts/tests/frontend/contributor-evaluation-edit.ts
+++ b/evap/static/ts/tests/frontend/contributor-evaluation-edit.ts
@@ -3,19 +3,12 @@ import { ElementHandle } from "puppeteer";
 import { assert, assertDefined } from "../../src/utils";
 
 import { pageHandler } from "../utils/page";
-
-const content = `
-*,
-*::after,
-*::before {
-    transition-delay: 0s !important;
-    transition-duration: 0s !important;
-}`;
+import { DISABLE_ANIMATIONS_CSS } from "../utils/constants";
 
 test(
     "contact-modal-opens",
     pageHandler("/contributor/evaluation/PK/edit/normal.html", async page => {
-        await page.addStyleTag({ content });
+        await page.addStyleTag({ content: DISABLE_ANIMATIONS_CSS });
 
         const modalVisible = async (modalHandle: ElementHandle) =>
             await page.evaluate(modal => {
@@ -56,7 +49,7 @@ test(
 test(
     "contact-modal-opens-with-allow-editors-to-edit",
     pageHandler("/contributor/evaluation/PK/edit/allow_editors_to_edit.html", async page => {
-        await page.addStyleTag({ content });
+        await page.addStyleTag({ content: DISABLE_ANIMATIONS_CSS });
 
         const modalVisible = async (modalHandle: ElementHandle) =>
             await page.evaluate(modal => {

--- a/evap/static/ts/tests/frontend/contributor-evaluation-edit.ts
+++ b/evap/static/ts/tests/frontend/contributor-evaluation-edit.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@jest/globals";
+import { ElementHandle } from "puppeteer";
+import { assert, assertDefined } from "../../src/utils";
+
+import { pageHandler } from "../utils/page";
+
+const content = `
+*,
+*::after,
+*::before {
+    transition-delay: 0s !important;
+    transition-duration: 0s !important;
+}`;
+
+test(
+    "contact-modal-opens",
+    pageHandler("/contributor/evaluation/PK/edit/normal.html", async page => {
+        await page.addStyleTag({ content });
+
+        const modalVisible = async (modalHandle: ElementHandle) =>
+            await page.evaluate(modal => {
+                return window.getComputedStyle(modal).display === "block";
+            }, modalHandle);
+
+        // "Request changes" button
+
+        const changeEvaluationRequestModal = await page.$("#changeEvaluationRequestModal");
+        assertDefined(changeEvaluationRequestModal);
+        expect(await modalVisible(changeEvaluationRequestModal)).toBe(false);
+
+        const [requestChangesButton] = await page.$x("//button[contains(., 'Request changes')]");
+        assertDefined(requestChangesButton);
+        await (requestChangesButton as ElementHandle<Element>).click();
+        await page.waitForSelector("#changeEvaluationRequestModal", { visible: true });
+        expect(await modalVisible(changeEvaluationRequestModal)).toBe(true);
+
+        // wait for open and close again
+        await page.waitForSelector("textarea:focus", { visible: true });
+        await changeEvaluationRequestModal.press("Escape");
+        await page.waitForSelector("#changeEvaluationRequestModal", { hidden: true });
+
+        // "Request creation of new account" button
+
+        const createAccountRequestModal = await page.$("#createAccountRequestModal");
+        assertDefined(createAccountRequestModal);
+        expect(await modalVisible(createAccountRequestModal)).toBe(false);
+
+        const [requestAccountCreateButton] = await page.$x("//button[contains(., 'Request creation of new account')]");
+        assertDefined(requestAccountCreateButton);
+        await (requestAccountCreateButton as ElementHandle<Element>).click();
+        await page.waitForSelector("#createAccountRequestModal", { visible: true });
+        expect(await modalVisible(createAccountRequestModal)).toBe(true);
+    }),
+);
+
+test(
+    "contact-modal-opens-with-allow-editors-to-edit",
+    pageHandler("/contributor/evaluation/PK/edit/allow_editors_to_edit.html", async page => {
+        await page.addStyleTag({ content });
+
+        const modalVisible = async (modalHandle: ElementHandle) =>
+            await page.evaluate(modal => {
+                return window.getComputedStyle(modal).display === "block";
+            }, modalHandle);
+
+        const createAccountRequestModal = await page.$("#createAccountRequestModal");
+        assertDefined(createAccountRequestModal);
+        expect(await modalVisible(createAccountRequestModal)).toBe(false);
+
+        const [button1, button2] = await page.$x("//button[contains(., 'Request creation of new account')]");
+        assertDefined(button1);
+        assertDefined(button2);
+
+        await (button1 as ElementHandle<Element>).click();
+        await page.waitForSelector("#createAccountRequestModal", { visible: true });
+        expect(await modalVisible(createAccountRequestModal)).toBe(true);
+
+        // wait for open and close again
+        await page.waitForSelector("textarea:focus", { visible: true });
+        await createAccountRequestModal.press("Escape");
+        await page.waitForSelector("createAccountRequestModal", { hidden: true });
+
+        await (button2 as ElementHandle<Element>).click();
+        await page.waitForSelector("#createAccountRequestModal", { visible: true });
+        expect(await modalVisible(createAccountRequestModal)).toBe(true);
+    }),
+);

--- a/evap/static/ts/tests/utils/constants.ts
+++ b/evap/static/ts/tests/utils/constants.ts
@@ -1,0 +1,7 @@
+export const DISABLE_ANIMATIONS_CSS = `
+*,
+*::after,
+*::before {
+    transition-delay: 0s !important;
+    transition-duration: 0s !important;
+}`;


### PR DESCRIPTION
Allow having 0 or multiple open buttons per modal (as is required by our usages).

I guess a frontend test would be nice. I'll try to build something...