### PR TITLE
ResultGrid: Don't hard-fail if some cell value is missing in filter checkboxes

### DIFF
--- a/evap/static/ts/src/datagrid.ts
+++ b/evap/static/ts/src/datagrid.ts
@@ -441,7 +441,7 @@ export class ResultGrid extends DataGrid {
             // To store filter values independent of the language, use the corresponding id from the checkbox
             const values = [...row.querySelectorAll(selector)]
                 .map(element => element.textContent!.trim())
-                .map(filterName => checkboxes.find(checkbox => checkbox.dataset.filter === filterName)!.value);
+                .map(filterName => checkboxes.find(checkbox => checkbox.dataset.filter === filterName)?.value);
             filterValues.set(name, values);
         }
         return filterValues;


### PR DESCRIPTION
Related to #1739.

Currently, if some of the rows contain filter values that do not correspond to any values in the grid header, the javascript will error out (because we're accessing `.values` of `undefined`). Conceptually, the datagrid assumes that the header checkboxes it is passed always perfectly match the data given. Due to outdated caches, this might not be the case.

To test this, simply merge two course types and then open the results page.

I'm open for other suggestions of how to handle this in javascript. Having `undefined` as a stored filter value seems semantically useful to me, but we can also coalesce to `false`. I'd also be open to issue a warning to the console if this happens, to make potential future debugging easier.

It is still non-perfect if we run into the outdated caches situation because now there will be rows that can not be filtered for, but at least the rest of the datagrid will function as expected. Users would simply be missing the right checkbox. I've been thinking about making the ResultGrid build the header checkboxes, but currently that really isn't its responsibility, so that would be a bigger change.

IMO, this change doesn't make it "good", but it makes it better, which is somewhat overdue.