### PR TITLE
Fix importers

### DIFF
--- a/evap/staff/importers/base.py
+++ b/evap/staff/importers/base.py
@@ -41,10 +41,11 @@ class ImporterLogEntry:
         DUPL = _CATEGORY_TUPLE("duplicate", gettext_lazy("Possible duplicates"), 9)
         EXISTS = _CATEGORY_TUPLE("existing", gettext_lazy("Existing courses"), 10)
         IGNORED = _CATEGORY_TUPLE("ignored", gettext_lazy("Ignored duplicates"), 11)
+        ALREADY_PARTICIPATING = _CATEGORY_TUPLE("already_participating", gettext_lazy("Existing participants"), 12)
 
-        DEGREE = _CATEGORY_TUPLE("degree", gettext_lazy("Degree mismatches"), 12)
+        DEGREE = _CATEGORY_TUPLE("degree", gettext_lazy("Degree mismatches"), 13)
         TOO_MANY_ENROLLMENTS = _CATEGORY_TUPLE(
-            "too_many_enrollments", gettext_lazy("Unusually high number of enrollments"), 13
+            "too_many_enrollments", gettext_lazy("Unusually high number of enrollments"), 14
         )
 
     level: Level

--- a/evap/staff/importers/enrollment.py
+++ b/evap/staff/importers/enrollment.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 from typing_extensions import TypeGuard
 
 from evap.evaluation.models import Contribution, Course, CourseType, Degree, Evaluation, Semester, UserProfile
-from evap.evaluation.tools import ilen
+from evap.evaluation.tools import clean_email, ilen
 from evap.staff.tools import create_user_list_html_string_for_message
 
 from .base import (
@@ -57,6 +57,11 @@ class CourseData:
 
     # An existing course that this imported one should be merged with. See #1596
     merge_into_course: MaybeInvalid[Optional[Course]] = invalid_value
+
+    def __post_init__(self):
+        self.name_de = self.name_de.strip()
+        self.name_en = self.name_en.strip()
+        self.responsible_email = clean_email(self.responsible_email)
 
     def equals_when_ignoring_degrees(self, other) -> bool:
         def key(data):
@@ -250,12 +255,12 @@ class EnrollmentInputRowMapper:
             self.invalid_is_graded_tracker.add_location_for_key(row.location, e.invalid_is_graded)
 
         course_data = CourseData(
-            name_de=row.evaluation_name_de.strip(),
-            name_en=row.evaluation_name_en.strip(),
+            name_de=row.evaluation_name_de,
+            name_en=row.evaluation_name_en,
             degrees=degrees,
             course_type=course_type,
             is_graded=is_graded,
-            responsible_email=row.responsible_email.strip(),
+            responsible_email=row.responsible_email,
         )
 
         return EnrollmentParsedRow(

--- a/evap/staff/importers/enrollment.py
+++ b/evap/staff/importers/enrollment.py
@@ -34,7 +34,9 @@ from .user import (
 )
 
 
+@dataclass
 class InvalidValue:
+    # We make this a dataclass to make sure all instances compare equal.
     pass
 
 

--- a/evap/staff/templates/staff_message_rendering_template.html
+++ b/evap/staff/templates/staff_message_rendering_template.html
@@ -8,12 +8,12 @@
 {% for category, errorlist in importer_log.errors_by_category.items %}
     <div class="card collapsible card-outline-danger mb-3">
         <div class="card-header">
-            <a class="collapse-toggle" data-bs-toggle="collapse" href="#{{ category.id }}Card" aria-expanded="false"
-                    aria-controls="{{ category.id }}Card">
-                {{ category.display_name }}
+            <a class="collapse-toggle" data-bs-toggle="collapse" href="#{{ category.value.id }}Card" aria-expanded="false"
+                    aria-controls="{{ category.value.id }}Card">
+                {{ category.value.display_name }}
             </a>
         </div>
-        <div class="collapse show" id="{{ category.id }}Card">
+        <div class="collapse show" id="{{ category.value.id }}Card">
             <div class="card-body">
                 {% for error in errorlist %}
                     <div class="alert alert-danger alert-dismissible">
@@ -29,12 +29,12 @@
 {% for category, warninglist in importer_log.warnings_by_category.items %}
     <div class="card card-outline-warning collapsible mb-3">
         <div class="card-header">
-            <a class="collapse-toggle" data-bs-toggle="collapse" href="#{{ category.id }}Card" aria-expanded="false"
-                    aria-controls="{{ category.id }}Card">
-                {{ category.display_name }}
+            <a class="collapse-toggle" data-bs-toggle="collapse" href="#{{ category.value.id }}Card" aria-expanded="false"
+                    aria-controls="{{ category.value.id }}Card">
+                {{ category.value.display_name }}
             </a>
         </div>
-        <div class="collapse show" id="{{ category.id }}Card">
+        <div class="collapse show" id="{{ category.value.id }}Card">
             <div class="card-body">
                 {% for warning in warninglist %}
                     <div class="alert alert-warning alert-dismissible">

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -476,7 +476,7 @@ class TestEnrollmentImport(TestCase):
             [msg.message for msg in importer_log_test.errors_by_category()[ImporterLogEntry.Category.COURSE]],
             [
                 'Sheet "MA Belegungen", row 18: The German name for course "Bought" is already used for another course in the import file.',
-                'Sheet "MA Belegungen", row 20: The data of course "Cost" differs from its data in a previous row.',
+                'Sheet "MA Belegungen", row 20: The data of course "Cost" differs from its data in the columns (responsible_email) in a previous row.',
             ],
         )
         self.assertEqual(

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -556,6 +556,8 @@ class TestUserImportView(WebTestStaffMode):
         form["excel_file"] = ("import.xls", self.valid_excel_file_content)
 
         reply = form.submit(name="operation", value="test")
+
+        self.assertContains(reply, "Name mismatches")
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"
@@ -1075,6 +1077,7 @@ class TestSemesterImportView(WebTestStaffMode):
         )
 
         reply = form.submit(name="operation", value="test")
+        self.assertContains(reply, "Name mismatches")
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"
@@ -2270,6 +2273,7 @@ class TestEvaluationImportPersonsView(WebTestStaffMode):
         form["ce-excel_file"] = ("import.xls", self.valid_excel_file_content)
 
         reply = form.submit(name="operation", value="test-contributors")
+        self.assertContains(reply, "Name mismatches")
         self.assertContains(
             reply,
             "The existing user would be overwritten with the following data:<br />"


### PR DESCRIPTION
An attempt to fix the stuff in #1806 -- let's see if it works out eventually.

(Possible) todos:
* [x] There is one todo left in the issue regarding message sorting after the test run vs after the import run. Discussion for this is in the issue.
* [ ] Do we want to refactor the message categories? Some of the shorter ones could be a bit more clear.
* [ ] Maybe annotate the tests as regression tests?