### PR TITLE
Importers: Disallow course merging for published evaluations and single results

### DIFF
--- a/evap/staff/importers/enrollment.py
+++ b/evap/staff/importers/enrollment.py
@@ -326,6 +326,7 @@ class CourseMergeLogic:
     @staticmethod
     def get_merge_hindrances(course_data: CourseData, merge_candidate: Course) -> list[str]:
         hindrances = []
+
         if merge_candidate.type != course_data.course_type:
             hindrances.append(_("the course type does not match"))
 
@@ -336,8 +337,17 @@ class CourseMergeLogic:
         merge_candidate_evaluations = merge_candidate.evaluations.all()
         if len(merge_candidate_evaluations) != 1:
             hindrances.append(_("the existing course does not have exactly one evaluation"))
-        elif merge_candidate_evaluations[0].wait_for_grade_upload_before_publishing != course_data.is_graded:
-            hindrances.append(_("the evaluation of the existing course has a mismatching grading specification"))
+        else:
+            merge_candidate_evaluation: Evaluation = merge_candidate_evaluations[0]
+            if merge_candidate_evaluation.wait_for_grade_upload_before_publishing != course_data.is_graded:
+                hindrances.append(_("the evaluation of the existing course has a mismatching grading specification"))
+
+            if merge_candidate_evaluation._participant_count is not None:
+                hindrances.append(
+                    _(
+                        "the evaluation of the existing course has unmodifiable participants (is it published or a single result?)"
+                    )
+                )
 
         return hindrances
 

--- a/evap/staff/importers/enrollment.py
+++ b/evap/staff/importers/enrollment.py
@@ -348,12 +348,9 @@ class CourseMergeLogic:
             hindrances.append(_("the evaluation of the existing course is a single result"))
             return hindrances
 
-        if merge_candidate_evaluation.state >= Evaluation.State.PUBLISHED:
+        if merge_candidate_evaluation.state >= Evaluation.State.IN_EVALUATION:
             hindrances.append(
-                _(
-                    "the import would add participants to the existing evaluation but the participants can't be modified "
-                    "because the evaluation is already published"
-                )
+                _("the import would add participants to the existing evaluation but the evaluation is already running")
             )
         else:
             assert merge_candidate_evaluation._participant_count is None

--- a/evap/staff/importers/enrollment.py
+++ b/evap/staff/importers/enrollment.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, fields
 from datetime import date, datetime
-from typing import TypeAlias, TypeGuard, TypeVar, NoReturn
+from typing import NoReturn, TypeAlias, TypeGuard, TypeVar
 
 from django.conf import settings
 from django.db import transaction

--- a/evap/staff/importers/enrollment.py
+++ b/evap/staff/importers/enrollment.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, fields
 from datetime import date, datetime
-from typing import TypeAlias, TypeGuard, TypeVar
+from typing import TypeAlias, TypeGuard, TypeVar, NoReturn
 
 from django.conf import settings
 from django.db import transaction
@@ -39,7 +39,9 @@ from .user import (
 @dataclass(frozen=True)
 class InvalidValue:
     # We make this a dataclass to make sure all instances compare equal.
-    pass
+
+    def __bool__(self) -> NoReturn:
+        raise NotImplementedError("Bool conversion of InvalidValue is likely a bug")
 
 
 invalid_value = InvalidValue()
@@ -423,7 +425,7 @@ class CourseNameChecker(Checker):
         except CourseMergeLogic.NameEnCollisionException:
             self.name_en_collision_tracker.add_location_for_key(location, course_data.name_en)
 
-        if course_data.merge_into_course:
+        if course_data.merge_into_course != invalid_value and course_data.merge_into_course:
             self.course_merged_tracker.add_location_for_key(location, course_data.name_en)
 
         self.name_en_by_name_de.setdefault(course_data.name_de, course_data.name_en)

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -712,6 +712,7 @@ class TestEnrollmentImport(ImporterTestCase):
             self.default_excel_content, self.semester, self.vote_start_datetime, self.vote_end_date, test_run=False
         )
 
+        self.assertEqual({}, importer_log.warnings_by_category())
         self.assertErrorIs(
             importer_log,
             ImporterLogEntry.Category.COURSE,
@@ -736,13 +737,13 @@ class TestEnrollmentImport(ImporterTestCase):
             self.default_excel_content, self.semester, self.vote_start_datetime, self.vote_end_date, test_run=False
         )
 
+        self.assertEqual({}, importer_log.warnings_by_category())
         self.assertErrorIs(
             importer_log,
             ImporterLogEntry.Category.COURSE,
             "Sheet &quot;BA Belegungen&quot;, row 2 and 1 other place: "
             + "Course &quot;Shake&quot; already exists in this semester, but the courses can not be merged for the following reasons:<br /> "
-            + "- the import would add participants to the existing evaluation but the participants can&#x27;t be modified "
-            + "because the evaluation is already published",
+            + "- the import would add participants to the existing evaluation but the evaluation is already running",
         )
 
         # Attempt with earlier state but set _participant_count
@@ -773,6 +774,7 @@ class TestEnrollmentImport(ImporterTestCase):
             self.default_excel_content, self.semester, self.vote_start_datetime, self.vote_end_date, test_run=False
         )
 
+        self.assertEqual({}, importer_log.warnings_by_category())
         self.assertErrorIs(
             importer_log,
             ImporterLogEntry.Category.COURSE,
@@ -796,6 +798,7 @@ class TestEnrollmentImport(ImporterTestCase):
             self.default_excel_content, self.semester, self.vote_start_datetime, self.vote_end_date, test_run=False
         )
 
+        self.assertEqual({}, importer_log.warnings_by_category())
         self.assertErrorIs(
             importer_log,
             ImporterLogEntry.Category.COURSE,
@@ -820,6 +823,7 @@ class TestEnrollmentImport(ImporterTestCase):
             self.default_excel_content, self.semester, self.vote_start_datetime, self.vote_end_date, test_run=False
         )
 
+        self.assertEqual({}, importer_log.warnings_by_category())
         self.assertErrorIs(
             importer_log,
             ImporterLogEntry.Category.COURSE,


### PR DESCRIPTION
Fixes #1976 (I hope)

@janno42 does simply checking for `_participant_count` cover all relevant cases?

We thought about preventing more changes to `participants` as soon as `_participant_count` is set, but
* deletions are an expected thing (if a `UserProfile` is deleted, the user is removed from `participants`, but kept in `_participant_count`. This is intentional to keep showing a correct count, even if users are deleted. Users are kept as `participants` so that we can still show what evaluations they participated in in the past).
* Only additions could be limited -- here, we could use a m2m signal handler on additions -- an addition is unexpected if the `_count` field is set, but we'd again bump into #1843 as soon as stuff uses bulk_inserts or similar operations.