### PR TITLE
Use bootstrap grid for staff evaluation

### DIFF
--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -10,10 +10,10 @@
                 <p>{{ result.question.text }}</p>
                 <div class="grid-striped container{% if not forloop.last %} mb-4{% endif %}">
                     <div class="row textanswer-review-grid-row fw-bold">
-                            <div data-col="answer" class="px-2">{% trans 'Text answer' %}</div>
-                            <div data-col="edit" class="px-2"></div>
-                            <div data-col="review" class="px-2">{% trans 'Decision' %}</div>
-                            <div data-col="flag" px-2">{% trans 'Flag' %}</div>
+                        <div data-col="answer" class="px-2">{% trans 'Text answer' %}</div>
+                        <div data-col="edit" class="px-2"></div>
+                        <div data-col="review" class="px-2">{% trans 'Decision' %}</div>
+                        <div data-col="flag" class="px-2">{% trans 'Flag' %}</div>
                     </div>
                     {% for answer in result.answers %}
                         <div class="row textanswer-review-grid-row" id="{{ answer.id }}">

--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -10,14 +10,14 @@
                 <p>{{ result.question.text }}</p>
                 <div class="grid-striped textanswer-review-grid container{% if not forloop.last %} mb-4{% endif %}">
                     <div class="grid-row fw-bold">
-                        <div class="px-2">{% trans 'Text answer' %}</div>
-                        <div class="px-2"></div>
-                        <div class="px-2">{% trans 'Decision' %}</div>
-                        <div class="px-2">{% trans 'Flag' %}</div>
+                        <div class="px-3 py-2">{% trans 'Text answer' %}</div>
+                        <div class="p-2"></div>
+                        <div class="px-3 py-2">{% trans 'Decision' %}</div>
+                        <div class="p-2">{% trans 'Flag' %}</div>
                     </div>
                     {% for answer in result.answers %}
                         <div class="grid-row" id="{{ answer.id }}">
-                            <div class="p-2 h-100 d-flex justify-content-left align-items-center">
+                            <div class="px-3 py-2 h-100 d-flex justify-content-left align-items-center">
                                 {{ answer.answer|linebreaksbr }}
                                 {% if answer.original_answer %}
                                     <br />
@@ -29,7 +29,7 @@
                                     <a class="btn btn-sm btn-outline-secondary" href="{% url 'staff:evaluation_textanswer_edit' answer.id %}"><span class="fas fa-pencil"></a>
                                 {% endif %}
                             </div>
-                            <div class="p-2 h-100 d-flex justify-content-center align-items-center">
+                            <div class="px-3 py-2 h-100 d-flex justify-content-center align-items-center">
                                 <form class="full-update-textanswer-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_publish' %}">
                                     {% csrf_token %}
 

--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -8,64 +8,60 @@
         <div class="card-body">
             {% for result in results %}
                 <p>{{ result.question.text }}</p>
-                <table class="table table-striped{% if not forloop.last %} mb-4{% endif %}">
-                    <thead>
-                        <tr>
-                            <th style="width: 75%">{% trans 'Text answer' %}</th>
-                            <th style="width: 5%"></th>
-                            <th style="width: 15%">{% trans 'Decision' %}</th>
-                            <th style="width: 5%">{% trans 'Flag' %}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for answer in result.answers %}
-                            <tr id="{{ answer.id }}">
-                                <td class="text-answer">
-                                    {{ answer.answer|linebreaksbr }}
-                                    {% if answer.original_answer %}
-                                        <br />
-                                        <span class="textanswer-original">({{ answer.original_answer|linebreaksbr }})</span>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if user.is_manager %}
-                                        <a class="btn btn-sm btn-outline-secondary" href="{% url 'staff:evaluation_textanswer_edit' answer.id %}"><span class="fas fa-pencil"></a>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    <form class="full-update-textanswer-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_publish' %}">
-                                        {% csrf_token %}
+                <div class="grid-striped container{% if not forloop.last %} mb-4{% endif %}">
+                    <div class="row flex-nowrap fw-bold">
+                            <div class="col p-2">{% trans 'Text answer' %}</div>
+                            <div class="col-fit-content p-2"></div>
+                            <div class="col-fit-content p-2">{% trans 'Decision' %}</div>
+                            <div class="col p-2">{% trans 'Flag' %}</div>
+                    </div>
+                    {% for answer in result.answers %}
+                        <div class="row flex-nowrap" id="{{ answer.id }}">
+                            <div class="text-answer col p-2">
+                                {{ answer.answer|linebreaksbr }}
+                                {% if answer.original_answer %}
+                                    <br />
+                                    <span class="textanswer-original">({{ answer.original_answer|linebreaksbr }})</span>
+                                {% endif %}
+                            </div>
+                            <div class="col-fit-content p-2">
+                                {% if user.is_manager %}
+                                    <a class="btn btn-sm btn-outline-secondary" href="{% url 'staff:evaluation_textanswer_edit' answer.id %}"><span class="fas fa-pencil"></a>
+                                {% endif %}
+                            </div>
+                            <div class="col-fit-content p-2">
+                                <form class="full-update-textanswer-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_publish' %}">
+                                    {% csrf_token %}
 
