### PR TITLE
Fix Borders in Outlined Button Group in textanswers view

### DIFF
--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -35,7 +35,7 @@
 
                                     <input type="hidden" name="answer_id" value="{{ answer.id }}" />
 
-                                    <div class="btn-group btn-group-sm" role="group">
+                                    <div class="btn-group btn-group-sm outline-fix" role="group">
                                         <input type="radio" class="btn-check" name="action" value="publish" id="{{ answer.id }}-radio-publish" autocomplete="off" {% if answer.will_be_public %}checked{% endif %}>
                                         <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-publish">{% trans 'Publish' %}</label>
 

--- a/evap/static/scss/_adjustments.scss
+++ b/evap/static/scss/_adjustments.scss
@@ -140,7 +140,7 @@ $alert-colors: (
 
     // If .btn is not the last element in the group, remove the right border.
     // Also uses :has to not remove the right border if the next element is a disabled input
-    .btn:not(:last-child):not(.dropdown-toggle):has(+ :not(.btn-check[disabled])), .btn-group:not(:last-child) > .btn {
+    .btn:not(:last-child):has(+ :not(.btn-check[disabled])) {
         border-right: 0;
     }
 
@@ -149,9 +149,8 @@ $alert-colors: (
         border-left: 0;
     }
 
-    // Revert Bootstrap (Prevent double borders when buttons are next to each other)
-    > :not(.btn-check:first-child) + .btn,
-    > .btn-group:not(:first-child) {
+    // Revert Bootstrap's hack, that uses negative margin which would appear as double borders
+    :not(.btn-check:first-child) + .btn {
         margin-left: unset;
     }
 }

--- a/evap/static/scss/_adjustments.scss
+++ b/evap/static/scss/_adjustments.scss
@@ -133,3 +133,25 @@ $alert-colors: (
     border-color: $input-focus-border-color;
     box-shadow: $input-focus-box-shadow;
 }
+
+// Change .btn-group outlined border style to fix double borders with outlined button style
+// see https://github.com/twbs/bootstrap/issues/25888
+.btn-group.outline-fix {
+
+    // If .btn is not the last element in the group, remove the right border.
+    // Also uses :has to not remove the right border if the next element is a disabled input
+    .btn:not(:last-child):not(.dropdown-toggle):has(+ :not(.btn-check[disabled])), .btn-group:not(:last-child) > .btn {
+        border-right: 0;
+    }
+
+    // Explicitly disable the left border of disabled .btn's to use the right border of the previous button.
+    .btn-check[disabled] + .btn {
+        border-left: 0;
+    }
+
+    // Revert Bootstrap (Prevent double borders when buttons are next to each other)
+    > :not(.btn-check:first-child) + .btn,
+    > .btn-group:not(:first-child) {
+        margin-left: unset;
+    }
+}

--- a/evap/static/scss/components/_button-group.scss
+++ b/evap/static/scss/components/_button-group.scss
@@ -17,3 +17,25 @@ div.vote-inputs > textarea {
 div.vote-inputs label.choice-error {
     border-color: $evap-red;
 }
+
+// Change .btn-group outlined border style to fix double borders with outlined button style
+// see https://github.com/twbs/bootstrap/issues/25888
+.btn-group.outline-fix {
+
+    // If .btn is not the last element in the group, remove the right border.
+    // Also uses :has to not remove the right border if the next element is a disabled input
+    .btn:not(:last-child):not(.dropdown-toggle):has(+ :not(.btn-check[disabled])), .btn-group:not(:last-child) > .btn {
+        border-right: 0;
+    }
+
+    // Explicitly disable the left border of disabled .btn's to use the right border of the previous button.
+    .btn-check[disabled] + .btn {
+        border-left: 0;
+    }
+
+    // Revert Bootstrap (Prevent double borders when buttons are next to each other)
+    > :not(.btn-check:first-child) + .btn,
+    > .btn-group:not(:first-child) {
+        margin-left: unset;
+    }
+}

--- a/evap/static/scss/components/_button-group.scss
+++ b/evap/static/scss/components/_button-group.scss
@@ -17,25 +17,3 @@ div.vote-inputs > textarea {
 div.vote-inputs label.choice-error {
     border-color: $evap-red;
 }
-
-// Change .btn-group outlined border style to fix double borders with outlined button style
-// see https://github.com/twbs/bootstrap/issues/25888
-.btn-group.outline-fix {
-
-    // If .btn is not the last element in the group, remove the right border.
-    // Also uses :has to not remove the right border if the next element is a disabled input
-    .btn:not(:last-child):not(.dropdown-toggle):has(+ :not(.btn-check[disabled])), .btn-group:not(:last-child) > .btn {
-        border-right: 0;
-    }
-
-    // Explicitly disable the left border of disabled .btn's to use the right border of the previous button.
-    .btn-check[disabled] + .btn {
-        border-left: 0;
-    }
-
-    // Revert Bootstrap (Prevent double borders when buttons are next to each other)
-    > :not(.btn-check:first-child) + .btn,
-    > .btn-group:not(:first-child) {
-        margin-left: unset;
-    }
-}


### PR DESCRIPTION
Fixes double borders referenced [here](https://github.com/e-valuation/EvaP/issues/1945#issuecomment-1819526342).

This needs the `:has()` pseudoselector, which will be supported in the next firefox release [121](https://bugzilla.mozilla.org/show_bug.cgi?id=1858743) (planned release date: 2023-12-19)

![grafik](https://github.com/e-valuation/EvaP/assets/45557700/2234c722-b71c-4c55-98da-7ae30e9c1fc1)

