### PR TITLE
add error suffix to exceptions

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -45,8 +45,8 @@ from evap.evaluation.tools import (
 logger = logging.getLogger(__name__)
 
 
-class NotArchiveable(Exception):
-    """An attempt has been made to archive something that is not archiveable."""
+class NotArchivableError(Exception):
+    """An attempt has been made to archive something that is not archivable."""
 
 
 class Semester(models.Model):
@@ -106,7 +106,7 @@ class Semester(models.Model):
     @transaction.atomic
     def archive(self):
         if not self.participations_can_be_archived:
-            raise NotArchiveable()
+            raise NotArchivableError()
         for evaluation in self.evaluations.all():
             evaluation._archive()
         self.participations_are_archived = True
@@ -119,14 +119,14 @@ class Semester(models.Model):
         from evap.grades.models import GradeDocument
 
         if not self.grade_documents_can_be_deleted:
-            raise NotArchiveable()
+            raise NotArchivableError()
         GradeDocument.objects.filter(course__semester=self).delete()
         self.grade_documents_are_deleted = True
         self.save()
 
     def archive_results(self):
         if not self.results_can_be_archived:
-            raise NotArchiveable()
+            raise NotArchivableError()
         self.results_are_archived = True
         self.save()
 
@@ -636,7 +636,7 @@ class Evaluation(LoggedModel):
     def _archive(self):
         """Should be called only via Semester.archive"""
         if not self.participations_can_be_archived:
-            raise NotArchiveable()
+            raise NotArchivableError()
         if self._participant_count is not None:
             assert self._voter_count is not None
             assert (

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -15,7 +15,7 @@ from evap.evaluation.models import (
     CourseType,
     EmailTemplate,
     Evaluation,
-    NotArchiveable,
+    NotArchivableError,
     Question,
     Questionnaire,
     QuestionType,
@@ -748,9 +748,9 @@ class ParticipationArchivingTests(TestCase):
 
     def test_archiving_participations_twice_raises_exception(self):
         self.semester.archive()
-        with self.assertRaises(NotArchiveable):
+        with self.assertRaises(NotArchivableError):
             self.semester.archive()
-        with self.assertRaises(NotArchiveable):
+        with self.assertRaises(NotArchivableError):
             self.semester.courses.first().evaluations.first()._archive()
 
     def test_evaluation_participations_are_not_archived_if_participant_count_is_set(self):

--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -40,12 +40,12 @@ class TestLanguageMiddleware(WebTest):
         translation.activate("en")  # for following tests
 
 
-class SaboteurException(Exception):
+class SaboteurError(Exception):
     """An exception class used for making sure that our mock is raising the exception and not some other unrelated code"""
 
 
 class TestLogExceptionsDecorator(TestCase):
-    @patch("evap.evaluation.models.Evaluation.update_evaluations", side_effect=SaboteurException())
+    @patch("evap.evaluation.models.Evaluation.update_evaluations", side_effect=SaboteurError())
     @patch("evap.evaluation.management.commands.tools.logger.exception")
     def test_log_exceptions_decorator(self, mock_logger, __):
         """
@@ -54,7 +54,7 @@ class TestLogExceptionsDecorator(TestCase):
         One could create a mock management command and call its handle method manually,
         but to me it seemed safer to use a real one.
         """
-        with self.assertRaises(SaboteurException):
+        with self.assertRaises(SaboteurError):
             management.call_command("update_evaluation_states")
 
         self.assertTrue(mock_logger.called)

--- a/evap/rewards/models.py
+++ b/evap/rewards/models.py
@@ -8,19 +8,19 @@ from django.utils.translation import gettext_lazy as _
 from evap.evaluation.models import Semester, UserProfile
 
 
-class NoPointsSelected(Exception):
+class NoPointsSelectedError(Exception):
     """An attempt has been made to redeem <= 0 points."""
 
 
-class NotEnoughPoints(Exception):
+class NotEnoughPointsError(Exception):
     """An attempt has been made to redeem more points than available."""
 
 
-class OutdatedRedemptionData(Exception):
+class OutdatedRedemptionDataError(Exception):
     """A redemption request has been sent with outdated data, e.g. when a request has been sent twice."""
 
 
-class RedemptionEventExpired(Exception):
+class RedemptionEventExpiredError(Exception):
     """An attempt has been made to redeem more points for an event whose redeem_end_date lies in the past."""
 
 

--- a/evap/rewards/views.py
+++ b/evap/rewards/views.py
@@ -19,10 +19,10 @@ from evap.evaluation.tools import AttachmentResponse, get_object_from_dict_pk_en
 from evap.rewards.exporters import RewardsExporter
 from evap.rewards.forms import RewardPointRedemptionEventForm
 from evap.rewards.models import (
-    NoPointsSelected,
-    NotEnoughPoints,
-    OutdatedRedemptionData,
-    RedemptionEventExpired,
+    NoPointsSelectedError,
+    NotEnoughPointsError,
+    OutdatedRedemptionDataError,
+    RedemptionEventExpiredError,
     RewardPointGranting,
     RewardPointRedemption,
     RewardPointRedemptionEvent,
@@ -45,15 +45,20 @@ def redeem_reward_points(request):
     try:
         save_redemptions(request, redemptions, previous_redeemed_points)
         messages.success(request, _("You successfully redeemed your points."))
-    except (NoPointsSelected, NotEnoughPoints, RedemptionEventExpired, OutdatedRedemptionData) as error:
+    except (
+        NoPointsSelectedError,
+        NotEnoughPointsError,
+        RedemptionEventExpiredError,
+        OutdatedRedemptionDataError,
+    ) as error:
         status_code = 400
-        if isinstance(error, NoPointsSelected):
+        if isinstance(error, NoPointsSelectedError):
             error_string = _("You cannot redeem 0 points.")
-        elif isinstance(error, NotEnoughPoints):
+        elif isinstance(error, NotEnoughPointsError):
             error_string = _("You don't have enough reward points.")
-        elif isinstance(error, RedemptionEventExpired):
+        elif isinstance(error, RedemptionEventExpiredError):
             error_string = _("Sorry, the deadline for this event expired already.")
-        elif isinstance(error, OutdatedRedemptionData):
+        elif isinstance(error, OutdatedRedemptionDataError):
             status_code = 409
             error_string = _(
                 "It appears that your browser sent multiple redemption requests. You can see all successful redemptions below."

--- a/evap/staff/importers/base.py
+++ b/evap/staff/importers/base.py
@@ -86,7 +86,7 @@ class ImporterLog:
 
     def raise_if_has_errors(self) -> None:
         if self.has_errors():
-            raise ImporterException(message="")
+            raise ImporterError(message="")
 
     def success_messages(self) -> list[ImporterLogEntry]:
         return self._messages_with_level_sorted_by_category(ImporterLogEntry.Level.SUCCESS)
@@ -117,7 +117,7 @@ class ImporterLog:
         return self.add_message(ImporterLogEntry(ImporterLogEntry.Level.SUCCESS, category, message_text))
 
 
-class ImporterException(Exception):
+class ImporterError(Exception):
     """Used to abort the import run immediately"""
 
     def __init__(
@@ -145,7 +145,7 @@ class ConvertExceptionsToMessages:
         pass
 
     def __exit__(self, exc_type, exc_value, traceback) -> bool:
-        if isinstance(exc_value, ImporterException):
+        if isinstance(exc_value, ImporterError):
             # Importers raise these to immediately abort with a message
             if exc_value.message:
                 self.importer_log.add_message(exc_value.as_importer_message())
@@ -202,7 +202,7 @@ class ExcelFileRowMapper:
         try:
             book = openpyxl.load_workbook(BytesIO(file_content))
         except Exception as e:
-            raise ImporterException(
+            raise ImporterError(
                 message=_("Couldn't read the file. Error: {}").format(e),
                 category=ImporterLogEntry.Category.SCHEMA,
             ) from e
@@ -213,7 +213,7 @@ class ExcelFileRowMapper:
                 continue
 
             if sheet.max_column != self.row_cls.column_count:
-                raise ImporterException(
+                raise ImporterError(
                     message=_("Wrong number of columns in sheet '{}'. Expected: {}, actual: {}").format(
                         sheet.title, self.row_cls.column_count, sheet.max_column
                     )


### PR DESCRIPTION
While discussing ruff support in #2051, rule [N818](https://docs.astral.sh/ruff/rules/error-suffix-on-exception-name/) failed. Basically, [PEP 8](https://peps.python.org/pep-0008/#exception-names) recommends custom exceptions to have the `Error` suffix:
> Because exceptions should be classes, the class naming convention applies here. However, you should use the suffix "Error" on your exception names (if the exception actually is an error).