### PR TITLE
Added README section clarifying how to get in touch with the team

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ That's it!
 
 ## Contributing
 
-We'd love to see contributions, feel free to fork! You should probably branch off `main`, the branch `release` is used for stable revisions.
+We'd love to see contributions! PRs solving existing issues are most helpful to us. It's best if you ask to be assigned for the issue so we won't have multiple people working on the same issue. Feel free to open issues for bugs, setup problems, or feature requests. If you have other questions, feel free to contact the [organization members](https://github.com/orgs/e-valuation/people). You should probably branch off `main`, the branch `release` is used for stable revisions.
 
 Before committing, run the following commands:
 - `./manage.py test` (runs the test suite)
@@ -52,10 +52,6 @@ Before committing, run the following commands:
 or, to combine all three, simply run `./manage.py precommit`.
 
 You can also set up `pylint`, `isort`, `black` and `prettier` in your IDE to avoid doing this manually all the time.
-
-### Meet The Team
-
-Feel free to get in touch! Our core team members are listed [here](https://github.com/orgs/e-valuation/people), feel free to email us to discuss how you can get involved with EvaP. Creating an issue or linking a pull request works just as well as an icebreaker though, do what you're most comfortable with.
 
 ### Creating a Pull Request (Workflow Suggestion)
 1. (once) [Fork](https://github.com/e-valuation/EvaP/fork) the repository so you have a GitHub repo that you have write access to.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ or, to combine all three, simply run `./manage.py precommit`.
 
 You can also set up `pylint`, `isort`, `black` and `prettier` in your IDE to avoid doing this manually all the time.
 
+### Meet The Team
+
+Feel free to get in touch! Our core team members are listed [here](https://github.com/orgs/e-valuation/people), feel free to email us to discuss how you can get involved with EvaP. Creating an issue or linking a pull request works just as well as an icebreaker though, do what you're most comfortable with.
+ 
+
 ## License
 
 MIT, see [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
I'm in a similar situation to the reporter of [#1906](https://github.com/e-valuation/EvaP/issues/1906) in that I wanted to make a non-code contribution to EvaP, but I wasn't sure how to introduce myself - do I create an issue, start a PR, or email a team member? I added a subsection to "contributing" about how a new contributor who doesn't know where to start can get in contact with the team, and start contributing in areas of need. Let me know if anything I wrote needs changed.