### PR TITLE
don't remove selected values from multiselect lists

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -145,6 +145,7 @@
                         },
                         closeAfterSelect: true, // also clears search input on enter.
                         plugins: {},
+                        hideSelected: false,
                     };
                     if(element.hasAttribute("data-tomselect-fullwidth")) {
                         // span needed to the "remove this icon" button is right-aligned


### PR DESCRIPTION
Participant lists can get quite long for some evaluations. When manually adding participants from a list, it is sometimes easier to just type in a few names and click to add them, rather than checking to see if the name already exists in the list. In these cases, if a name doesn't show up in the list, the editor may think that the account doesn't exist yet and request that it be created.
This can be avoided by showing all names in the list, whether selected or not.