### PR TITLE
Update to django 4.2

### DIFF
--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -108,7 +108,7 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        {{ preview_html|safe }}
+                        {{ preview_html }}
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% trans 'Close' %}</button>
@@ -132,11 +132,11 @@
         };
     </script>
 
-    {% blocktrans asvar title with evaluation_name=evaluation.full_name|safe %}Request account creation for {{ evaluation_name }}{% endblocktrans %}
+    {% blocktrans asvar title with evaluation_name=evaluation.full_name %}Request account creation for {{ evaluation_name }}{% endblocktrans %}
     {% trans 'Please tell us which new account we should create. We need the name and email for all new accounts.' as teaser %}
     {% include 'contact_modal.html' with modal_id='createAccountRequestModal' user=request.user title=title teaser=teaser %}
 
-    {% blocktrans asvar title with evaluation_name=evaluation.full_name|safe %}Request evaluation changes for {{ evaluation_name }}{% endblocktrans %}
+    {% blocktrans asvar title with evaluation_name=evaluation.full_name %}Request evaluation changes for {{ evaluation_name }}{% endblocktrans %}
     {% trans 'Please tell us what changes to the evaluation we should make.' as teaser %}
     {% include 'contact_modal.html' with modal_id='changeEvaluationRequestModal' user=request.user title=title teaser=teaser %}
 {% endblock %}

--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -4,6 +4,7 @@ from django.db import IntegrityError, transaction
 from django.db.models import Exists, Max, OuterRef, Q
 from django.forms.models import inlineformset_factory
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
@@ -155,9 +156,9 @@ def render_preview(request, formset, evaluation_form, evaluation):
             formset.save()
             request.POST = None  # this prevents errors rendered in the vote form
 
-            preview_response = render_vote_page(
-                request, evaluation, preview=True, for_rendering_in_modal=True
-            ).content.decode()
+            preview_response = mark_safe(
+                render_vote_page(request, evaluation, preview=True, for_rendering_in_modal=True).content.decode()
+            )
             raise IntegrityError  # rollback transaction to discard the database writes
     except IntegrityError:
         pass

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1132,6 +1132,9 @@ class Question(models.Model):
     def save(self, *args, **kwargs):
         if self.type in [Question.TEXT, Question.HEADING]:
             self.allows_additional_textanswers = False
+            if "update_fields" in kwargs:
+                kwargs["update_fields"] = {"allows_additional_textanswers"}.union(kwargs["update_fields"])
+
         super().save(*args, **kwargs)
 
     @property

--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -121,7 +121,10 @@
                     <a class="nav-link dropdown-toggle" href="#" id="navbarUserDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="fas fa-user"></span> {{ user.full_name }}</a>
                     <div class="dropdown-menu dropdown-menu-end dropdown-menu-tight" aria-labelledby="navbarUserDropdownMenuLink">
                         <a class="dropdown-item" href="{% url 'evaluation:profile_edit' %}">{% trans 'Profile' %}</a>
-                        <a class="dropdown-item" href="{% url 'django-auth-logout' %}">{% trans 'Logout' %}</a>
+                        <form method="post" action="{% url 'django-auth-logout' %}" id="logout-form">
+                            {% csrf_token %}
+                            <button type="submit" class="dropdown-item">{% trans 'Logout' %}</button>
+                        </form>
                     </div>
                 </li>
             {% endif %}

--- a/evap/evaluation/tests/test_auth.py
+++ b/evap/evaluation/tests/test_auth.py
@@ -67,7 +67,7 @@ class LoginTests(WebTest):
         page = self.app.post(url_with_key).follow().follow()
         self.assertContains(page, "Logout")
 
-        page = self.app.get(reverse("django-auth-logout")).follow()
+        page = page.forms["logout-form"].submit().follow()
         self.assertNotContains(page, "Logout")
 
         page = self.app.get(url_with_key).follow()
@@ -162,7 +162,7 @@ class LoginTestsWithCSRF(WebTest):
         self.assertContains(page, "Logout")
 
         # log out user
-        page = self.app.get(reverse("django-auth-logout")).follow()
+        page = page.forms["logout-form"].submit().follow()
         self.assertNotContains(page, "Logout")
 
         # log user in again

--- a/evap/grades/templates/grades_upload_form.html
+++ b/evap/grades/templates/grades_upload_form.html
@@ -22,7 +22,7 @@
             {% blocktrans with course=course.name semester=semester.name %}Upload midterm grades for {{ course }} ({{ semester }}){% endblocktrans %}
         {% endif %}
     </h3>
-    <form method="POST" class="form-horizontal" enctype="multipart/form-data">
+    <form method="POST" class="form-horizontal" id="grades-upload-form" enctype="multipart/form-data">
         {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -242,7 +242,7 @@ class GradeEditTest(WebTest):
         previous_modifying_user = self.grade_document.last_modified_user
         self.assertNotEqual(previous_modifying_user, self.grade_publisher)
         response = self.app.get(self.url, user=self.grade_publisher)
-        form = response.forms[3]
+        form = response.forms["grades-upload-form"]
         form["description_en"] = "Absolutely final grades"
         form["file"] = ("grades.txt", b"You did great!")
         form.submit()

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -133,6 +133,15 @@ CACHES = {
     },
 }
 
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
+}
+
 CONTACT_EMAIL = "webmaster@localhost"
 ALLOW_ANONYMOUS_FEEDBACK_MESSAGES = True
 
@@ -320,8 +329,6 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, "static"),
 ]
 
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
-
 # Absolute path to the directory static files should be collected to.
 STATIC_ROOT = os.path.join(BASE_DIR, "static_collected")
 
