### PR TITLE
Remove @types/puppeteer dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
                 "@types/jest": "^28.1.6",
                 "@types/jest-environment-puppeteer": "^5.0.2",
                 "@types/jquery": "^3.5.14",
-                "@types/puppeteer": "^5.4.6",
                 "@types/sortablejs": "^1.13.0",
                 "jest": "^28.1.3",
                 "jest-environment-jsdom": "^29.4.2",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
     "devDependencies": {
+        "@types/bootstrap": "^5.2.6",
         "@types/jest": "^28.1.6",
         "@types/jest-environment-puppeteer": "^5.0.2",
         "@types/jquery": "^3.5.14",
-        "@types/puppeteer": "^5.4.6",
         "@types/sortablejs": "^1.13.0",
-        "@types/bootstrap": "^5.2.6",
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^29.4.2",
         "jest-environment-puppeteer": "^7.0.0",


### PR DESCRIPTION
Continuation of #1880. From the documentation:
> This package has been deprecated
> This is a stub types definition. puppeteer provides its own type definitions, so you do not need this installed.

Everything works when removing it, so lets just remove it.