### PR TITLE
Use builtin types instead of `typing` module for type hints

### DIFF
--- a/evap/evaluation/management/commands/send_reminders.py
+++ b/evap/evaluation/management/commands/send_reminders.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-from typing import List, Tuple
 
 from django.conf import settings
 from django.contrib.auth.models import Group
@@ -13,8 +12,8 @@ from evap.evaluation.models import EmailTemplate, Evaluation
 logger = logging.getLogger(__name__)
 
 
-def get_sorted_evaluation_url_tuples_with_urgent_review() -> List[Tuple[Evaluation, str]]:
-    evaluation_url_tuples: List[Tuple[Evaluation, str]] = [
+def get_sorted_evaluation_url_tuples_with_urgent_review() -> list[tuple[Evaluation, str]]:
+    evaluation_url_tuples: list[tuple[Evaluation, str]] = [
         (
             evaluation,
             settings.PAGE_URL

--- a/evap/evaluation/models_logging.py
+++ b/evap/evaluation/models_logging.py
@@ -44,7 +44,7 @@ class LogJSONEncoder(JSONEncoder):
 
     def default(self, o):
         # o is the object to serialize -- we can't rename the argument in JSONEncoder
-        if isinstance(o, (date, time, datetime)):
+        if isinstance(o, date | time | datetime):
             return localize(o)
         return super().default(o)
 

--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -1,4 +1,3 @@
-from typing import Type
 from unittest.mock import patch
 from uuid import UUID
 
@@ -67,7 +66,7 @@ class TestHelperMethods(WebTest):
         evaluation = baker.make(Evaluation, voters=[baker.make(UserProfile)])
         baker.make(Contribution, evaluation=evaluation)
 
-        def test_logic(cls: Type[Model], pk: int, field: str) -> None:
+        def test_logic(cls: type[Model], pk: int, field: str) -> None:
             instance = cls.objects.get(pk=pk)
             self.assertFalse(is_prefetched(instance, field))
 

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -1,7 +1,7 @@
 import functools
 import os
+from collections.abc import Sequence
 from datetime import timedelta
-from typing import List, Optional, Sequence, Union
 
 from django.conf import settings
 from django.contrib.auth.models import Group
@@ -110,7 +110,7 @@ def render_pages(test_item):
 
 class WebTestWith200Check(WebTest):
     url = "/"
-    test_users: List[Union[UserProfile, str]] = []
+    test_users: list[UserProfile | str] = []
 
     def test_check_response_code_200(self):
         for user in self.test_users:
@@ -180,7 +180,7 @@ def make_editor(user, evaluation):
 def make_rating_answer_counters(
     question: Question,
     contribution: Contribution,
-    answer_counts: Optional[Sequence[int]] = None,
+    answer_counts: Sequence[int] | None = None,
     store_in_db: bool = True,
 ):
     """

--- a/evap/evaluation/tools.py
+++ b/evap/evaluation/tools.py
@@ -1,7 +1,8 @@
 import datetime
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Type, TypeVar
+from collections.abc import Iterable, Mapping
+from typing import Any, TypeVar
 from urllib.parse import quote
 
 import xlwt
@@ -18,7 +19,7 @@ Key = TypeVar("Key")
 Value = TypeVar("Value")
 
 
-def unordered_groupby(key_value_pairs: Iterable[Tuple[Key, Value]]) -> Dict[Key, List[Value]]:
+def unordered_groupby(key_value_pairs: Iterable[tuple[Key, Value]]) -> dict[Key, list[Value]]:
     """
     We need this in several places: Take list of (key, value) pairs and make
     them into the aggregated all-values-of-every-unique-key dict. Note that
@@ -32,7 +33,7 @@ def unordered_groupby(key_value_pairs: Iterable[Tuple[Key, Value]]) -> Dict[Key,
     return dict(result)
 
 
-def get_object_from_dict_pk_entry_or_logged_40x(model_cls: Type[M], dict_obj: Mapping[str, Any], key: str) -> M:
+def get_object_from_dict_pk_entry_or_logged_40x(model_cls: type[M], dict_obj: Mapping[str, Any], key: str) -> M:
     try:
         return get_object_or_404(model_cls, pk=dict_obj[key])
     # ValidationError happens for UUID id fields when passing invalid arguments
@@ -132,7 +133,7 @@ def ilen(iterable):
     return sum(1 for _ in iterable)
 
 
-def assert_not_none(value: Optional[T]) -> T:
+def assert_not_none(value: T | None) -> T:
     assert value is not None
     return value
 
@@ -196,7 +197,7 @@ class ExcelExporter(ABC):
 
     # Derived classes can set this to
     # have a sheet added at initialization.
-    default_sheet_name: Optional[str] = None
+    default_sheet_name: str | None = None
 
     def __init__(self):
         self.workbook = xlwt.Workbook()

--- a/evap/grades/views.py
+++ b/evap/grades/views.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple
-
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
@@ -29,7 +27,7 @@ def index(request):
     return render(request, "grades_index.html", template_data)
 
 
-def course_grade_document_count_tuples(courses: QuerySet[Course]) -> List[Tuple[Course, int, int]]:
+def course_grade_document_count_tuples(courses: QuerySet[Course]) -> list[tuple[Course, int, int]]:
     courses = courses.prefetch_related("degrees", "responsibles", "evaluations", "grade_documents")
 
     return [

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -1,7 +1,6 @@
 import warnings
 from collections import OrderedDict, defaultdict
 from itertools import chain, repeat
-from typing import Dict, Tuple
 
 import xlwt
 from django.db.models import Q
@@ -24,7 +23,7 @@ class ResultsExporter(ExcelExporter):
     STEP = 0.2  # we only have a limited number of custom colors
 
     # Filled in ResultsExporter.init_grade_styles
-    COLOR_MAPPINGS: Dict[int, Tuple[int, int, int]] = {}
+    COLOR_MAPPINGS: dict[int, tuple[int, int, int]] = {}
 
     styles = {
         "evaluation": xlwt.easyxf(

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict, defaultdict
+from collections.abc import Iterable
 from copy import copy
 from math import ceil, modf
-from typing import Dict, Iterable, List, Optional, Tuple, Union, cast
+from typing import cast
 
 from django.conf import settings
 from django.core.cache import caches
@@ -59,7 +60,7 @@ class RatingResult:
         return CHOICES[self.question.type]
 
     @property
-    def count_sum(self) -> Optional[int]:
+    def count_sum(self) -> int | None:
         if not self.is_published:
             return None
         return sum(self.counts)
@@ -71,14 +72,14 @@ class RatingResult:
         return (self.count_sum - portion_left) / 2
 
     @property
-    def approval_count(self) -> Optional[int]:
+    def approval_count(self) -> int | None:
         assert self.question.is_yes_no_question
         if not self.is_published:
             return None
         return self.counts[0] if self.question.is_positive_yes_no_question else self.counts[1]
 
     @property
-    def average(self) -> Optional[float]:
+    def average(self) -> float | None:
         if not self.has_answers:
             return None
         return sum(grade * count for count, grade in zip(self.counts, self.choices.grades)) / self.count_sum
@@ -97,7 +98,7 @@ class TextResult:
         self,
         question: Question,
         answers: Iterable[TextAnswer],
-        answers_visible_to: Optional[TextAnswerVisibility] = None,
+        answers_visible_to: TextAnswerVisibility | None = None,
     ):
         assert question.can_have_textanswers
         self.question = discard_cached_related_objects(copy(question))
@@ -110,18 +111,18 @@ class HeadingResult:
         self.question = discard_cached_related_objects(copy(question))
 
 
-QuestionResult = Union[RatingResult, TextResult, HeadingResult]
+QuestionResult = RatingResult | TextResult | HeadingResult
 
 
 class QuestionnaireResult:
-    def __init__(self, questionnaire: Questionnaire, question_results: List[QuestionResult]):
+    def __init__(self, questionnaire: Questionnaire, question_results: list[QuestionResult]):
         self.questionnaire = discard_cached_related_objects(copy(questionnaire))
         self.question_results = question_results
 
 
 class ContributionResult:
     def __init__(
-        self, contributor: Optional[UserProfile], label: Optional[str], questionnaire_results: List[QuestionnaireResult]
+        self, contributor: UserProfile | None, label: str | None, questionnaire_results: list[QuestionnaireResult]
     ):
         self.contributor = discard_cached_related_objects(copy(contributor)) if contributor is not None else None
         self.label = label
@@ -141,11 +142,11 @@ class ContributionResult:
 
 
 class EvaluationResult:
-    def __init__(self, contribution_results: List[ContributionResult]):
+    def __init__(self, contribution_results: list[ContributionResult]):
         self.contribution_results = contribution_results
 
     @property
-    def questionnaire_results(self) -> List[QuestionnaireResult]:
+    def questionnaire_results(self) -> list[QuestionnaireResult]:
         return [
             questionnaire_result
             for contribution_result in self.contribution_results
@@ -200,14 +201,14 @@ def _get_results_impl(evaluation: Evaluation, *, refetch_related_objects: bool =
 
     prefetch_related_objects([evaluation], *GET_RESULTS_PREFETCH_LOOKUPS)
 
-    tas_per_contribution_question: Dict[Tuple[int, int], List[TextAnswer]] = unordered_groupby(
+    tas_per_contribution_question: dict[tuple[int, int], list[TextAnswer]] = unordered_groupby(
         ((textanswer.contribution_id, textanswer.question_id), textanswer)
         for contribution in evaluation.contributions.all()
         for textanswer in contribution.textanswer_set.all()
         if textanswer.review_decision in [TextAnswer.ReviewDecision.PRIVATE, TextAnswer.ReviewDecision.PUBLIC]
     )
 
-    racs_per_contribution_question: Dict[Tuple[int, int], List[RatingAnswerCounter]] = unordered_groupby(
+    racs_per_contribution_question: dict[tuple[int, int], list[RatingAnswerCounter]] = unordered_groupby(
         ((counter.contribution_id, counter.question_id), counter)
         for contribution in evaluation.contributions.all()
         for counter in contribution.ratinganswercounter_set.all()
@@ -217,7 +218,7 @@ def _get_results_impl(evaluation: Evaluation, *, refetch_related_objects: bool =
     for contribution in evaluation.contributions.all():
         questionnaire_results = []
         for questionnaire in contribution.questionnaires.all():
-            results: List[Union[HeadingResult, TextResult, RatingResult]] = []
+            results: list[HeadingResult | TextResult | RatingResult] = []
             for question in questionnaire.questions.all():
                 if question.is_heading_question:
                     results.append(HeadingResult(question=question))
@@ -422,7 +423,7 @@ def distribution_to_grade(distribution):
 
 def color_mix(color1, color2, fraction):
     return cast(
-        Tuple[int, int, int], tuple(int(round(color1[i] * (1 - fraction) + color2[i] * fraction)) for i in range(3))
+        tuple[int, int, int], tuple(int(round(color1[i] * (1 - fraction) + color2[i] * fraction)) for i in range(3))
     )
 
 
@@ -457,7 +458,7 @@ def textanswers_visible_to(contribution):
 
 def can_textanswer_be_seen_by(
     user: UserProfile,
-    represented_users: List[UserProfile],
+    represented_users: list[UserProfile],
     textanswer: TextAnswer,
     view: str,
 ) -> bool:

--- a/evap/rewards/tools.py
+++ b/evap/rewards/tools.py
@@ -1,5 +1,4 @@
 from datetime import date
-from typing import Dict
 
 from django.conf import settings
 from django.contrib import messages
@@ -24,7 +23,7 @@ from evap.rewards.models import (
 
 
 @transaction.atomic
-def save_redemptions(request, redemptions: Dict[int, int], previous_redeemed_points: int):
+def save_redemptions(request, redemptions: dict[int, int], previous_redeemed_points: int):
     # lock these rows to prevent race conditions
     list(request.user.reward_point_grantings.select_for_update())
     list(request.user.reward_point_redemptions.select_for_update())

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -11,7 +11,7 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 import logging
 import os
 import sys
-from typing import Any, List, Tuple
+from typing import Any
 
 from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 
@@ -72,7 +72,7 @@ INSTITUTION_EMAIL_DOMAINS = ["institution.example.com"]
 # List of tuples defining email domains that should be replaced on saving UserProfiles.
 # Emails ending on the first value will have this part replaced by the second value.
 # e.g.: [("institution.example.com", "institution.com")]
-INSTITUTION_EMAIL_REPLACEMENTS: List[Tuple[str, str]] = []
+INSTITUTION_EMAIL_REPLACEMENTS: list[tuple[str, str]] = []
 
 # the importer accepts only these two strings in the 'graded' column
 IMPORTER_GRADED_YES = "yes"
@@ -100,7 +100,7 @@ EVALUATION_END_WARNING_PERIOD = 5
 ### Installation specific settings
 
 # People who get emails on errors.
-ADMINS: List[Tuple[str, str]] = [
+ADMINS: list[tuple[str, str]] = [
     # ('Your Name', 'your_email@example.com'),
 ]
 

--- a/evap/staff/fixtures/excel_files_test_data.py
+++ b/evap/staff/fixtures/excel_files_test_data.py
@@ -198,7 +198,7 @@ valid_user_courses_import_filedata = {
     ]
 }
 
-random_file_content = "Hallo Welt\n".encode()
+random_file_content = b"Hallo Welt\n"
 
 
 wrong_column_count_excel_data = {

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -743,7 +743,7 @@ class QuestionnaireForm(forms.ModelForm):
 
     def save(self, *args, commit=True, force_highest_order=False, **kwargs):
         # get instance that has all the changes from the form applied, dont write to database
-        questionnaire_instance = super().save(commit=False, *args, **kwargs)
+        questionnaire_instance = super().save(*args, commit=False, **kwargs)
 
         if force_highest_order or "type" in self.changed_data:
             highest_existing_order = (

--- a/evap/staff/importers/base.py
+++ b/evap/staff/importers/base.py
@@ -1,10 +1,11 @@
 import itertools
 from abc import ABC, abstractmethod
 from collections import Counter, namedtuple
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from enum import Enum
 from io import BytesIO
-from typing import Any, Dict, Iterable, Iterator, List, Tuple, Type
+from typing import Any
 
 import openpyxl
 from django.conf import settings
@@ -59,12 +60,12 @@ class ImporterLog:
     """Just a fancy wrapper around a collection of messages with some utility functions"""
 
     def __init__(self) -> None:
-        self.messages: List[ImporterLogEntry] = []
+        self.messages: list[ImporterLogEntry] = []
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.messages})"  # pragma: no cover
 
-    def _messages_with_level_sorted_by_category(self, level: ImporterLogEntry.Level) -> List[ImporterLogEntry]:
+    def _messages_with_level_sorted_by_category(self, level: ImporterLogEntry.Level) -> list[ImporterLogEntry]:
         return sorted(
             (msg for msg in self.messages if msg.level == level),
             key=lambda msg: (msg.category.value.order, msg.category.value.id),
@@ -72,7 +73,7 @@ class ImporterLog:
 
     def _messages_with_level_by_category(
         self, level: ImporterLogEntry.Level
-    ) -> Dict[ImporterLogEntry.Category, List[ImporterLogEntry]]:
+    ) -> dict[ImporterLogEntry.Category, list[ImporterLogEntry]]:
         sorted_messages = self._messages_with_level_sorted_by_category(level)
         grouped_messages = itertools.groupby(sorted_messages, lambda msg: msg.category)
         return {category: list(messages) for category, messages in grouped_messages}
@@ -87,13 +88,13 @@ class ImporterLog:
         if self.has_errors():
             raise ImporterException(message="")
 
-    def success_messages(self) -> List[ImporterLogEntry]:
+    def success_messages(self) -> list[ImporterLogEntry]:
         return self._messages_with_level_sorted_by_category(ImporterLogEntry.Level.SUCCESS)
 
-    def warnings_by_category(self) -> Dict[ImporterLogEntry.Category, List[ImporterLogEntry]]:
+    def warnings_by_category(self) -> dict[ImporterLogEntry.Category, list[ImporterLogEntry]]:
         return self._messages_with_level_by_category(ImporterLogEntry.Level.WARNING)
 
-    def errors_by_category(self) -> Dict[ImporterLogEntry.Category, List[ImporterLogEntry]]:
+    def errors_by_category(self) -> dict[ImporterLogEntry.Category, list[ImporterLogEntry]]:
         return self._messages_with_level_by_category(ImporterLogEntry.Level.ERROR)
 
     def forward_messages_to_django(self, request) -> None:
@@ -192,7 +193,7 @@ class ExcelFileRowMapper:
     Take a excel file and map it to a list of row_cls instances
     """
 
-    def __init__(self, skip_first_n_rows: int, row_cls: Type[InputRow], importer_log: ImporterLog):
+    def __init__(self, skip_first_n_rows: int, row_cls: type[InputRow], importer_log: ImporterLog):
         self.skip_first_n_rows = skip_first_n_rows
         self.row_cls = row_cls
         self.importer_log = importer_log
@@ -253,14 +254,14 @@ class FirstLocationAndCountTracker:
     """Track locations by a key to only give a single aggregated message with first occurence and count"""
 
     def __init__(self, *args, **kwargs) -> None:
-        self.first_location_by_key: Dict[Any, ExcelFileLocation] = {}
+        self.first_location_by_key: dict[Any, ExcelFileLocation] = {}
         self.location_count_by_key: Counter = Counter()
 
     def add_location_for_key(self, location: ExcelFileLocation, key: Any):
         self.first_location_by_key.setdefault(key, location)
         self.location_count_by_key.update([key])
 
-    def aggregated_keys_and_location_strings(self) -> Iterator[Tuple[Any, str]]:
+    def aggregated_keys_and_location_strings(self) -> Iterator[tuple[Any, str]]:
         for key, first_location in self.first_location_by_key.items():
             count = self.location_count_by_key[key]
 

--- a/evap/staff/importers/enrollment.py
+++ b/evap/staff/importers/enrollment.py
@@ -1,15 +1,15 @@
 import difflib
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass, fields
 from datetime import date, datetime
-from typing import DefaultDict, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union
+from typing import TypeAlias, TypeGuard, TypeVar
 
 from django.conf import settings
 from django.db import transaction
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import gettext as _
 from django.utils.translation import ngettext
-from typing_extensions import TypeGuard
 
 from evap.evaluation.models import Contribution, Course, CourseType, Degree, Evaluation, Semester, UserProfile
 from evap.evaluation.tools import clean_email, ilen, unordered_groupby
@@ -45,7 +45,7 @@ class InvalidValue:
 invalid_value = InvalidValue()
 
 T = TypeVar("T")
-MaybeInvalid = Union[T, InvalidValue]
+MaybeInvalid: TypeAlias = T | InvalidValue
 
 
 @dataclass
@@ -54,30 +54,30 @@ class CourseData:
 
     name_de: str
     name_en: str
-    degrees: MaybeInvalid[Set[Degree]]
+    degrees: MaybeInvalid[set[Degree]]
     course_type: MaybeInvalid[CourseType]
     is_graded: MaybeInvalid[bool]
     responsible_email: str
 
     # An existing course that this imported one should be merged with. See #1596
-    merge_into_course: MaybeInvalid[Optional[Course]] = invalid_value
+    merge_into_course: MaybeInvalid[Course | None] = invalid_value
 
     def __post_init__(self):
         self.name_de = self.name_de.strip()
         self.name_en = self.name_en.strip()
         self.responsible_email = clean_email(self.responsible_email)
 
-    def differing_fields(self, other) -> Set[str]:
+    def differing_fields(self, other) -> set[str]:
         return {field.name for field in fields(self) if getattr(self, field.name) != getattr(other, field.name)}
 
 
 class ValidCourseData(CourseData):
     """Typing: CourseData instance where no element is invalid_value"""
 
-    degrees: Set[Degree]
+    degrees: set[Degree]
     course_type: CourseType
     is_graded: bool
-    merge_into_course: Optional[Course]
+    merge_into_course: Course | None
 
 
 def all_fields_valid(course_data: CourseData) -> TypeGuard[ValidCourseData]:
@@ -91,7 +91,7 @@ class DegreeImportMapper:
             super().__init__(*args, **kwargs)
 
     def __init__(self) -> None:
-        self.degrees: Dict[str, Degree] = {
+        self.degrees: dict[str, Degree] = {
             import_name.strip().lower(): degree
             for degree in Degree.objects.all()
             for import_name in degree.import_names
@@ -113,7 +113,7 @@ class CourseTypeImportMapper:
             self.invalid_course_type: str = invalid_course_type
 
     def __init__(self) -> None:
-        self.course_types: Dict[str, CourseType] = {
+        self.course_types: dict[str, CourseType] = {
             import_name.strip().lower(): course_type
             for course_type in CourseType.objects.all()
             for import_name in course_type.import_names
@@ -194,9 +194,9 @@ class EnrollmentInputRowMapper:
         self.degree_mapper = DegreeImportMapper()
         self.is_graded_mapper = IsGradedImportMapper()
 
-        self.invalid_degrees_tracker: Optional[FirstLocationAndCountTracker] = None
-        self.invalid_course_types_tracker: Optional[FirstLocationAndCountTracker] = None
-        self.invalid_is_graded_tracker: Optional[FirstLocationAndCountTracker] = None
+        self.invalid_degrees_tracker: FirstLocationAndCountTracker | None = None
+        self.invalid_course_types_tracker: FirstLocationAndCountTracker | None = None
+        self.invalid_is_graded_tracker: FirstLocationAndCountTracker | None = None
 
     def map(self, rows: Iterable[EnrollmentInputRow]) -> Iterable[EnrollmentParsedRow]:
         self.invalid_degrees_tracker = FirstLocationAndCountTracker()
@@ -226,7 +226,7 @@ class EnrollmentInputRowMapper:
             email=row.responsible_email,
         )
 
-        degrees: MaybeInvalid[Set[Degree]]
+        degrees: MaybeInvalid[set[Degree]]
         try:
             degrees = {self.degree_mapper.degree_from_import_string(row.evaluation_degree_name)}
         except DegreeImportMapper.InvalidDegreeNameException as e:
@@ -304,9 +304,9 @@ class EnrollmentInputRowMapper:
 
 class CourseMergeLogic:
     class MergeException(Exception):
-        def __init__(self, *args, merge_hindrances: List[str], **kwargs):
+        def __init__(self, *args, merge_hindrances: list[str], **kwargs):
             super().__init__(*args, **kwargs)
-            self.merge_hindrances: List[str] = merge_hindrances
+            self.merge_hindrances: list[str] = merge_hindrances
 
     class NameDeCollisionException(Exception):
         """Course with same name_de, but different name_en exists"""
@@ -324,7 +324,7 @@ class CourseMergeLogic:
         self.courses_by_name_en = {course.name_en: course for course in courses}
 
     @staticmethod
-    def get_merge_hindrances(course_data: CourseData, merge_candidate: Course) -> List[str]:
+    def get_merge_hindrances(course_data: CourseData, merge_candidate: Course) -> list[str]:
         hindrances = []
         if merge_candidate.type != course_data.course_type:
             hindrances.append(_("the course type does not match"))
@@ -389,7 +389,7 @@ class CourseNameChecker(Checker):
         self.name_de_collision_tracker = FirstLocationAndCountTracker()
         self.name_en_collision_tracker = FirstLocationAndCountTracker()
 
-        self.name_en_by_name_de: Dict[str, str] = {}
+        self.name_en_by_name_de: dict[str, str] = {}
         self.name_de_mismatch_tracker = FirstLocationAndCountTracker()
 
     def check_course_data(self, course_data: CourseData, location: ExcelFileLocation) -> None:
@@ -416,7 +416,7 @@ class CourseNameChecker(Checker):
             self.name_de_mismatch_tracker.add_location_for_key(location, (course_data.name_en, course_data.name_de))
 
     def finalize(self) -> None:
-        for name_en, location_string in self.course_merged_tracker.aggregated_keys_and_location_strings():
+        for name_en, _location_string in self.course_merged_tracker.aggregated_keys_and_location_strings():
             self.importer_log.add_warning(
                 _(
                     'Course "{course_name}" already exists. The course will not be created, instead users are imported into the '
@@ -518,7 +518,7 @@ class ExistingParticipationChecker(Checker, RowCheckerMixin):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.participant_emails_per_course_name_en: DefaultDict[str, Set[str]] = defaultdict(set)
+        self.participant_emails_per_course_name_en: defaultdict[str, set[str]] = defaultdict(set)
 
     def check_row(self, row: EnrollmentParsedRow) -> None:
         # invalid value will still be set for courses with merge conflicts
@@ -563,7 +563,7 @@ class CourseDataMismatchChecker(Checker):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.course_data_by_name_en: Dict[str, CourseData] = {}
+        self.course_data_by_name_en: dict[str, CourseData] = {}
         self.tracker = FirstLocationAndCountTracker()
 
     def check_course_data(self, course_data: CourseData, location: ExcelFileLocation) -> None:
@@ -597,7 +597,7 @@ class UserDegreeMismatchChecker(Checker, RowCheckerMixin):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
-        self.degree_by_email: Dict[str, Degree] = {}
+        self.degree_by_email: dict[str, Degree] = {}
         self.tracker = FirstLocationAndCountTracker()
 
     def check_row(self, row: EnrollmentParsedRow):
@@ -630,7 +630,7 @@ class TooManyEnrollmentsChecker(Checker, RowCheckerMixin):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.evaluation_names_en_per_user: DefaultDict[str, Set[str]] = defaultdict(set)
+        self.evaluation_names_en_per_user: defaultdict[str, set[str]] = defaultdict(set)
 
     def check_row(self, row: EnrollmentParsedRow):
         if row.student_data.email == "":
@@ -675,8 +675,8 @@ class CourseDataAdapter(RowCheckerMixin):
 def import_enrollments(
     excel_content: bytes,
     semester: Semester,
-    vote_start_datetime: Optional[datetime],
-    vote_end_date: Optional[date],
+    vote_start_datetime: datetime | None,
+    vote_end_date: date | None,
     test_run: bool,
 ) -> ImporterLog:
     # pylint: disable=too-many-locals
@@ -751,10 +751,10 @@ def import_enrollments(
     return importer_log
 
 
-def normalize_rows(enrollment_rows: Iterable[EnrollmentParsedRow]) -> Tuple[List[UserData], List[ValidCourseData]]:
+def normalize_rows(enrollment_rows: Iterable[EnrollmentParsedRow]) -> tuple[list[UserData], list[ValidCourseData]]:
     """The row schema has denormalized students and evaluations. Normalize / merge them back together"""
-    user_data_by_email: Dict[str, UserData] = {}
-    course_data_by_name_en: Dict[str, ValidCourseData] = {}
+    user_data_by_email: dict[str, UserData] = {}
+    course_data_by_name_en: dict[str, ValidCourseData] = {}
 
     for row in enrollment_rows:
         stored = user_data_by_email.setdefault(row.student_data.email, row.student_data)

--- a/evap/staff/importers/person.py
+++ b/evap/staff/importers/person.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 from django.utils.translation import ngettext
 

--- a/evap/staff/importers/user.py
+++ b/evap/staff/importers/user.py
@@ -1,7 +1,7 @@
 import functools
 import operator
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Set, Tuple, Union
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -135,7 +135,7 @@ class UserDataMismatchChecker(Checker):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # maps user's mail to UserData instance where it was first seen to have O(1) lookup
-        self.users: Dict[str, UserData] = {}
+        self.users: dict[str, UserData] = {}
 
         self.in_file_mismatch_tracker = FirstLocationAndCountTracker()
 
@@ -235,7 +235,7 @@ class UserDataMismatchChecker(Checker):
         self.importer_log.add_warning(msg, category=ImporterLogEntry.Category.DUPL)
 
     @staticmethod
-    def _create_user_string(user: Union[UserProfile, UserData]):
+    def _create_user_string(user: UserProfile | UserData):
         if isinstance(user, UserProfile):
             return format_html(
                 "{} {} {}, {} [{}]",
@@ -256,7 +256,7 @@ class UserDataValidationChecker(Checker):
         super().__init__(*args, **kwargs)
 
         # Only give one error per unique user_data.
-        self.already_checked: Set[UserData] = set()
+        self.already_checked: set[UserData] = set()
 
     def check_userdata(self, user_data: UserData, _location: ExcelFileLocation):
         if user_data.email == "":
@@ -281,7 +281,7 @@ class DuplicateUserDataChecker(Checker):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.first_location_by_user_data: Dict[UserData, ExcelFileLocation] = {}
+        self.first_location_by_user_data: dict[UserData, ExcelFileLocation] = {}
 
         self.tracker = FirstLocationAndCountTracker()
 
@@ -318,7 +318,7 @@ class UserDataAdapter(RowCheckerMixin):
 
 
 @transaction.atomic
-def import_users(excel_content: bytes, test_run: bool) -> Tuple[List[UserProfile], ImporterLog]:
+def import_users(excel_content: bytes, test_run: bool) -> tuple[list[UserProfile], ImporterLog]:
     importer_log = ImporterLog()
 
     with ConvertExceptionsToMessages(importer_log):
@@ -369,7 +369,7 @@ def import_users(excel_content: bytes, test_run: bool) -> Tuple[List[UserProfile
     return [], importer_log
 
 
-def get_user_profile_objects(users: Iterable[UserData]) -> Tuple[List[UserProfile], List[UserProfile]]:
+def get_user_profile_objects(users: Iterable[UserData]) -> tuple[list[UserProfile], list[UserProfile]]:
     user_data_by_email = {user_data.email: user_data for user_data in users}
 
     existing_objects = list(UserProfile.objects.filter(email__in=user_data_by_email.keys()))

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Dict, List
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
@@ -45,7 +44,7 @@ class ImporterTestCase(TestCase):
         self.assertErrorsAre(importer_log, {category: [message]})
 
     def assertErrorsAre(
-        self, importer_log: ImporterLog, messages_by_category: Dict[ImporterLogEntry.Category, List[str]]
+        self, importer_log: ImporterLog, messages_by_category: dict[ImporterLogEntry.Category, list[str]]
     ):
         """Helper to assert that no unexpected errors were triggered"""
 

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2,7 +2,7 @@ import datetime
 import os
 from abc import ABC, abstractmethod
 from io import BytesIO
-from typing import Literal, Tuple, Type, Union
+from typing import Literal
 from unittest.mock import PropertyMock, patch
 
 import openpyxl
@@ -65,9 +65,9 @@ class DeleteViewTestMixin(ABC):
     csrf_checks = False
 
     # To be set by derived classes
-    model_cls: Type[Model]
+    model_cls: type[Model]
     url: str
-    permission_method_to_patch: Tuple[Type, str]
+    permission_method_to_patch: tuple[type, str]
 
     @classmethod
     @abstractmethod
@@ -3240,7 +3240,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         self,
         action: str,
         old_decision: TextAnswer.ReviewDecision,
-        expected_new_decision: Union[TextAnswer.ReviewDecision, Literal["unchanged"]] = "unchanged",
+        expected_new_decision: TextAnswer.ReviewDecision | Literal["unchanged"] = "unchanged",
         *,
         status: int = 204,
     ):
@@ -3289,7 +3289,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         results = get_results(self.evaluation)
 
         textresult = next(
-            (result for result in results.questionnaire_results[0].question_results if isinstance(result, TextResult))
+            result for result in results.questionnaire_results[0].question_results if isinstance(result, TextResult)
         )
         self.assertEqual(len(textresult.answers), 0)
 
@@ -3301,7 +3301,7 @@ class TestEvaluationTextAnswersUpdatePublishView(WebTest):
         results = get_results(self.evaluation)
 
         textresult = next(
-            (result for result in results.questionnaire_results[0].question_results if isinstance(result, TextResult))
+            result for result in results.questionnaire_results[0].question_results if isinstance(result, TextResult)
         )
         self.assertEqual(len(textresult.answers), 1)
 

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -1,7 +1,7 @@
 import os
+from collections.abc import Iterable
 from datetime import date, datetime, timedelta
 from enum import Enum
-from typing import Iterable
 
 from django.conf import settings
 from django.contrib import messages

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1,9 +1,10 @@
 import csv
 import itertools
 from collections import OrderedDict, defaultdict, namedtuple
+from collections.abc import Container
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Any, Container, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import Any, cast
 
 import openpyxl
 from django.conf import settings
@@ -201,7 +202,7 @@ def semester_view(request, semester_id) -> HttpResponse:
         first_start: datetime = datetime(9999, 1, 1)
         last_end: date = date(2000, 1, 1)
 
-    degree_stats: Dict[Degree, Stats] = defaultdict(Stats)
+    degree_stats: dict[Degree, Stats] = defaultdict(Stats)
     total_stats = Stats()
     for evaluation in evaluations:
         if evaluation.is_single_result:
@@ -223,7 +224,7 @@ def semester_view(request, semester_id) -> HttpResponse:
                 stats.last_end = max(stats.last_end, evaluation.vote_end_date)
     degree_stats = OrderedDict(sorted(degree_stats.items(), key=lambda x: x[0].order))
 
-    degree_stats_with_total = cast(Dict[Union[Degree, str], Stats], degree_stats)
+    degree_stats_with_total = cast(dict[Degree | str, Stats], degree_stats)
     degree_stats_with_total["total"] = total_stats
 
     template_data = {
@@ -246,10 +247,10 @@ def semester_view(request, semester_id) -> HttpResponse:
 
 
 class EvaluationOperation:
-    email_template_name: Optional[str] = None
-    email_template_contributor_name: Optional[str] = None
-    email_template_participant_name: Optional[str] = None
-    confirmation_message: Optional[StrOrPromise] = None
+    email_template_name: str | None = None
+    email_template_contributor_name: str | None = None
+    email_template_participant_name: str | None = None
+    confirmation_message: StrOrPromise | None = None
 
     @staticmethod
     def applicable_to(evaluation):
@@ -477,7 +478,7 @@ EVALUATION_OPERATIONS = {
 }
 
 
-def target_state_and_operation_from_str(target_state_str: str) -> Tuple[int, Type[EvaluationOperation]]:
+def target_state_and_operation_from_str(target_state_str: str) -> tuple[int, type[EvaluationOperation]]:
     try:
         target_state = int(target_state_str)
     except (KeyError, ValueError, TypeError) as err:
@@ -1049,7 +1050,7 @@ def course_delete(request):
     return HttpResponse()  # 200 OK
 
 
-def evaluation_create_impl(request, semester: Semester, course: Optional[Course]):
+def evaluation_create_impl(request, semester: Semester, course: Course | None):
     if course is not None:
         assert course.semester == semester
     if semester.participations_are_archived:
@@ -1134,7 +1135,7 @@ def evaluation_copy(request, evaluation_id):
     )
 
 
-def single_result_create_impl(request, semester: Semester, course: Optional[Course]):
+def single_result_create_impl(request, semester: Semester, course: Course | None):
     if course is not None:
         assert course.semester == semester
     if semester.participations_are_archived:
@@ -1463,7 +1464,7 @@ TextAnswerSection = namedtuple(
 def get_evaluation_and_contributor_textanswer_sections(
     evaluation: Evaluation,
     textanswer_filter: Q,
-) -> Tuple[List[TextAnswerSection], List[TextAnswerSection]]:
+) -> tuple[list[TextAnswerSection], list[TextAnswerSection]]:
     evaluation_sections = []
     contributor_sections = []
     evaluation_responsibles = list(evaluation.course.responsibles.all())
@@ -1726,7 +1727,7 @@ def questionnaire_create(request):
     return render(request, "staff_questionnaire_form.html", {"form": form, "formset": formset, "editable": True})
 
 
-def disable_all_except_named(fields: Dict[str, Any], names_of_editable: Container[str]):
+def disable_all_except_named(fields: dict[str, Any], names_of_editable: Container[str]):
     for name, field in fields.items():
         if name not in names_of_editable:
             field.disabled = True


### PR DESCRIPTION
Since Python 3.9, `typing.List` and friends are deprecated in favor of using the builtin types directly (for example `list[int]`). I used `ruff` to convert most of the occurrences and also fixed some other stuff it complained about. I think the most controversial change is `Optional[T]` vs `T | None`, because there is no deprecation or recommendation against the former and I would intuitively prefer it. However, we then agreed in the meeting that the latter is probably more intuitive for newcomers and kept it.