-                                        <input type="hidden" name="answer_id" value="{{ answer.id }}" />
+                                    <input type="hidden" name="answer_id" value="{{ answer.id }}" />
 
-                                        <div class="btn-group btn-group-sm" role="group">
-                                            <input type="radio" class="btn-check" name="action" value="publish" id="{{ answer.id }}-radio-publish" autocomplete="off" {% if answer.will_be_public %}checked{% endif %}>
-                                            <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-publish">{% trans 'Publish' %}</label>
+                                    <div class="btn-group btn-group-sm" role="group">
+                                        <input type="radio" class="btn-check" name="action" value="publish" id="{{ answer.id }}-radio-publish" autocomplete="off" {% if answer.will_be_public %}checked{% endif %}>
+                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-publish">{% trans 'Publish' %}</label>
 
-                                            <input type="radio" class="btn-check" name="action" value="make_private" id="{{ answer.id }}-radio-private" autocomplete="off" {% if answer.will_be_private %}checked{% endif %} {% if not contributor %}disabled{% endif %}>
-                                            <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-private">{% trans 'Private' %}</label>
+                                        <input type="radio" class="btn-check" name="action" value="make_private" id="{{ answer.id }}-radio-private" autocomplete="off" {% if answer.will_be_private %}checked{% endif %} {% if not contributor %}disabled{% endif %}>
+                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-private">{% trans 'Private' %}</label>
 
-                                            <input type="radio" class="btn-check" name="action" value="unreview" id="{{ answer.id }}-radio-undecided" autocomplete="off" {% if not answer.is_reviewed %}checked{% endif %}>
-                                            <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-undecided">{% trans 'Undecided' %}</label>
+                                        <input type="radio" class="btn-check" name="action" value="unreview" id="{{ answer.id }}-radio-undecided" autocomplete="off" {% if not answer.is_reviewed %}checked{% endif %}>
+                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-undecided">{% trans 'Undecided' %}</label>
 
-                                            <input type="radio" class="btn-check" name="action" value="delete" id="{{ answer.id }}-radio-delete" autocomplete="off" {% if answer.will_be_deleted %}checked{% endif %}>
-                                            <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-delete">{% trans 'Delete' %}</label>
-                                        </div>
-                                    </form>
-                                </td>
-                                <td class="text-center">
-                                    <form class="full-textanswer-flag-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_flag' %}">
-                                        {% csrf_token %}
+                                        <input type="radio" class="btn-check" name="action" value="delete" id="{{ answer.id }}-radio-delete" autocomplete="off" {% if answer.will_be_deleted %}checked{% endif %}>
+                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-delete">{% trans 'Delete' %}</label>
+                                    </div>
+                                </form>
+                            </div>
+                            <div class="text-center">
+                                <form class="full-textanswer-flag-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_flag' %}">
+                                    {% csrf_token %}
 
-                                        <input type="hidden" name="answer_id" value="{{ answer.id }}" />
+                                    <input type="hidden" name="answer_id" value="{{ answer.id }}" />
 
-                                        {% include "staff_evaluation_textanswer_flag_radios.html" with is_initially_flagged=answer.is_flagged id=answer.id %}
-                                    </form>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+                                    {% include "staff_evaluation_textanswer_flag_radios.html" with is_initially_flagged=answer.is_flagged id=answer.id %}
+                                </form>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
             {% endfor %}
         </div>
     </div>

