### PR TITLE
Test that the enrollment importer creates general contributions

### DIFF
--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -367,6 +367,9 @@ class TestEnrollmentImport(ImporterTestCase):
         self.assertEqual(importer_log.warnings_by_category(), {})
 
         self.assertEqual(Evaluation.objects.all().count(), 23)
+        for evaluation in Evaluation.objects.all():
+            self.assertIsNotNone(evaluation.general_contribution)
+
         expected_user_count = old_user_count + 23
         self.assertEqual(UserProfile.objects.all().count(), expected_user_count)
 


### PR DESCRIPTION
Follow up to #1843, test for the problem from #1839. I think the addition felt silly back then, but considering that #1846 is probably going to take some time, I'd rather have this in the tests.