### PR TITLE
Importer performance

### DIFF
--- a/evap/staff/importers/base.py
+++ b/evap/staff/importers/base.py
@@ -216,10 +216,9 @@ class ExcelFileRowMapper:
                     )
                 )
 
-            for row_index in range(self.skip_first_n_rows, sheet.max_row):
-                # We use 0-based indexing, openpyxl uses 1-based indexing.
-                row = [cell.value for cell in sheet[row_index + 1]]
-                location = ExcelFileLocation(sheet.title, row_index)
+            # We use 0-based indexing, openpyxl uses 1-based indexing.
+            for row_index, row in enumerate(sheet.iter_rows(min_row=self.skip_first_n_rows + 1, values_only=True)):
+                location = ExcelFileLocation(sheet.title, row_index + 1)
 
                 if not all(isinstance(cell, str) or cell is None for cell in row):
                     self.importer_log.add_error(

--- a/evap/staff/importers/base.py
+++ b/evap/staff/importers/base.py
@@ -216,9 +216,11 @@ class ExcelFileRowMapper:
                     )
                 )
 
-            # We use 0-based indexing, openpyxl uses 1-based indexing.
-            for row_index, row in enumerate(sheet.iter_rows(min_row=self.skip_first_n_rows + 1, values_only=True)):
-                location = ExcelFileLocation(sheet.title, row_index + 1)
+            # openpyxl uses 1-based indexing.
+            for row_number, row in enumerate(
+                sheet.iter_rows(min_row=self.skip_first_n_rows + 1, values_only=True), start=self.skip_first_n_rows
+            ):
+                location = ExcelFileLocation(sheet.title, row_number)
 
                 if not all(isinstance(cell, str) or cell is None for cell in row):
                     self.importer_log.add_error(

--- a/evap/staff/importers/enrollment.py
+++ b/evap/staff/importers/enrollment.py
@@ -339,9 +339,10 @@ class CourseMergeLogic:
         if len(responsibles) != 1 or responsibles[0].email != course_data.responsible_email:
             hindrances.append(_("the responsibles of the course do not match"))
 
-        if len(merge_candidate.evaluations.all()) != 1:
+        merge_candidate_evaluations = merge_candidate.evaluations.all()
+        if len(merge_candidate_evaluations) != 1:
             hindrances.append(_("the existing course does not have exactly one evaluation"))
-        elif merge_candidate.evaluations.all()[0].wait_for_grade_upload_before_publishing != course_data.is_graded:
+        elif merge_candidate_evaluations[0].wait_for_grade_upload_before_publishing != course_data.is_graded:
             hindrances.append(_("the evaluation of the existing course has a mismatching grading specification"))
 
         return hindrances

--- a/evap/staff/importers/enrollment.py
+++ b/evap/staff/importers/enrollment.py
@@ -321,7 +321,7 @@ class CourseMergeLogic:
         """Course with same name_en, but different name_de exists"""
 
     def __init__(self, semester: Semester):
-        courses = Course.objects.filter(semester=semester).prefetch_related("responsibles", "evaluations")
+        courses = Course.objects.filter(semester=semester).prefetch_related("type", "responsibles", "evaluations")
 
         assert ("semester", "name_de") in Course._meta.unique_together
         self.courses_by_name_de = {course.name_de: course for course in courses}
@@ -341,7 +341,7 @@ class CourseMergeLogic:
 
         if len(merge_candidate.evaluations.all()) != 1:
             hindrances.append(_("the existing course does not have exactly one evaluation"))
-        elif merge_candidate.evaluations.get().wait_for_grade_upload_before_publishing != course_data.is_graded:
+        elif merge_candidate.evaluations.all()[0].wait_for_grade_upload_before_publishing != course_data.is_graded:
             hindrances.append(_("the evaluation of the existing course has a mismatching grading specification"))
 
         return hindrances

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
+from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Iterable
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
@@ -22,13 +22,11 @@ from evap.staff.tools import ImportType, user_edit_link
 
 
 class TestExcelFileRowMapper(TestCase):
+    @dataclass
     class SingleColumnInputRow(InputRow):
         column_count = 1
-
-        def __init__(self, location: ExcelFileLocation, *cells: Iterable[str]):
-            assert len(cells) == 1
-            self.value = cells[0]
-            self.location = location
+        location: ExcelFileLocation
+        value: str
 
     def test_skip_first_n_rows_handled_correctly(self):
         workbook_data = {"SheetName": [[str(i)] for i in range(10)]}

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from datetime import date, datetime
-from unittest.mock import patch
 from typing import Iterable
+from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 from django.forms.models import model_to_dict
@@ -17,7 +17,7 @@ from evap.staff.importers import (
     import_persons_from_evaluation,
     import_users,
 )
-from evap.staff.importers.base import InputRow, ExcelFileLocation, ExcelFileRowMapper
+from evap.staff.importers.base import ExcelFileLocation, ExcelFileRowMapper, InputRow
 from evap.staff.tools import ImportType, user_edit_link
 
 


### PR DESCRIPTION
Best reviewed by commit. Fixes #1840.

Openpyxl no longer spends half a minute on determining the worksheet dimensions.
We prevent some N+1 query behavior, making the importer and the staff semester page (which the importer redirects to) a bit faster.

On my machine, import times for a 6000 row sheet go from 32-40s to 3-6s.