--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -10,26 +10,26 @@
                 <p>{{ result.question.text }}</p>
                 <div class="grid-striped textanswer-review-grid container{% if not forloop.last %} mb-4{% endif %}">
                     <div class="grid-row fw-bold">
-                        <div class="px-3 py-2">{% trans 'Text answer' %}</div>
-                        <div class="p-2"></div>
-                        <div class="px-3 py-2">{% trans 'Decision' %}</div>
-                        <div class="p-2">{% trans 'Flag' %}</div>
+                        <div>{% trans 'Text answer' %}</div>
+                        <div></div>
+                        <div>{% trans 'Decision' %}</div>
+                        <div>{% trans 'Flag' %}</div>
                     </div>
                     {% for answer in result.answers %}
                         <div class="grid-row" id="{{ answer.id }}">
-                            <div class="px-3 py-2 h-100 d-flex justify-content-left align-items-center">
+                            <div class="justify-content-left">
                                 {{ answer.answer|linebreaksbr }}
                                 {% if answer.original_answer %}
                                     <br />
                                     <span class="textanswer-original">({{ answer.original_answer|linebreaksbr }})</span>
                                 {% endif %}
                             </div>
-                            <div class="p-2 h-100 d-flex justify-content-center align-items-center">
+                            <div class="justify-content-center">
                                 {% if user.is_manager %}
                                     <a class="btn btn-sm btn-outline-secondary" href="{% url 'staff:evaluation_textanswer_edit' answer.id %}"><span class="fas fa-pencil"></a>
                                 {% endif %}
                             </div>
-                            <div class="px-3 py-2 h-100 d-flex justify-content-center align-items-center">
+                            <div class="justify-content-center">
                                 <form class="full-update-textanswer-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_publish' %}">
                                     {% csrf_token %}
 
@@ -50,7 +50,7 @@
                                     </div>
                                 </form>
                             </div>
-                            <div class="p-2 text-center h-100 d-flex justify-content-center align-items-center">
+                            <div class="justify-content-center">
                                 <form class="full-textanswer-flag-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_flag' %}">
                                     {% csrf_token %}
 

--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -10,26 +10,26 @@
                 <p>{{ result.question.text }}</p>
                 <div class="grid-striped container{% if not forloop.last %} mb-4{% endif %}">
                     <div class="row textanswer-review-grid-row fw-bold">
-                        <div data-col="answer" class="px-2">{% trans 'Text answer' %}</div>
-                        <div data-col="edit" class="px-2"></div>
-                        <div data-col="review" class="px-2">{% trans 'Decision' %}</div>
-                        <div data-col="flag" class="px-2">{% trans 'Flag' %}</div>
+                        <div data-col="answer">{% trans 'Text answer' %}</div>
+                        <div data-col="edit"></div>
+                        <div data-col="review">{% trans 'Decision' %}</div>
+                        <div data-col="flag">{% trans 'Flag' %}</div>
                     </div>
                     {% for answer in result.answers %}
                         <div class="row textanswer-review-grid-row" id="{{ answer.id }}">
-                            <div data-col="answer"  class="text-answer col p-2">
+                            <div data-col="answer" class="text-answer col">
                                 {{ answer.answer|linebreaksbr }}
                                 {% if answer.original_answer %}
                                     <br />
                                     <span class="textanswer-original">({{ answer.original_answer|linebreaksbr }})</span>
                                 {% endif %}
                             </div>
-                            <div data-col="edit"  class="p-2">
+                            <div data-col="edit">
                                 {% if user.is_manager %}
                                     <a class="btn btn-sm btn-outline-secondary" href="{% url 'staff:evaluation_textanswer_edit' answer.id %}"><span class="fas fa-pencil"></a>
                                 {% endif %}
                             </div>
-                            <div data-col="review"  class="p-2">
+                            <div data-col="review">
                                 <form class="full-update-textanswer-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_publish' %}">
                                     {% csrf_token %}
 

--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -9,27 +9,27 @@
             {% for result in results %}
                 <p>{{ result.question.text }}</p>
                 <div class="grid-striped container{% if not forloop.last %} mb-4{% endif %}">
