### PR TITLE
Remove navbar cache

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -127,10 +127,6 @@ class Semester(models.Model):
         self.save()
 
     @classmethod
-    def get_all_with_unarchived_results(cls):
-        return cls.objects.filter(results_are_archived=False).distinct()
-
-    @classmethod
     def get_all_with_published_unarchived_results(cls):
         return cls.objects.filter(
             courses__evaluations__state=Evaluation.State.PUBLISHED, results_are_archived=False

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -37,9 +37,7 @@
         {% endblock %}
 
         <div class="sticky-top d-print-none">
-            {% cache 3600 navbar request.user.email LANGUAGE_CODE %}
-                {% include_navbar user LANGUAGE_CODE %}
-            {% endcache %}
+            {% include_navbar user LANGUAGE_CODE %}
 
             {% block breadcrumb_bar %}
             {% endblock %}

--- a/evap/evaluation/templatetags/navbar_templatetags.py
+++ b/evap/evaluation/templatetags/navbar_templatetags.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from django.template import Library
 
 from evap.evaluation.models import Semester
@@ -8,12 +9,26 @@ register = Library()
 
 @register.inclusion_tag("navbar.html")
 def include_navbar(user, language):
+    semesters_with_unarchived_results_or_grade_documents = Semester.objects.filter(
+        Q(results_are_archived=False) | Q(grade_documents_are_deleted=False)
+    )
+
+    semesters_with_unarchived_results = {
+        semester
+        for semester in semesters_with_unarchived_results_or_grade_documents
+        if not semester.results_are_archived
+    }
+    semesters_with_grade_documents = {
+        semester
+        for semester in semesters_with_unarchived_results_or_grade_documents
+        if not semester.grade_documents_are_deleted
+    }
+
     return {
         "user": user,
         "current_language": language,
         "languages": LANGUAGES,
-        "published_result_semesters": Semester.get_all_with_published_unarchived_results(),
-        "result_semesters": Semester.get_all_with_unarchived_results(),
-        "grade_document_semesters": Semester.objects.filter(grade_documents_are_deleted=False),
+        "result_semesters": semesters_with_unarchived_results,
+        "grade_document_semesters": semesters_with_grade_documents,
         "debug": DEBUG,
     }

--- a/evap/evaluation/views.py
+++ b/evap/evaluation/views.py
@@ -18,7 +18,6 @@ from django.views.i18n import set_language
 from evap.evaluation.forms import DelegatesForm, LoginEmailForm, NewKeyForm
 from evap.evaluation.models import EmailTemplate, FaqSection, Semester
 from evap.middleware import no_login_required
-from evap.staff.tools import delete_navbar_cache_for_users
 
 logger = logging.getLogger(__name__)
 
@@ -95,9 +94,6 @@ def index(request):
             openid_active=settings.ACTIVATE_OPEN_ID_LOGIN,
         )
         return render(request, "index.html", template_data)
-
-    # the cached navbar might contain CSRF tokens that are invalid after a new login
-    delete_navbar_cache_for_users([request.user])
 
     # check for redirect variable
     redirect_to = request.GET.get("next", None)

--- a/evap/staff/tests/test_tools.py
+++ b/evap/staff/tests/test_tools.py
@@ -1,43 +1,10 @@
 from django.contrib.auth.models import Group
-from django.core.cache import cache
-from django.core.cache.utils import make_template_fragment_key
 from django.test import TestCase
 from model_bakery import baker
 
 from evap.evaluation.models import Contribution, Course, Evaluation, UserProfile
-from evap.evaluation.tests.tools import WebTest
 from evap.rewards.models import RewardPointGranting, RewardPointRedemption
-from evap.staff.tools import (
-    delete_navbar_cache_for_users,
-    merge_users,
-    remove_user_from_represented_and_ccing_users,
-    user_edit_link,
-)
-
-
-class NavbarCacheTest(WebTest):
-    def test_navbar_cache_deletion_for_users(self):
-        user1 = baker.make(UserProfile, email="user1@institution.example.com")
-        user2 = baker.make(UserProfile, email="user2@institution.example.com")
-
-        # create navbar caches for anonymous user, user1 and user2
-        self.app.get("/")
-        self.app.get("/results/", user="user1@institution.example.com")
-        self.app.get("/results/", user="user2@institution.example.com")
-
-        cache_key1 = make_template_fragment_key("navbar", [user1.email, "en"])
-        cache_key2 = make_template_fragment_key("navbar", [user2.email, "en"])
-        cache_key_anonymous = make_template_fragment_key("navbar", ["", "en"])
-
-        self.assertIsNotNone(cache.get(cache_key1))
-        self.assertIsNotNone(cache.get(cache_key2))
-        self.assertIsNotNone(cache.get(cache_key_anonymous))
-
-        delete_navbar_cache_for_users([user2])
-
-        self.assertIsNotNone(cache.get(cache_key1))
-        self.assertIsNone(cache.get(cache_key2))
-        self.assertIsNotNone(cache.get(cache_key_anonymous))
+from evap.staff.tools import merge_users, remove_user_from_represented_and_ccing_users, user_edit_link
 
 
 class MergeUsersTest(TestCase):

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -5,8 +5,6 @@ from enum import Enum
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import Group
-from django.core.cache import cache
-from django.core.cache.utils import make_template_fragment_key
 from django.core.exceptions import SuspiciousOperation
 from django.db import transaction
 from django.db.models import Count
@@ -61,15 +59,6 @@ def get_import_file_content_or_raise(user_id, import_type):
         raise SuspiciousOperation("No test run performed previously.")
     with open(filename, "rb") as file:
         return file.read()
-
-
-def delete_navbar_cache_for_users(users):
-    # delete navbar cache from base.html
-    for user in users:
-        key = make_template_fragment_key("navbar", [user.email, "de"])
-        cache.delete(key)
-        key = make_template_fragment_key("navbar", [user.email, "en"])
-        cache.delete(key)
 
 
 def create_user_list_html_string_for_message(users):


### PR DESCRIPTION
Removes the navbar cache.

Should thus fix #1645. Increases page load times by ~20ms. I tried
1. just fetching semesters from the DB once instead of twice with different filters (still in this PR)
2. prefetching the groups of `request.user` to allow the privilege-checks to happen without database hits.

Both didn't really change much about the performance. At 40-60ms to render a static view, the effects of removing singular db hits is really hard to qualify. I left the semester logic in, as it is contained, and reverted the user profile groups stuff, as prefetching is a bit tricky to do there: We only want it for `request.user` and not for other users, and ideally, we'd want it directly during initial creation of the object (and not later annotated by a middleware).