### PR TITLE
Readme: Fix reference to outdated 'master' branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://github.com/e-valuation/EvaP/workflows/EvaP%20Test%20Suite/badge.svg?branch=main)](https://github.com/e-valuation/EvaP/actions?query=workflow%3A%22EvaP+Test+Suite%22)
 [![Requirements Status](https://requires.io/github/e-valuation/EvaP/requirements.svg?branch=main)](https://requires.io/github/e-valuation/EvaP/requirements/?branch=main)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2cf538781fdc4680a7103bcf96417a9a)](https://www.codacy.com/gh/e-valuation/EvaP/dashboard)
-[![codecov](https://codecov.io/gh/e-valuation/EvaP/branch/master/graph/badge.svg)](https://codecov.io/gh/e-valuation/EvaP)
+[![codecov](https://codecov.io/gh/e-valuation/EvaP/branch/main/graph/badge.svg)](https://codecov.io/gh/e-valuation/EvaP)
 
 
 ## What is EvaP?


### PR DESCRIPTION
For weeks now I've been randomly wondering why codecov shows 94% coverage in the badge when we hit 95% back in may 2022 and are at 95.7% now.

Turns out the badge was generated for the master branch, but we switched to main quite some time ago. This now gives us the 96% badge.