-                    <div class="row flex-nowrap fw-bold">
-                            <div class="col p-2">{% trans 'Text answer' %}</div>
-                            <div class="col-fit-content p-2"></div>
-                            <div class="col-fit-content p-2">{% trans 'Decision' %}</div>
-                            <div class="col p-2">{% trans 'Flag' %}</div>
+                    <div class="row textanswer-review-grid-row fw-bold">
+                            <div data-col="answer" class="px-2">{% trans 'Text answer' %}</div>
+                            <div data-col="edit" class="px-2"></div>
+                            <div data-col="review" class="px-2">{% trans 'Decision' %}</div>
+                            <div data-col="flag" px-2">{% trans 'Flag' %}</div>
                     </div>
                     {% for answer in result.answers %}
-                        <div class="row flex-nowrap" id="{{ answer.id }}">
-                            <div class="text-answer col p-2">
+                        <div class="row textanswer-review-grid-row" id="{{ answer.id }}">
+                            <div data-col="answer"  class="text-answer col p-2">
                                 {{ answer.answer|linebreaksbr }}
                                 {% if answer.original_answer %}
                                     <br />
                                     <span class="textanswer-original">({{ answer.original_answer|linebreaksbr }})</span>
                                 {% endif %}
                             </div>
-                            <div class="col-fit-content p-2">
+                            <div data-col="edit"  class="p-2">
                                 {% if user.is_manager %}
                                     <a class="btn btn-sm btn-outline-secondary" href="{% url 'staff:evaluation_textanswer_edit' answer.id %}"><span class="fas fa-pencil"></a>
                                 {% endif %}
                             </div>
-                            <div class="col-fit-content p-2">
+                            <div data-col="review"  class="p-2">
                                 <form class="full-update-textanswer-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_publish' %}">
                                     {% csrf_token %}
 
@@ -50,7 +50,7 @@
                                     </div>
                                 </form>
                             </div>
-                            <div class="text-center">
+                            <div data-col="flag" class="text-center">
                                 <form class="full-textanswer-flag-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_flag' %}">
                                     {% csrf_token %}
 

--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -8,28 +8,28 @@
         <div class="card-body">
             {% for result in results %}
                 <p>{{ result.question.text }}</p>
-                <div class="grid-striped container{% if not forloop.last %} mb-4{% endif %}">
-                    <div class="row textanswer-review-grid-row fw-bold">
-                        <div data-col="answer">{% trans 'Text answer' %}</div>
-                        <div data-col="edit"></div>
-                        <div data-col="review">{% trans 'Decision' %}</div>
-                        <div data-col="flag">{% trans 'Flag' %}</div>
+                <div class="grid-striped textanswer-review-grid container{% if not forloop.last %} mb-4{% endif %}">
+                    <div class="grid-row fw-bold">
+                        <div class="px-2">{% trans 'Text answer' %}</div>
+                        <div class="px-2"></div>
+                        <div class="px-2">{% trans 'Decision' %}</div>
+                        <div class="px-2">{% trans 'Flag' %}</div>
                     </div>
                     {% for answer in result.answers %}
-                        <div class="row textanswer-review-grid-row" id="{{ answer.id }}">
-                            <div data-col="answer" class="text-answer col">
+                        <div class="grid-row" id="{{ answer.id }}">
+                            <div class="p-2 h-100 d-flex justify-content-left align-items-center">
                                 {{ answer.answer|linebreaksbr }}
                                 {% if answer.original_answer %}
                                     <br />
                                     <span class="textanswer-original">({{ answer.original_answer|linebreaksbr }})</span>
                                 {% endif %}
                             </div>
-                            <div data-col="edit">
+                            <div class="p-2 h-100 d-flex justify-content-center align-items-center">
                                 {% if user.is_manager %}
                                     <a class="btn btn-sm btn-outline-secondary" href="{% url 'staff:evaluation_textanswer_edit' answer.id %}"><span class="fas fa-pencil"></a>
                                 {% endif %}
                             </div>
-                            <div data-col="review">
+                            <div class="p-2 h-100 d-flex justify-content-center align-items-center">
                                 <form class="full-update-textanswer-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_publish' %}">
                                     {% csrf_token %}
 
@@ -50,7 +50,7 @@
                                     </div>
                                 </form>
                             </div>
-                            <div data-col="flag" class="text-center">
+                            <div class="text-center h-100 d-flex justify-content-center align-items-center">
                                 <form class="full-textanswer-flag-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_flag' %}">
                                     {% csrf_token %}
 

--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -50,7 +50,7 @@
                                     </div>
                                 </form>
                             </div>