@@ -395,7 +402,7 @@ TESTING = "test" in sys.argv or "pytest" in sys.modules
 # speed up tests
 if TESTING:
     # do not use ManifestStaticFilesStorage as it requires running collectstatic beforehand
-    STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+    STORAGES["staticfiles"]["BACKEND"] = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
     logging.disable(logging.CRITICAL)  # disable logging, primarily to prevent console spam
 

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -605,7 +605,7 @@ class ContributionForm(forms.ModelForm):
             .filter(
                 Q(visibility=Questionnaire.Visibility.MANAGERS)
                 | Q(visibility=Questionnaire.Visibility.EDITORS)
-                | Q(contributions__evaluation=self.evaluation)
+                | Q(contributions__evaluation=(self.evaluation if self.evaluation.pk else None))
             )
             .distinct()
         )
@@ -810,6 +810,9 @@ class ContributionFormset(BaseInlineFormSet):
             return data
 
         evaluation = kwargs["instance"]
+        if evaluation and not evaluation.pk:
+            evaluation = None
+
         total_forms = int(data["contributions-TOTAL_FORMS"])
         for i in range(0, total_forms):
             prefix = "contributions-" + str(i) + "-"

--- a/evap/staff/importers/person.py
+++ b/evap/staff/importers/person.py
@@ -49,7 +49,8 @@ def add_participants_to(
 def add_contributors_to(
     evaluation: Evaluation, users: Iterable[UserProfile], test_run: bool, importer_log: ImporterLog
 ):
-    already_related_contributions = Contribution.objects.filter(evaluation=evaluation, contributor__in=users)
+    users_with_pk = [user for user in users if user.pk]
+    already_related_contributions = Contribution.objects.filter(evaluation=evaluation, contributor__in=users_with_pk)
     already_related = {assert_not_none(contribution.contributor) for contribution in already_related_contributions}
     if already_related:
         msg = ngettext(

--- a/evap/staff/tests/test_tools.py
+++ b/evap/staff/tests/test_tools.py
@@ -195,8 +195,8 @@ class MergeUsersTest(TestCase):
         self.assertEqual(set(self.evaluation3.voters.all()), {self.main_user})
 
         self.assertFalse(UserProfile.objects.filter(email="other_user@institution.example.com").exists())
-        self.assertFalse(RewardPointGranting.objects.filter(user_profile=self.other_user).exists())
-        self.assertFalse(RewardPointRedemption.objects.filter(user_profile=self.other_user).exists())
+        self.assertFalse(RewardPointGranting.objects.filter(user_profile__email=self.other_user.email).exists())
+        self.assertFalse(RewardPointRedemption.objects.filter(user_profile__email=self.other_user.email).exists())
 
 
 class RemoveUserFromRepresentedAndCCingUsersTest(TestCase):

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -1,7 +1,6 @@
 from functools import partial
 
 from django.test.utils import override_settings
-from django.urls import reverse
 from django_webtest import WebTest
 from model_bakery import baker
 
@@ -380,7 +379,9 @@ class TestVoteView(WebTest):
         page = self.app.get(self.url, user=self.voting_user1, status=200)
         form = page.forms["student-vote-form"]
         self.fill_form(form)
-        page = self.app.get(reverse("django-auth-logout"), user=self.voting_user1, status=302)
+
+        page = page.forms["logout-form"].submit(status=302)
+
         response = form.submit(status=302)
         self.assertNotIn(SUCCESS_MAGIC_STRING, response)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@
 black~=23.3.0
 coverage[toml]
 django-debug-toolbar~=4.0
-django-stubs~=1.16.0
-django-stubs-ext~=0.8.0
+django-stubs~=4.2.0
+django-stubs-ext~=4.2.0
 django-webtest~=1.9.10
 isort~=5.12.0
 model-bakery~=1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django-extensions==3.2.1
 django-fsm==2.8.1
-django~=4.1.7
+django~=4.2.0
 mozilla-django-oidc==3.0.0
 openpyxl==3.1.2
 psycopg2-binary==2.9.6


### PR DESCRIPTION
Technically, our dev-dependency `django-stubs` doesn't support django4.2 yet. However, I don't see a problem here if CI passes, so I wouldn't wait for them.

The other problematic candidate, `mozilla-django-oidc`, doesn't really give any kind of "we support these versions of django" information. Their tests don't yet run with django4.2. Locally, for me, OIDC login works as expected, and django's changelog doesn't indicate any relevant changes to the authentication mechanism.

---
Running the tests with warnings enabled currently triggers these:
* [x] > /home/evap/venv/lib/python3.8/site-packages/django/contrib/auth/views.py:142: RemovedInDjango50Warning: Log out via GET requests is deprecated and will be removed in Django 5.0. Use POST requests for logging out.

    -> We currently have three tests that `self.app.get(reverse("django-auth-logout")`. Simply changing these to "post" seems to fail. The logout button in the navbar currently simply is a link, not a form that will be submitted. I guess both require a bit of work.

* [x] > /home/evap/venv/lib/python3.8/site-packages/django/db/models/fields/related_lookups.py:52: RemovedInDjango50Warning: Passing unsaved model instances to related filters is deprecated.

    -> A few of our tests currently do this (`test_copy_contribution`, `test_initial_from_original`, `test_no_original_given`, `test_merge_users_changes_data_on_success`. Will have to reevaluate those. It seems like this also happens on some staff views (evaluation_copy, evaluation_create, import-views)