### PR TITLE
Fixed accidentally removed whitespaces in clickable data rows

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -174,7 +174,7 @@
                 for(const table_data of row.children) {
                     const wrapping_anchor = document.createElement("a");
                     wrapping_anchor.href = row.dataset["url"];
-                    wrapping_anchor.append(...table_data.children);
+                    wrapping_anchor.append(...table_data.childNodes);
                     table_data.replaceChildren(wrapping_anchor);
                 }
             });


### PR DESCRIPTION
Accidentally broke it in https://github.com/e-valuation/EvaP/pull/2013/commits/f740a002cc36380c300c3b57357403a25d236edf in #2013 