### PR TITLE
Dependabot: No automatic rebases, no JS-patch-versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
     labels:
       - "[T] Dependencies"
   - package-ecosystem: "npm"
@@ -12,5 +13,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
     labels:
       - "[T] Dependencies"


### PR DESCRIPTION
@niklasmohrin what do you think?

* automatic rebases: Disabled so we don't get N^2 commits, CI runs, and notifications.

* no patch versions on JS dependencies: semver-patches shouldn't change behavior unless its a bugfix. Then, we will either notice the bug ourselves and update manually, or we won't be affected and it doesn't matter. (Possible exception: Something is broken and we don't notice, e.g. typescript compilation produces wrong js, so our frontend breaks. This seems rather unlikely to me, e.g. typescript has tests to catch big problems)