-                            <div class="text-center h-100 d-flex justify-content-center align-items-center">
+                            <div class="p-2 text-center h-100 d-flex justify-content-center align-items-center">
                                 <form class="full-textanswer-flag-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_flag' %}">
                                     {% csrf_token %}
 

--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -17,19 +17,19 @@
                     </div>
                     {% for answer in result.answers %}
                         <div class="grid-row" id="{{ answer.id }}">
-                            <div class="justify-content-left">
+                            <div>
                                 {{ answer.answer|linebreaksbr }}
                                 {% if answer.original_answer %}
                                     <br />
                                     <span class="textanswer-original">({{ answer.original_answer|linebreaksbr }})</span>
                                 {% endif %}
                             </div>
-                            <div class="justify-content-center">
+                            <div>
                                 {% if user.is_manager %}
                                     <a class="btn btn-sm btn-outline-secondary" href="{% url 'staff:evaluation_textanswer_edit' answer.id %}"><span class="fas fa-pencil"></a>
                                 {% endif %}
                             </div>
-                            <div class="justify-content-center">
+                            <div>
                                 <form class="full-update-textanswer-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_publish' %}">
                                     {% csrf_token %}
 
@@ -50,7 +50,7 @@
                                     </div>
                                 </form>
                             </div>
-                            <div class="justify-content-center">
+                            <div>
                                 <form class="full-textanswer-flag-form" method="POST" action="{% url 'staff:evaluation_textanswers_update_flag' %}">
                                     {% csrf_token %}
 

--- a/evap/static/scss/components/_grid.scss
+++ b/evap/static/scss/components/_grid.scss
@@ -2,6 +2,11 @@
     background-color: $table-striped-bg;
 }
 
+// CSS Grid needs it the exact other way around as the title also has the row class
+.grid-striped .row:nth-of-type(even) {
+    background-color: $table-striped-bg;
+}
+
 .lcr-left {
     flex: 1;
 }
@@ -43,6 +48,10 @@
         padding-top: 0.75rem;
         padding-bottom: 0.75rem;
     }
+}
+
+.col-fit-content {
+    flex: 0 0 fit-content;
 }
 
 %grid-row {

--- a/evap/static/scss/components/_grid.scss
+++ b/evap/static/scss/components/_grid.scss
@@ -132,7 +132,11 @@
 
     grid:
         "answer edit review flag"
-        / auto  3rem 310px  5.5rem;
+        / auto  2rem 285px  4.5rem;
+
+    min-height: 0;
+    padding: 0.5rem;
+    gap: 1rem;
 }
 
 @each $col in name, semester, responsible, participants, result, answer, edit, review, flag {

--- a/evap/static/scss/components/_grid.scss
+++ b/evap/static/scss/components/_grid.scss
@@ -2,9 +2,14 @@
     background-color: $table-striped-bg;
 }
 
-// CSS Grid needs it the exact other way around as the title also has the row class
-.grid-striped .row:nth-of-type(even) {
+.grid-row {
+    display: contents;
+}
+
+.grid-striped .grid-row:nth-of-type(even) > div {
     background-color: $table-striped-bg;
+    border-top: 1px solid $table-border-color;
+    border-bottom: 1px solid $table-border-color;
 }
 
 .lcr-left {
@@ -127,16 +132,16 @@
     }
 }
 
-.textanswer-review-grid-row {
+.textanswer-review-grid {
     @extend %grid-row;
 
+    gap: 0;
     grid:
         "answer edit review flag"
-        / auto  2rem 285px  4.5rem;
+        / auto  min-content min-content min-content;
 
     min-height: 0;
     padding: 0.5rem;
-    gap: 1rem;
 }
 
 @each $col in name, semester, responsible, participants, result, answer, edit, review, flag {

--- a/evap/static/scss/components/_grid.scss
+++ b/evap/static/scss/components/_grid.scss
@@ -50,10 +50,6 @@
     }
 }
 
-.col-fit-content {
-    flex: 0 0 fit-content;
-}
-
 %grid-row {
     display: grid;
     min-height: 2.5rem;
@@ -129,6 +125,14 @@
             color: $dark-gray;
         }
     }
