### PR TITLE
Remove remaining uses of `@login_required`

### DIFF
--- a/evap/evaluation/tests/test_views.py
+++ b/evap/evaluation/tests/test_views.py
@@ -150,6 +150,10 @@ class TestProfileView(WebTest):
         result = create_evaluation_with_responsible_and_editor()
         cls.responsible = result["responsible"]
 
+    def test_requires_login(self):
+        response = self.app.get(self.url, user=None, status=302)
+        self.assertRedirects(response, f"/?next={self.url}", fetch_redirect_response=False)
+
     def test_save_settings(self):
         user = baker.make(UserProfile)
         page = self.app.get(self.url, user=self.responsible, status=200)

--- a/evap/evaluation/views.py
+++ b/evap/evaluation/views.py
@@ -3,7 +3,6 @@ from datetime import date, timedelta
 
 from django.conf import settings
 from django.contrib import auth, messages
-from django.contrib.auth.decorators import login_required
 from django.core.exceptions import SuspiciousOperation
 from django.core.mail import EmailMessage
 from django.http import HttpResponse, HttpResponseBadRequest
@@ -160,7 +159,6 @@ def legal_notice(request):
 
 
 @require_POST
-@login_required
 def contact(request):
     sent_anonymous = request.POST.get("anonymous") == "true"
     if sent_anonymous and not settings.ALLOW_ANONYMOUS_FEEDBACK_MESSAGES:
@@ -202,7 +200,6 @@ def set_lang(request):
     return set_language(request)
 
 
-@login_required
 def profile_edit(request):
     user = request.user
     if user.is_editor:

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from statistics import median
 
 from django.conf import settings
-from django.contrib.auth.decorators import login_required
 from django.core.cache import caches
 from django.core.cache.utils import make_template_fragment_key
 from django.core.exceptions import BadRequest, PermissionDenied
@@ -162,7 +161,6 @@ def index(request):
     return render(request, "results_index.html", template_data)
 
 
-@login_required
 def evaluation_detail(request, semester_id, evaluation_id):
     # pylint: disable=too-many-locals
     semester = get_object_or_404(Semester, id=semester_id)

--- a/evap/rewards/tools.py
+++ b/evap/rewards/tools.py
@@ -3,7 +3,6 @@ from typing import Dict
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.db import models, transaction
 from django.db.models import Sum
 from django.dispatch import receiver
@@ -23,7 +22,6 @@ from evap.rewards.models import (
 )
 
 
-@login_required
 @transaction.atomic
 def save_redemptions(request, redemptions: Dict[int, int]):
     # lock these rows to prevent race conditions


### PR DESCRIPTION
In #1452, we made `login_required` the default and introduced
the `@no_login_required` decorator to opt out instead. Apparently, we
missed some usages of `login_required` or they sneaked back in through
merges or whatnot.
