### PR TITLE
Pip dependency versioning: Use "compatible-version" specification

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
 -r requirements.txt
-black==23.3.0
+black~=23.3.0
 coverage[toml]
 django-debug-toolbar>=1.6
-django-stubs>=1.13.1
-django-stubs-ext>=0.7.0
-django-webtest==1.9.10
-isort==5.12.0
-model-bakery==1.10.1
-mypy
-openpyxl-stubs==0.1.25
-pylint-django==2.5.3
-pylint==2.17.1
-tblib
-xlrd==2.0.1
+django-stubs~=1.13.1
+django-stubs-ext~=0.7.0
+django-webtest~=1.9.10
+isort~=5.12.0
+model-bakery~=1.10.1
+mypy~=1.1.1
+openpyxl-stubs~=0.1.25
+pylint-django~=2.5.3
+pylint~=2.17.1
+tblib~=1.7.0
+xlrd~=2.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@
 black~=23.3.0
 coverage[toml]
 django-debug-toolbar~=4.0
-django-stubs~=1.13.1
-django-stubs-ext~=0.7.0
+django-stubs~=1.16.0
+django-stubs-ext~=0.8.0
 django-webtest~=1.9.10
 isort~=5.12.0
 model-bakery~=1.10.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 black~=23.3.0
 coverage[toml]
-django-debug-toolbar>=1.6
+django-debug-toolbar~=4.0
 django-stubs~=1.13.1
 django-stubs-ext~=0.7.0
 django-webtest~=1.9.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django-extensions==3.2.1
 django-fsm==2.8.1
-django>=4.1,<4.2
+django~=4.1.7
 mozilla-django-oidc==3.0.0
 openpyxl==3.1.2
 psycopg2-binary==2.9.5


### PR DESCRIPTION
This is defined as "at least this patch version, but feel free to use any higher patch (=compatible) version". This should reduce dependabot spam, since we're basically always up-to-date on patch-versions, while it still allows to specify a minimum patch version if there is a bug we need to have fixed.

I've left  the "smaller" dependencies in `requirements.txt` pinned because I think it's more likely that they have a faulty release, so full version pinning might be beneficial there. These core dependencies usually don't have that many patch updates, so this should be fine.