+}
+
+.textanswer-review-grid-row {
+    @extend %grid-row;
+
+    grid:
+        "answer edit review flag"
+        / auto  3rem 310px  5.5rem;
 }
 
 @each $col in name, semester, responsible, participants, result {

--- a/evap/static/scss/components/_grid.scss
+++ b/evap/static/scss/components/_grid.scss
@@ -142,6 +142,16 @@
 
     min-height: 0;
     padding: 0.5rem;
+
+    .grid-row > div {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        padding: 0.5rem;
+        &:not(:first-child) {
+            padding-left: 0.75rem;
+        }
+    }
 }
 
 @each $col in name, semester, responsible, participants, result, answer, edit, review, flag {

--- a/evap/static/scss/components/_grid.scss
+++ b/evap/static/scss/components/_grid.scss
@@ -143,13 +143,11 @@
     min-height: 0;
     padding: 0.5rem;
 
-    .grid-row {
-        &> div {
-            height: 100%;
-            padding: 0.5rem;
-        }
+    .grid-row > div {
+        height: 100%;
+        padding: 0.5rem;
 
-        &> div:not(:first-child) {
+        &:not(:first-child) {
             display: flex;
             align-items: center;
             padding-left: 0.75rem;

--- a/evap/static/scss/components/_grid.scss
+++ b/evap/static/scss/components/_grid.scss
@@ -135,7 +135,7 @@
         / auto  3rem 310px  5.5rem;
 }
 
-@each $col in name, semester, responsible, participants, result {
+@each $col in name, semester, responsible, participants, result, answer, edit, review, flag {
     [data-col=#{$col}] {
         grid-area: $col;
     }

--- a/evap/static/scss/components/_grid.scss
+++ b/evap/static/scss/components/_grid.scss
@@ -143,12 +143,15 @@
     min-height: 0;
     padding: 0.5rem;
 
-    .grid-row > div {
-        height: 100%;
-        display: flex;
-        align-items: center;
-        padding: 0.5rem;
-        &:not(:first-child) {
+    .grid-row {
+        &> div {
+            height: 100%;
+            padding: 0.5rem;
+        }
+
+        &> div:not(:first-child) {
+            display: flex;
+            align-items: center;
             padding-left: 0.75rem;
         }
     }

--- a/evap/static/scss/components/_grid.scss
+++ b/evap/static/scss/components/_grid.scss
@@ -2,14 +2,20 @@
     background-color: $table-striped-bg;
 }
 
+// Only needed for selecting all elements of a row
+// https://stackoverflow.com/a/50734005/3984653
 .grid-row {
     display: contents;
 }
 
-.grid-striped .grid-row:nth-of-type(even) > div {
-    background-color: $table-striped-bg;
-    border-top: 1px solid $table-border-color;
-    border-bottom: 1px solid $table-border-color;
+.grid-striped .grid-row {
+    &:nth-of-type(even) > div {
+        background-color: $table-striped-bg;
+    }
+
+    & > div {
+        border-bottom: 1px solid $table-border-color;
+    }
 }
 
 .lcr-left {
@@ -55,7 +61,7 @@
     }
 }
 
-%grid-row {
+%table-grid {
     display: grid;
     min-height: 2.5rem;
     padding: 0.75rem;
@@ -81,7 +87,7 @@
 }
 
 .results-grid-row {
-    @extend %grid-row;
+    @extend %table-grid;
 
     grid:
         "name semester responsible participants result"
@@ -133,7 +139,7 @@
 }
 
 .textanswer-review-grid {
-    @extend %grid-row;
+    @extend %table-grid;
 
     gap: 0;
     grid:
@@ -152,6 +158,9 @@
             align-items: center;
             padding-left: 0.75rem;
         }
+    }
+    .grid-row:not(:first-child) > div:not(:first-child) {
+        justify-content: center;
     }
 }
 


### PR DESCRIPTION
This is the ~"low-effort" version~ high-effort approach, using bootstrap classes. This works well, however, aligning the columns to be the same size is not really possible with the default classes (atleast I didnt find the ones with the right width for this table). With dynamic sizing, this only shifts the second title "Entscheidung" to the right.

**Before:**
<img width="681" alt="image" src="https://user-images.githubusercontent.com/15076254/221685208-9dac5ec9-dc8a-43fe-8055-91e8fb522d2a.png">
**After:**
<img width="681" alt="image" src="https://user-images.githubusercontent.com/15076254/221685308-6039131d-f89f-4382-a727-bfbec2bfde1d.png">

closes #1818