### PR TITLE
fixed notebook overflow

### DIFF
--- a/evap/static/scss/components/_notebook.scss
+++ b/evap/static/scss/components/_notebook.scss
@@ -64,7 +64,8 @@
         }
 
         .notebook-card {
-            height: calc(45vh - (#{$spacer} * 1.5) * 2); // subtract spacer with padding
+            min-height: calc(45vh - (#{$spacer} * 1.5) * 2); //subtract spacer with padding
+            max-height: 43.5vh; //approximation for size needed in smallest window (50vh - (spacer + leeway))
         }
     }
 }


### PR DESCRIPTION

Overflow in very small windows:
![image](https://github.com/e-valuation/EvaP/assets/147043649/177fc635-419f-4ab6-a7ea-5a38bf48df40)

button does not overflow


closes #2048