### PR TITLE
Fix typecheck failure introduced with `django-stubs==4.2.5`

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1681,11 +1681,13 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
 
     # delegates of the user, which can also manage their evaluations
     delegates = models.ManyToManyField(
-        "UserProfile", verbose_name=_("Delegates"), related_name="represented_users", blank=True
+        "evaluation.UserProfile", verbose_name=_("Delegates"), related_name="represented_users", blank=True
     )
 
     # users to which all emails should be sent in cc without giving them delegate rights
-    cc_users = models.ManyToManyField("UserProfile", verbose_name=_("CC Users"), related_name="ccing_users", blank=True)
+    cc_users = models.ManyToManyField(
+        "evaluation.UserProfile", verbose_name=_("CC Users"), related_name="ccing_users", blank=True
+    )
 
     # flag for proxy users which represent a group of users
     is_proxy_user = models.BooleanField(default=False, verbose_name=_("Proxy user"))
@@ -1725,7 +1727,7 @@ class UserProfile(AbstractBaseUser, PermissionsMixin):
         verbose_name_plural = _("users")
 
     USERNAME_FIELD = "email"
-    REQUIRED_FIELDS: list[str] = []
+    REQUIRED_FIELDS = []
 
     objects = UserProfileManager()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@
 black~=23.9.1
 coverage[toml]
 django-debug-toolbar~=4.0
-django-stubs~=4.2.4
-django-stubs-ext~=4.2.0
+django-stubs~=4.2.5
+django-stubs-ext~=4.2.5
 django-webtest~=1.9.10
 isort~=5.12.0
 model-bakery~=1.16.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@
 black~=23.9.1
 coverage[toml]
 django-debug-toolbar~=4.0
-django-stubs~=4.2.5
-django-stubs-ext~=4.2.5
+django-stubs==4.2.5
+django-stubs-ext==4.2.5
 django-webtest~=1.9.10
 isort~=5.12.0
 model-bakery~=1.16.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ black~=23.9.1
 coverage[toml]
 django-debug-toolbar~=4.0
 django-stubs==4.2.5
-django-stubs-ext==4.2.5
 django-webtest~=1.9.10
 isort~=5.12.0
 model-bakery~=1.16.0


### PR DESCRIPTION
With their 4.2.5 release (coming from 4.2.4), django-stubs did two things that broke type checking for us

* They improved their typing on ManyToManyFields, but didn't add functionality to correctly resolve lazy model names (`"UserProfile`) without an app label (`"evaluation.UserProfile"` works).
* They added `AbstractBaseUser.REQUIRED_FIELDS` as a `ClassVar`, we had it defined as an instance variable.