### PR TITLE
Remove some redundant id parameters

### DIFF
--- a/evap/staff/templates/staff_evaluation_textanswers_quick.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_quick.html
@@ -34,8 +34,6 @@
     <form method="POST" action="{% url 'staff:evaluation_textanswers_update_publish' %}" id="textanswer-update-form">
         {% csrf_token %}
 
-        <input type="hidden" name="evaluation_id" value="{{ evaluation.id }}" />
-
         <div class="card card-outline-primary slider">
             <div class="card-header">
                 {% trans 'Text answers' %}

--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -28,7 +28,7 @@
                                 </td>
                                 <td>
                                     {% if user.is_manager %}
-                                        <a class="btn btn-sm btn-outline-secondary" href="{% url 'staff:evaluation_textanswer_edit' semester.id evaluation.id answer.id %}"><span class="fas fa-pencil"></a>
+                                        <a class="btn btn-sm btn-outline-secondary" href="{% url 'staff:evaluation_textanswer_edit' answer.id %}"><span class="fas fa-pencil"></a>
                                     {% endif %}
                                 </td>
                                 <td>
@@ -36,7 +36,6 @@
                                         {% csrf_token %}
 
                                         <input type="hidden" name="answer_id" value="{{ answer.id }}" />
-                                        <input type="hidden" name="evaluation_id" value="{{ evaluation_id }}" />
 
                                         <div class="btn-group btn-group-sm" role="group">
                                             <input type="radio" class="btn-check" name="action" value="publish" id="{{ answer.id }}-radio-publish" autocomplete="off" {% if answer.will_be_public %}checked{% endif %}>

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2561,7 +2561,7 @@ class TestEvaluationTextAnswerEditView(WebTestStaffMode):
 
         cls.url = reverse(
             "staff:evaluation_textanswer_edit",
-            args=(cls.textanswer.pk),
+            args=[cls.textanswer.pk],
         )
 
     def test_textanswers_showing_up(self):
@@ -3045,7 +3045,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
             TextAnswer.ReviewDecision.UNDECIDED,
             status=302,
         )
-        self.assertRegex(response.location, r"/staff/semester/\d+/evaluation/\d+/textanswer/[0-9a-f\-]+/edit$")
+        self.assertRegex(response.location, r"/staff/textanswer/[0-9a-f\-]+/edit$")
 
     def test_invalid_action(self):
         let_user_vote_for_evaluation(self.student2, self.evaluation)

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2561,7 +2561,7 @@ class TestEvaluationTextAnswerEditView(WebTestStaffMode):
 
         cls.url = reverse(
             "staff:evaluation_textanswer_edit",
-            args=(cls.evaluation.course.semester.pk, cls.evaluation.pk, cls.textanswer.pk),
+            args=(cls.textanswer.pk),
         )
 
     def test_textanswers_showing_up(self):
@@ -3019,8 +3019,8 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         expected_new_decision = old_decision if expected_new_decision == "unchanged" else expected_new_decision
 
         with run_in_staff_mode(self):
-            textanswer = baker.make(TextAnswer, review_decision=old_decision)
-            params = {"answer_id": textanswer.id, "action": action, "evaluation_id": self.evaluation.pk}
+            textanswer = baker.make(TextAnswer, contribution__evaluation=self.evaluation, review_decision=old_decision)
+            params = {"answer_id": textanswer.id, "action": action}
             response = self.app.post(self.url, params=params, user=self.manager, status=status)
 
             textanswer.refresh_from_db()

