### PR TITLE
Isolate node_modules inside development container/VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ The easiest setup using [Vagrant](https://www.vagrantup.com) is shown here.
      git config --global core.autocrlf input
      ```
 
-   * Symlink Privileges: Our setup script for the VM creates symlinks in the repository folder. This requires either [explicitly allowing your user account to create symlinks](https://superuser.com/a/105381) or simply running the commands in step 3 as administrator. Thus, we suggest doing step 3 in a Git Bash that was started using "Run as administrator". Generally, this is only required for the first time executing `vagrant up`.
-
 3. Run the following commands on the command line to clone the repository, create the Vagrant VM and run the Django development server.
    To use Docker, replace `vagrant up` with `vagrant up --provider docker && vagrant provision`.
    ```bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,8 @@ Vagrant.configure("2") do |config|
     # Docker container really are supposed to be used differently. Hacky way to make it into a "VM".
     d.cmd = ["tail", "-f", "/dev/null"]
 
+    d.create_args = ["--cap-add=SYS_ADMIN", "--security-opt=apparmor:unconfined"]
+
     # Workaround for no SSH server as long as https://github.com/hashicorp/vagrant/issues/8145 is still open
     override.trigger.before :provision do |trigger|
       trigger.ruby do |env, machine| system("vagrant docker-exec -it -- /evap/deployment/provision_vagrant_vm.sh") end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure("2") do |config|
     # Docker container really are supposed to be used differently. Hacky way to make it into a "VM".
     d.cmd = ["tail", "-f", "/dev/null"]
 
+    # Required so we can use mount inside the VM -- see e.g. https://github.com/moby/moby/issues/16429
     d.create_args = ["--cap-add=SYS_ADMIN", "--security-opt=apparmor:unconfined"]
 
     # Workaround for no SSH server as long as https://github.com/hashicorp/vagrant/issues/8145 is still open

--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -6,6 +6,7 @@ MOUNTPOINT="/evap"
 USER="evap"
 REPO_FOLDER="/opt/evap"
 ENV_FOLDER="/home/$USER/venv"
+NODE_MODULES_FOLDER="/home/$USER/node_modules"
 EVAP_PYTHON=python3.8
 
 # force apt to not ask, just do defaults.
@@ -101,8 +102,15 @@ wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh --no-verbos
 # setup evap
 cd "$MOUNTPOINT"
 sudo -H -u $USER git submodule update --init
+
+sudo -H -u $USER mkdir node_modules
+sudo -H -u $USER mkdir ${NODE_MODULES_FOLDER}
+sudo mount --bind ${NODE_MODULES_FOLDER} ${MOUNTPOINT}/node_modules
+echo "sudo mount --bind ${NODE_MODULES_FOLDER} ${MOUNTPOINT}/node_modules" >> /home/$USER/.bashrc
+
 sudo -H -u $USER bash -c "source /home/$USER/.nvm/nvm.sh; nvm install --no-progress node; npm ci"
 echo "nvm use node" >> /home/$USER/.bashrc
+
 sudo -H -u $USER $ENV_FOLDER/bin/python manage.py migrate --noinput
 sudo -H -u $USER $ENV_FOLDER/bin/python manage.py collectstatic --noinput
 sudo -H -u $USER $ENV_FOLDER/bin/python manage.py compilemessages --locale de


### PR DESCRIPTION
Attempt to fix #1648.

Would be nice if some of you could test it out -- inside the VM, you should have `node_modules`, but outside, the folder should simply be empty (or have whatever contents you want it to have)

I will have to test around with the setup a bit more, especially trying to make it break when having `node_modules` populated both inside and outside the VM. In theory, it should work.

We probably also want to document the docker flags used.