### PR TITLE
Enable javascript import replacements for ManifestStaticFilesStorage

### DIFF
--- a/evap/settings.py
+++ b/evap/settings.py
@@ -13,6 +13,8 @@ import os
 import sys
 from typing import Any, List, Tuple
 
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
@@ -133,9 +135,10 @@ CACHES = {
     },
 }
 
-from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
 class ManifestStaticFilesStorageWithJsReplacement(ManifestStaticFilesStorage):
     support_js_module_import_aggregation = True
+
 
 STORAGES = {
     "default": {

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -133,12 +133,16 @@ CACHES = {
     },
 }
 
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+class ManifestStaticFilesStorageWithJsReplacement(ManifestStaticFilesStorage):
+    support_js_module_import_aggregation = True
+
 STORAGES = {
     "default": {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
     "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+        "BACKEND": "evap.settings.ManifestStaticFilesStorageWithJsReplacement",
     },
 }
 


### PR DESCRIPTION
Fixes #1808.

For local testing, I needed to
1. disable `DEBUG`
2. run `collectstatic`
3. access the page through apache2 at `localhost:8001`