### PR TITLE
Importers: Use .save() instead of `bulk_` operations to fix #1839

### DIFF
--- a/evap/staff/importers/user.py
+++ b/evap/staff/importers/user.py
@@ -385,5 +385,8 @@ def update_existing_and_create_new_user_profiles(
     existing_user_profiles: Iterable[UserProfile],
     new_user_profiles: Iterable[UserProfile],
 ):
-    UserProfile.objects.bulk_update(existing_user_profiles, UserData.bulk_update_fields())
-    UserProfile.objects.bulk_create(new_user_profiles)
+    for user_profile in existing_user_profiles:
+        user_profile.save()
+
+    for user_profile in new_user_profiles:
+        user_profile.save()

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -223,7 +223,7 @@ class TestUserImport(TestCase):
         )
 
     @override_settings(DEBUG=False)
-    @patch("evap.evaluation.models.UserProfile.objects.bulk_create")
+    @patch("evap.evaluation.models.UserProfile.save")
     def test_unhandled_exception(self, mocked_db_access):
         mocked_db_access.side_effect = Exception("Contact your database admin right now!")
         result, importer_log = import_users(self.valid_excel_file_content, test_run=False)


### PR DESCRIPTION
Quick fix to get the bug resolved before the long architectural discussion takes place. Use `.save()` in the importers so assert side effects of `.save()` happen.

Fixes #1839, but we'll have to discuss how to handle this in the long term. E.g., the user profile still has this comment:
https://github.com/e-valuation/EvaP/blob/e889dce5b2111f42f3cda777649c19d30de165be/evap/evaluation/models.py#L1556-L1560