--- a/evap/staff/urls.py
+++ b/evap/staff/urls.py
@@ -31,7 +31,6 @@ urlpatterns = [
     path("semester/<int:semester_id>/evaluation/<int:evaluation_id>/person_management", views.evaluation_person_management, name="evaluation_person_management"),
     path("semester/<int:semester_id>/evaluation/<int:evaluation_id>/login_key_export", views.evaluation_login_key_export, name="evaluation_login_key_export"),
     path("semester/<int:semester_id>/evaluation/<int:evaluation_id>/textanswers", views.evaluation_textanswers, name="evaluation_textanswers"),
-    path("semester/<int:semester_id>/evaluation/<int:evaluation_id>/textanswer/<uuid:textanswer_id>/edit", views.evaluation_textanswer_edit, name="evaluation_textanswer_edit"),
     path("semester/<int:semester_id>/evaluationoperation", views.semester_evaluation_operation, name="semester_evaluation_operation"),
     path("semester/<int:semester_id>/singleresult/create", views.single_result_create, name="single_result_create"),
     path("semester/<int:semester_id>/singleresult/create/<int:course_id>", views.single_result_create, name="single_result_create"),
@@ -45,6 +44,7 @@ urlpatterns = [
     path("semester/evaluation_delete", views.evaluation_delete, name="evaluation_delete"),
     path("semester/make_active", views.semester_make_active, name="semester_make_active"),
 
+    path("textanswer/<uuid:textanswer_id>/edit", views.evaluation_textanswer_edit, name="evaluation_textanswer_edit"),
     path("textanswers/update_publish", views.evaluation_textanswers_update_publish, name="evaluation_textanswers_update_publish"),
     path("textanswers/skip", views.evaluation_textanswers_skip, name="evaluation_textanswers_skip"),
 

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1527,7 +1527,7 @@ def evaluation_textanswers_skip(request):
     return HttpResponse()
 
 
-def check_textanswer_review_permissions(evaluation: Evaluation) -> None:
+def assert_textanswer_review_permissions(evaluation: Evaluation) -> None:
     if evaluation.state == Evaluation.State.PUBLISHED:
         raise PermissionDenied
     if evaluation.course.semester.results_are_archived:
@@ -1543,7 +1543,7 @@ def evaluation_textanswers_update_publish(request):
     evaluation = answer.contribution.evaluation
     action = request.POST.get("action", None)
 
-    check_textanswer_review_permissions(evaluation)
+    assert_textanswer_review_permissions(evaluation)
 
     if action == "textanswer_edit":
         return redirect("staff:evaluation_textanswer_edit", answer.pk)
@@ -1575,7 +1575,7 @@ def evaluation_textanswers_update_publish(request):
 def evaluation_textanswer_edit(request, textanswer_id):
     textanswer = get_object_or_404(TextAnswer, id=textanswer_id)
     evaluation = textanswer.contribution.evaluation
-    check_textanswer_review_permissions(evaluation)
+    assert_textanswer_review_permissions(evaluation)
 
     form = TextAnswerForm(request.POST or None, instance=textanswer)
 

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1527,13 +1527,7 @@ def evaluation_textanswers_skip(request):
     return HttpResponse()
 
 
-@require_POST
-@reviewer_required
-def evaluation_textanswers_update_publish(request):
-    answer = get_object_from_dict_pk_entry_or_logged_40x(TextAnswer, request.POST, "answer_id")
-    evaluation = get_object_from_dict_pk_entry_or_logged_40x(Evaluation, request.POST, "evaluation_id")
-    action = request.POST.get("action", None)
-
+def check_textanswer_review_permissions(evaluation: Evaluation) -> None:
     if evaluation.state == Evaluation.State.PUBLISHED:
         raise PermissionDenied
     if evaluation.course.semester.results_are_archived:
@@ -1541,8 +1535,18 @@ def evaluation_textanswers_update_publish(request):
     if not evaluation.can_publish_text_results:
         raise PermissionDenied
 
+
+@require_POST
+@reviewer_required
+def evaluation_textanswers_update_publish(request):
+    answer = get_object_from_dict_pk_entry_or_logged_40x(TextAnswer, request.POST, "answer_id")
+    evaluation = answer.contribution.evaluation
+    action = request.POST.get("action", None)
+
+    check_textanswer_review_permissions(evaluation)
+
     if action == "textanswer_edit":
-        return redirect("staff:evaluation_textanswer_edit", evaluation.course.semester.id, evaluation.pk, answer.pk)
+        return redirect("staff:evaluation_textanswer_edit", answer.pk)
 
     review_decision_for_action = {
         "publish": TextAnswer.ReviewDecision.PUBLIC,
@@ -1568,27 +1572,24 @@ def evaluation_textanswers_update_publish(request):
 
 
 @manager_required
-def evaluation_textanswer_edit(request, semester_id, evaluation_id, textanswer_id):
-    semester = get_object_or_404(Semester, id=semester_id)
-    if semester.results_are_archived:
-        raise PermissionDenied
-    evaluation = get_object_or_404(Evaluation, id=evaluation_id, course__semester=semester)
+def evaluation_textanswer_edit(request, textanswer_id):
+    textanswer = get_object_or_404(TextAnswer, id=textanswer_id)
+    evaluation = textanswer.contribution.evaluation
+    check_textanswer_review_permissions(evaluation)
 
-    if evaluation.state == Evaluation.State.PUBLISHED:
-        raise PermissionDenied
-    if not evaluation.can_publish_text_results:
-        raise PermissionDenied
-
-    textanswer = get_object_or_404(TextAnswer, id=textanswer_id, contribution__evaluation=evaluation)
     form = TextAnswerForm(request.POST or None, instance=textanswer)
 
     if form.is_valid():
         form.save()
         # jump to edited answer
-        url = reverse("staff:evaluation_textanswers", args=[semester_id, evaluation_id]) + "#" + str(textanswer.id)
+        url = (
+            reverse("staff:evaluation_textanswers", args=[evaluation.course.semester.id, evaluation.id])
+            + "#"
+            + str(textanswer.id)
+        )
         return HttpResponseRedirect(url)
 
-    template_data = dict(semester=semester, evaluation=evaluation, form=form, textanswer=textanswer)
+    template_data = dict(semester=evaluation.course.semester, evaluation=evaluation, form=form, textanswer=textanswer)
     return render(request, "staff_evaluation_textanswer_edit.html", template_data)
 
 


### PR DESCRIPTION
It is quite common that we have views that take an id for an evaluation
and a semester such that the evaluation must belong to the semester.
I believe that such requirements should be avoided, because we need to
check that they hold everywhere anyways (or fail to do so). The only
nice thing about this is that users can the /evaluation/foo suffix from
the url to get to the corresponding semester - but in a normal
interaction they can already do that using the breadcrumbs.

I noticed that we are actually missing on such check for the
textanswer-update view (and abused that ourselves in the tests). An evil
reviewer could change the review decision for a textanswer after the
evaluation is published (or similar). Consequently, I removed all other
parameters from urls containing textanswer ids.
