### PR TITLE
Fixed duplicate through email cleaning #1956

### DIFF
--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -987,11 +987,11 @@ class UserForm(forms.ModelForm):
         return evaluations_participating_in
 
     def clean_email(self):
-        email = self.cleaned_data.get("email")
+        email = clean_email(self.cleaned_data.get("email"))
         if email is None:
             return None
 
-        user_with_same_email = UserProfile.objects.filter(email__iexact=clean_email(email))
+        user_with_same_email = UserProfile.objects.filter(email__iexact=email)
 
         # make sure we don't take the instance itself into account
         if self.instance and self.instance.pk:
@@ -999,7 +999,7 @@ class UserForm(forms.ModelForm):
 
         if user_with_same_email.exists():
             raise forms.ValidationError(_("A user with the email '%s' already exists") % email)
-        return email.lower()
+        return email
 
     def save(self, *args, **kw):
         super().save(*args, **kw)

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -31,7 +31,7 @@ from evap.evaluation.models import (
     TextAnswer,
     UserProfile,
 )
-from evap.evaluation.tools import date_to_datetime, clean_email
+from evap.evaluation.tools import clean_email, date_to_datetime
 from evap.results.tools import STATES_WITH_RESULT_TEMPLATE_CACHING, STATES_WITH_RESULTS_CACHING, cache_results
 from evap.results.views import update_template_cache, update_template_cache_of_published_evaluations_in_course
 from evap.staff.tools import remove_user_from_represented_and_ccing_users

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -31,7 +31,7 @@ from evap.evaluation.models import (
     TextAnswer,
     UserProfile,
 )
-from evap.evaluation.tools import date_to_datetime
+from evap.evaluation.tools import date_to_datetime, clean_email
 from evap.results.tools import STATES_WITH_RESULT_TEMPLATE_CACHING, STATES_WITH_RESULTS_CACHING, cache_results
 from evap.results.views import update_template_cache, update_template_cache_of_published_evaluations_in_course
 from evap.staff.tools import remove_user_from_represented_and_ccing_users
@@ -991,7 +991,7 @@ class UserForm(forms.ModelForm):
         if email is None:
             return None
 
-        user_with_same_email = UserProfile.objects.filter(email__iexact=email)
+        user_with_same_email = UserProfile.objects.filter(email__iexact=clean_email(email))
 
         # make sure we don't take the instance itself into account
         if self.instance and self.instance.pk:

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -163,7 +163,7 @@ class UserFormTests(TestCase):
         data = {"email": "existing@institution.example.com"}
         form = UserForm(instance=user, data=data)
         self.assertFalse(form.is_valid())
-        self.assertIn("A user with the email 'existing@institution.example.com' already exists", form.errors["email"])
+        self.assertIn("A user with the email 'existing@example.com' already exists", form.errors["email"])
 
     def test_user_cannot_be_removed_from_evaluation_already_voted_for(self):
         student = baker.make(UserProfile)

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -121,7 +121,6 @@ class EvaluationEmailFormTests(TestCase):
 
 
 class UserFormTests(TestCase):
-
     @classmethod
     def setUpTestData(cls):
         cls.existing_user = baker.make(UserProfile, email="existing@example.com")


### PR DESCRIPTION
Emails now get transformed before being validated / checked for duplicates in the edit form. Therefor, you can avoid accidentally triggering a database constraint.

Fixes #1956