### PR TITLE
Prefetching

### DIFF
--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -44,6 +44,7 @@ class EvaluationForm(forms.ModelForm):
             Questionnaire.objects.general_questionnaires()
             .filter(Q(visibility=Questionnaire.Visibility.EDITORS) | Q(contributions__evaluation=self.instance))
             .distinct()
+            .prefetch_related("questions")
         )
 
         self.fields["vote_start_datetime"].localize = True
@@ -111,6 +112,7 @@ class EditorContributionForm(ContributionForm):
             Questionnaire.objects.contributor_questionnaires()
             .filter(Q(visibility=Questionnaire.Visibility.EDITORS) | Q(contributions__evaluation=self.evaluation))
             .distinct()
+            .prefetch_related("questions")
         )
         self.fields["contributor"].queryset = UserProfile.objects.filter(
             (Q(is_active=True) & Q(is_proxy_user=False)) | Q(pk=existing_contributor_pk)

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -35,7 +35,7 @@ from evap.evaluation.tools import (
     clean_email,
     date_to_datetime,
     is_external_email,
-    is_m2m_prefetched,
+    is_many_prefetched,
     translate,
     vote_end_datetime,
 )
@@ -601,7 +601,7 @@ class Evaluation(LoggedModel):
         if self._participant_count is not None:
             return self._participant_count
 
-        if is_m2m_prefetched(self, "participants"):
+        if is_many_prefetched(self, "participants"):
             return len(self.participants.all())
 
         return self.participants.count()

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -35,7 +35,7 @@ from evap.evaluation.tools import (
     clean_email,
     date_to_datetime,
     is_external_email,
-    is_many_prefetched,
+    is_prefetched,
     translate,
     vote_end_datetime,
 )
@@ -219,8 +219,8 @@ class Questionnaire(models.Model):
 
     @property
     def can_be_edited_by_manager(self):
-        if is_many_prefetched(self, "contributions"):
-            if all(is_single_prefetched(contribution, "evaluation") for contribution in self.contributions.all()):
+        if is_prefetched(self, "contributions"):
+            if all(is_prefetched(contribution, "evaluation") for contribution in self.contributions.all()):
                 return all(
                     contribution.evaluation.state == Evaluation.State.NEW for contribution in self.contributions.all()
                 )
@@ -367,7 +367,7 @@ class Course(LoggedModel):
 
     @property
     def all_evaluations_finished(self):
-        if is_many_prefetched(self, "evaluations"):
+        if is_prefetched(self, "evaluations"):
             return all(evaluation.state >= Evaluation.State.EVALUATED for evaluation in self.evaluations.all())
 
         return not self.evaluations.exclude(state__gte=Evaluation.State.EVALUATED).exists()
@@ -610,7 +610,7 @@ class Evaluation(LoggedModel):
         if self._participant_count is not None:
             return self._participant_count
 
-        if is_many_prefetched(self, "participants"):
+        if is_prefetched(self, "participants"):
             return len(self.participants.all())
 
         return self.participants.count()

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -361,6 +361,9 @@ class Course(LoggedModel):
 
     @property
     def all_evaluations_finished(self):
+        if is_many_prefetched(self, "evaluations"):
+            return all(evaluation.state >= Evaluation.State.EVALUATED for evaluation in self.evaluations.all())
+
         return not self.evaluations.exclude(state__gte=Evaluation.State.EVALUATED).exists()
 
 

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -219,6 +219,12 @@ class Questionnaire(models.Model):
 
     @property
     def can_be_edited_by_manager(self):
+        if is_many_prefetched(self, "contributions"):
+            if all(is_single_prefetched(contribution, "evaluation") for contribution in self.contributions.all()):
+                return all(
+                    contribution.evaluation.state == Evaluation.State.NEW for contribution in self.contributions.all()
+                )
+
         return not self.contributions.exclude(evaluation__state=Evaluation.State.NEW).exists()
 
     @property

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -556,8 +556,15 @@ class Evaluation(LoggedModel):
 
     @property
     def all_contributions_have_questionnaires(self):
+        if is_prefetched(self, "contributions"):
+            if not self.contributions:
+                return False
+
+            if is_prefetched(self.contributions[0], "questionnaires"):
+                return all(len(contribution.questionnaires) > 0 for contribution in self.contributions)
+
         return (
-            self.general_contribution
+            self.general_contribution is not None
             and not self.contributions.annotate(Count("questionnaires")).filter(questionnaires__count=0).exists()
         )
 

--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -1,9 +1,10 @@
+from typing import Type
 from unittest.mock import patch
 from uuid import UUID
 
 from django.core import management
 from django.core.exceptions import SuspiciousOperation
-from django.db.models import prefetch_related_objects
+from django.db.models import Model, prefetch_related_objects
 from django.http import Http404
 from django.test.testcases import TestCase
 from django.utils import translation
@@ -14,7 +15,7 @@ from evap.evaluation.tests.tools import WebTest
 from evap.evaluation.tools import (
     discard_cached_related_objects,
     get_object_from_dict_pk_entry_or_logged_40x,
-    is_many_prefetched,
+    is_prefetched,
 )
 
 
@@ -62,20 +63,26 @@ class TestLogExceptionsDecorator(TestCase):
 
 
 class TestHelperMethods(WebTest):
-    def test_is_many_prefetched(self):
-        evaluation = baker.make(Evaluation)
+    def test_is_prefetched(self):
+        evaluation = baker.make(Evaluation, voters=[baker.make(UserProfile)])
         baker.make(Contribution, evaluation=evaluation)
 
-        self.assertFalse(is_many_prefetched(evaluation, "contributions"))
+        def test_logic(cls: Type[Model], pk: int, field: str) -> None:
+            instance = cls.objects.get(pk=pk)
+            self.assertFalse(is_prefetched(instance, field))
 
-        prefetch_related_objects([evaluation], "contributions")
-        self.assertTrue(is_many_prefetched(evaluation, "contributions"))
+            prefetch_related_objects([instance], field)
+            self.assertTrue(is_prefetched(instance, field))
 
-        evaluation.refresh_from_db(fields=["contributions"])
-        self.assertFalse(is_many_prefetched(evaluation, "contributions"))
+            instance.refresh_from_db(fields=[field])
+            self.assertFalse(is_prefetched(instance, field))
 
-        evaluation = Evaluation.objects.filter(pk=evaluation.pk).prefetch_related("contributions").first()
-        self.assertTrue(is_many_prefetched(evaluation, "contributions"))
+            instance = cls.objects.filter(pk=instance.pk).prefetch_related(field).get()
+            self.assertTrue(is_prefetched(instance, field))
+
+        test_logic(Evaluation, evaluation.pk, "contributions")  # inverse foreign key
+        test_logic(Evaluation, evaluation.pk, "voters")  # many to many
+        test_logic(Evaluation, evaluation.pk, "course")  # foreign key
 
     def test_discard_cached_related_objects_discards_cached_foreign_key_instances(self):
         evaluation = baker.make(Evaluation, course__name_en="old_name")

--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -14,7 +14,7 @@ from evap.evaluation.tests.tools import WebTest
 from evap.evaluation.tools import (
     discard_cached_related_objects,
     get_object_from_dict_pk_entry_or_logged_40x,
-    is_m2m_prefetched,
+    is_many_prefetched,
 )
 
 
@@ -62,20 +62,20 @@ class TestLogExceptionsDecorator(TestCase):
 
 
 class TestHelperMethods(WebTest):
-    def test_is_m2m_prefetched(self):
+    def test_is_many_prefetched(self):
         evaluation = baker.make(Evaluation)
         baker.make(Contribution, evaluation=evaluation)
 
-        self.assertFalse(is_m2m_prefetched(evaluation, "contributions"))
+        self.assertFalse(is_many_prefetched(evaluation, "contributions"))
 
         prefetch_related_objects([evaluation], "contributions")
-        self.assertTrue(is_m2m_prefetched(evaluation, "contributions"))
+        self.assertTrue(is_many_prefetched(evaluation, "contributions"))
 
         evaluation.refresh_from_db(fields=["contributions"])
-        self.assertFalse(is_m2m_prefetched(evaluation, "contributions"))
+        self.assertFalse(is_many_prefetched(evaluation, "contributions"))
 
         evaluation = Evaluation.objects.filter(pk=evaluation.pk).prefetch_related("contributions").first()
-        self.assertTrue(is_m2m_prefetched(evaluation, "contributions"))
+        self.assertTrue(is_many_prefetched(evaluation, "contributions"))
 
     def test_discard_cached_related_objects_discards_cached_foreign_key_instances(self):
         evaluation = baker.make(Evaluation, course__name_en="old_name")

--- a/evap/evaluation/tools.py
+++ b/evap/evaluation/tools.py
@@ -39,20 +39,20 @@ def get_object_from_dict_pk_entry_or_logged_40x(model_cls: Type[M], dict_obj: Ma
         raise SuspiciousOperation from e
 
 
-def is_many_prefetched(instance, attribute_name):
+def is_prefetched(instance, attribute_name: str):
     """
-    Is the given M2M or inverse foreign key attribute prefetched? Can be used to do ordering or counting in python and
-    avoid additional database queries
+    Is the given related attribute prefetched? Can be used to do ordering or counting in python and avoid additional
+    database queries
     """
-    return hasattr(instance, "_prefetched_objects_cache") and attribute_name in instance._prefetched_objects_cache
+    # foreign key fields
+    if attribute_name in instance._state.fields_cache:
+        return True
 
+    # m2m and inverse foreign key fields
+    if hasattr(instance, "_prefetched_objects_cache") and attribute_name in instance._prefetched_objects_cache:
+        return True
 
-def is_single_prefetched(instance, attribute_name):
-    """
-    Is the given foreign key attribute cached / prefetched? Can be used to determine whether direct access is cheaper
-    than a separate database query
-    """
-    return attribute_name in instance._state.field_cache
+    return False
 
 
 def discard_cached_related_objects(instance):

--- a/evap/evaluation/tools.py
+++ b/evap/evaluation/tools.py
@@ -39,10 +39,10 @@ def get_object_from_dict_pk_entry_or_logged_40x(model_cls: Type[M], dict_obj: Ma
         raise SuspiciousOperation from e
 
 
-def is_m2m_prefetched(instance, attribute_name):
+def is_many_prefetched(instance, attribute_name):
     """
-    Is the given M2M-attribute prefetched? Can be used to do ordering or counting
-    in python and avoid additional database queries
+    Is the given M2M or inverse foreign key attribute prefetched? Can be used to do ordering or counting in python and
+    avoid additional database queries
     """
     return hasattr(instance, "_prefetched_objects_cache") and attribute_name in instance._prefetched_objects_cache
 

--- a/evap/evaluation/tools.py
+++ b/evap/evaluation/tools.py
@@ -47,6 +47,14 @@ def is_many_prefetched(instance, attribute_name):
     return hasattr(instance, "_prefetched_objects_cache") and attribute_name in instance._prefetched_objects_cache
 
 
+def is_single_prefetched(instance, attribute_name):
+    """
+    Is the given foreign key attribute cached / prefetched? Can be used to determine whether direct access is cheaper
+    than a separate database query
+    """
+    return attribute_name in instance._state.field_cache
+
+
 def discard_cached_related_objects(instance):
     """
     Discard all cached related objects (for ForeignKey and M2M Fields). Useful

--- a/evap/grades/views.py
+++ b/evap/grades/views.py
@@ -1,3 +1,4 @@
+from django.db.models.query import QuerySet
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
@@ -5,6 +6,7 @@ from django.http import FileResponse, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET, require_POST
+from typing import Tuple, List
 
 from evap.evaluation.auth import (
     grade_downloader_required,
@@ -12,7 +14,7 @@ from evap.evaluation.auth import (
     grade_publisher_required,
 )
 from evap.evaluation.models import Course, EmailTemplate, Evaluation, Semester
-from evap.evaluation.tools import get_object_from_dict_pk_entry_or_logged_40x
+from evap.evaluation.tools import get_object_from_dict_pk_entry_or_logged_40x, ilen
 from evap.grades.forms import GradeDocumentForm
 from evap.grades.models import GradeDocument
 
@@ -26,14 +28,17 @@ def index(request):
     return render(request, "grades_index.html", template_data)
 
 
-def prefetch_data(courses):
-    courses = courses.prefetch_related("degrees", "responsibles")
+def course_grade_document_count_tuples(courses: QuerySet[Course]) -> List[Tuple[Course, int, int]]:
+    courses = courses.prefetch_related("degrees", "responsibles", "evaluations", "grade_documents")
 
-    course_data = []
-    for course in courses:
-        course_data.append((course, course.midterm_grade_documents.count(), course.final_grade_documents.count()))
-
-    return course_data
+    return [
+        (
+            course,
+            ilen(gd for gd in course.grade_documents.all() if gd.type == GradeDocument.Type.MIDTERM_GRADES),
+            ilen(gd for gd in course.grade_documents.all() if gd.type == GradeDocument.Type.FINAL_GRADES),
+        )
+        for course in courses
+    ]
 
 
 @grade_publisher_required
@@ -47,7 +52,7 @@ def semester_view(request, semester_id):
         .exclude(evaluations__state=Evaluation.State.NEW)
         .distinct()
     )
-    courses = prefetch_data(courses)
+    courses = course_grade_document_count_tuples(courses)
 
     template_data = dict(
         semester=semester,

--- a/evap/grades/views.py
+++ b/evap/grades/views.py
@@ -1,12 +1,13 @@
-from django.db.models.query import QuerySet
+from typing import List, Tuple
+
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
+from django.db.models.query import QuerySet
 from django.http import FileResponse, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET, require_POST
-from typing import Tuple, List
 
 from evap.evaluation.auth import (
     grade_downloader_required,

--- a/evap/rewards/models.py
+++ b/evap/rewards/models.py
@@ -30,12 +30,10 @@ class RewardPointRedemptionEvent(models.Model):
 
     @property
     def can_delete(self):
-        if RewardPointRedemption.objects.filter(event=self).exists():
-            return False
-        return True
+        return not self.reward_point_redemptions.exists()
 
     def redemptions_by_user(self):
-        redemptions = self.reward_point_redemptions.order_by("user_profile")
+        redemptions = self.reward_point_redemptions.order_by("user_profile").prefetch_related("user_profile")
         redemptions_dict = OrderedDict()
         for redemption in redemptions:
             if redemption.user_profile not in redemptions_dict:

--- a/evap/staff/templates/staff_questionnaire_index_list.html
+++ b/evap/staff/templates/staff_questionnaire_index_list.html
@@ -28,7 +28,7 @@
                             <td>
                                 <strong class="questionnaire-name">{{ questionnaire.name }}</strong>
                                 <br />
-                                {% blocktrans count questionnaire.questions.all.count as count %}{{ count }} question{% plural %}{{ count }} questions{% endblocktrans %},
+                                {% blocktrans count questionnaire.questions.count as count %}{{ count }} question{% plural %}{{ count }} questions{% endblocktrans %},
                                 {% blocktrans count questionnaire.contributions.count as count %}used {{ count }} time{% plural %}used {{ count }} times{% endblocktrans %}
                             </td>
                             <td>

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -150,6 +150,7 @@ def get_evaluations_with_prefetched_data(semester):
             "course__degrees",
             "course__responsibles",
             "course__semester",
+            "contributions__questionnaires",
         )
         .annotate(
             num_contributors=Count("contributions", filter=~Q(contributions__contributor=None), distinct=True),

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1596,8 +1596,9 @@ def evaluation_preview(request, semester_id, evaluation_id):
 def questionnaire_index(request):
     filter_questionnaires = get_parameter_from_url_or_session(request, "filter_questionnaires")
 
-    general_questionnaires = Questionnaire.objects.general_questionnaires()
-    contributor_questionnaires = Questionnaire.objects.contributor_questionnaires()
+    prefetch_list = ("questions", "contributions__evaluation")
+    general_questionnaires = Questionnaire.objects.general_questionnaires().prefetch_related(*prefetch_list)
+    contributor_questionnaires = Questionnaire.objects.contributor_questionnaires().prefetch_related(*prefetch_list)
 
     if filter_questionnaires:
         general_questionnaires = general_questionnaires.exclude(visibility=Questionnaire.Visibility.HIDDEN)

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -149,6 +149,7 @@ def get_evaluations_with_prefetched_data(semester):
             ),
             "course__degrees",
             "course__responsibles",
+            "course__semester",
         )
         .annotate(
             num_contributors=Count("contributions", filter=~Q(contributions__contributor=None), distinct=True),
@@ -180,7 +181,9 @@ def semester_view(request, semester_id) -> HttpResponse:
 
     evaluations = get_evaluations_with_prefetched_data(semester)
     evaluations = sorted(evaluations, key=lambda cr: cr.full_name)
-    courses = Course.objects.filter(semester=semester)
+    courses = Course.objects.filter(semester=semester).prefetch_related(
+        "type", "degrees", "responsibles", "evaluations"
+    )
 
     # semester statistics (per degree)
     @dataclass


### PR DESCRIPTION
I went through the pages and fixed some N+1 query patterns we had.

Throughout the commits I changed a bit of stuff with the `is_m2m_prefetched` method. I ended up just making it `is_prefetched` and handle both m2m as well as foreign key fields (forward and backward lookup). A given attribute on a model can only refer to a single field type, so it doesn't add much to have separate `is_prefetched` methods.