### PR TITLE
Dependabot: Don't create PRs that just narrow supported python versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     rebase-strategy: "disabled"
     labels:
       - "[T] Dependencies"
+    versioning-strategy: "increase-if-necessary"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
https://github.com/dependabot/dependabot-core/issues/5537 indicates this should work.