### PR TITLE
Stricter password handling in UserProfileManager

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -10,6 +10,7 @@ from typing import Dict, List, NamedTuple, Tuple, Union
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, Group, PermissionsMixin
+from django.contrib.auth.password_validation import validate_password
 from django.contrib.postgres.fields import ArrayField
 from django.core.cache import caches
 from django.core.exceptions import ValidationError
@@ -1593,13 +1594,14 @@ class Infotext(models.Model):
 
 
 class UserProfileManager(BaseUserManager):
-    def create_user(self, email, password=None, first_name=None, last_name=None):
+    def create_user(self, *, email, password=None, first_name=None, last_name=None):
         user = self.model(email=self.normalize_email(email), first_name_given=first_name, last_name=last_name)
+        validate_password(password, user=user)
         user.set_password(password)
         user.save()
         return user
 
-    def create_superuser(self, email, password, first_name=None, last_name=None):
+    def create_superuser(self, *, email, password=None, first_name=None, last_name=None):
         user = self.create_user(
             password=password,
             email=self.normalize_email(email),


### PR DESCRIPTION
A minor thing that annoyed me ever since https://github.com/mozilla/mozilla-django-oidc/issues/388. None of this is really relevant right now, as we don't use passwords, but if we one day do, these things might come back to bite us.

* django [does not specify](https://docs.djangoproject.com/en/4.2/topics/auth/customizing/#django.contrib.auth.models.CustomUserManager.create_user) the order of arguments for `create_user` and `create_superuser`. Any attempt to call them with positional arguments is thus wrong.
* If password validators are configured, our implementation currently does not check against them. [Semgrep warns about this](https://semgrep.dev/playground/r/pZTQKg/python.django.security.audit.unvalidated-password.unvalidated-password). I'm not sure if they are right, the django documentation doesn't really say what there methods should do. Sprinkling a [`validate_password`](https://docs.djangoproject.com/en/4.2/topics/auth/passwords/#django.contrib.auth.password_validation.validate_password) in here can't hurt.
* There's no reason for `create_superuser` to enforce a password, if `None` is given the user simply [won't be able to login via password](https://docs.djangoproject.com/en/4.2/topics/auth/customizing/#django.contrib.auth.models.AbstractBaseUser.set_password).

I manually tested OIDC login and `manage.py createsuperuser`, both still work.