### PR TITLE
Migrate from requires.io to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "[T] Dependencies"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "[T] Dependencies"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # EvaP - Evaluation Platform
 
 [![Build Status](https://github.com/e-valuation/EvaP/workflows/EvaP%20Test%20Suite/badge.svg?branch=main)](https://github.com/e-valuation/EvaP/actions?query=workflow%3A%22EvaP+Test+Suite%22)
-[![Requirements Status](https://requires.io/github/e-valuation/EvaP/requirements.svg?branch=main)](https://requires.io/github/e-valuation/EvaP/requirements/?branch=main)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2cf538781fdc4680a7103bcf96417a9a)](https://www.codacy.com/gh/e-valuation/EvaP/dashboard)
 [![codecov](https://codecov.io/gh/e-valuation/EvaP/branch/master/graph/badge.svg)](https://codecov.io/gh/e-valuation/EvaP)
 


### PR DESCRIPTION
Although we didn't notice, our badge has been linking to [the deprecation post of requires.io](http://shiningpanda.com/requires-io-clap-de-fin/) for some time now. Dependabot seems convenient.