### PR TITLE
Fix navbar semester ordering

### DIFF
--- a/evap/evaluation/templatetags/navbar_templatetags.py
+++ b/evap/evaluation/templatetags/navbar_templatetags.py
@@ -13,16 +13,16 @@ def include_navbar(user, language):
         Q(results_are_archived=False) | Q(grade_documents_are_deleted=False)
     )
 
-    semesters_with_unarchived_results = {
+    semesters_with_unarchived_results = [
         semester
         for semester in semesters_with_unarchived_results_or_grade_documents
         if not semester.results_are_archived
-    }
-    semesters_with_grade_documents = {
+    ]
+    semesters_with_grade_documents = [
         semester
         for semester in semesters_with_unarchived_results_or_grade_documents
         if not semester.grade_documents_are_deleted
-    }
+    ]
 
     return {
         "user": user,


### PR DESCRIPTION
In #1849, I added two sets to the `include_navbar` template tag. This messes up the ordering of the semesters shown in the navbar. This commit fixes it to be lists instead.

@niklasmohrin do we want a test here? On one hand, the default ordering is the right one here, so we would be explicitly testing that we're not changing the order. On the other hand, we got it wrong.