### PR TITLE
Added tooltip for language slider in navbar

### DIFF
--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -91,7 +91,7 @@
                             {% csrf_token %}
                             <input name="language" type="hidden" value="{{ language_code }}">
                             <button type="submit"{% if current_language == language_code %} disabled{% endif %} onclick="setSpinnerIcon('span-set-language-{{ language_code }}')"
-                                class="btn btn-sm btn-navbar{% if current_language == language_code %} active{% endif %}" title="{{ language_name }}">
+                                class="btn btn-sm btn-navbar{% if current_language == language_code %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ language_name }}">
                                 <span id="span-set-language-{{ language_code }}">{{ language_code|upper }}</span>
                             </button>
                         </form>


### PR DESCRIPTION
Added the additional attribute to enable the Bootstrap tooltip on the language slider, this only shows the disabled option similar to the other sliders in the navbar.

<img width="182" alt="DE" src="https://user-images.githubusercontent.com/47167694/224237296-f7f2fee3-52cf-4211-8a22-555fce47e56f.PNG">
