### PR TITLE
Dependabot: Only update major versions for anything puppeteer-related

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+      - dependency-name: "*puppeteer*"
+        update-types: ["version-update:semver-minor"]
     labels:
       - "[T] Dependencies"


### PR DESCRIPTION
As discussed in https://github.com/e-valuation/EvaP/pull/1949#issuecomment-1567537412