### PR TITLE
fix: notebook logic

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -47,12 +47,6 @@
 
         {% if user.is_authenticated %}
             {% include 'notebook.html' %}
-
-            <div class="collapse show" tabindex="-1" id="notebookButton">
-                <button class="btn btn-outline-secondary button-open-notebook" type="button" data-bs-toggle="collapse" data-bs-target="#notebook">
-                    <span class="fas fa-pen-to-square"></span>
-                </button>
-            </div>
         {% endif %}
 
         <div class="p-3 mb-4" id="evapContent">
@@ -206,11 +200,6 @@
                 element.className = "fas fa-spinner fa-spin";  // clears all other classes
             };
 
-        </script>
-        <script type="module">
-            import  { NotebookLogic } from "{% static 'js/notebook.js' %}"
-
-            new NotebookLogic("#notebook").attach();
         </script>
 
         {% block additional_javascript %}{% endblock %}

--- a/evap/evaluation/templates/notebook.html
+++ b/evap/evaluation/templates/notebook.html
@@ -1,3 +1,4 @@
+{% load static %}
 <div class="notebook">
    <div class="collapse position-fixed collapse-horizontal notebook-animation mt-0 d-print-none" tabindex="-1" id="notebook" aria-expanded="false">
         <div class="card">
@@ -35,7 +36,7 @@
 </div>
 
 <script type="module">
-    import  { initNotebook } from "{% static 'js/notebook.js' %}"
-    initNotebook("#notebook", "#notebook-form", "#evapContent", "evap_notebook_open", "#notebookButton");
+    import { NotebookLogic } from "{% static 'js/notebook.js' %}";
+    import { selectOrError } from "{% static 'js/utils.js' %}";
+    new NotebookLogic(selectOrError("#notebook"), selectOrError("#notebook-form"), selectOrError("#evapContent"), selectOrError("#notebookButton"), "evap_notebook_open").attach();
 </script>
-

--- a/evap/evaluation/templates/notebook.html
+++ b/evap/evaluation/templates/notebook.html
@@ -27,3 +27,15 @@
         </div>
     </div>
 </div>
+
+<div class="collapse show" tabindex="-1" id="notebookButton">
+    <button class="btn btn-outline-secondary button-open-notebook" type="button" data-bs-toggle="collapse" data-bs-target="#notebook">
+        <span class="fas fa-pen-to-square"></span>
+    </button>
+</div>
+
+<script type="module">
+    import  { initNotebook } from "{% static 'js/notebook.js' %}"
+    initNotebook("#notebook", "#notebook-form", "#evapContent", "evap_notebook_open", "#notebookButton");
+</script>
+

--- a/evap/static/ts/src/notebook.ts
+++ b/evap/static/ts/src/notebook.ts
@@ -1,11 +1,6 @@
 import "./translation.js";
 import { unwrap, assert, selectOrError } from "./utils.js";
 
-const NOTEBOOK_LOCALSTORAGE_KEY = "evap_notebook_open";
-const COLLAPSE_TOGGLE_BUTTON_SELECTOR = "#notebookButton";
-const WEBSITE_CONTENT_SELECTOR = "#evapContent";
-const NOTEBOOK_FORM_SELECTOR = "#notebook-form";
-
 class NotebookFormLogic {
     private readonly notebook: HTMLFormElement;
     private readonly updateCooldown = 2000;
@@ -45,17 +40,19 @@ class NotebookFormLogic {
     };
 }
 
-export class NotebookLogic {
+class NotebookLogic {
     private readonly notebookCard: HTMLElement;
     private readonly evapContent: HTMLElement;
     private readonly formLogic: NotebookFormLogic;
     private readonly localStorageKey: string;
+    private readonly collapseNotebookButtonSelector: string;
 
-    constructor(notebookSelector: string) {
+    constructor(notebookSelector: string, noteBookFormSelector: string, evapContentSelector: string, localStorageKey: string, collapseNotebookButtonSelector: string) {
         this.notebookCard = selectOrError(notebookSelector);
-        this.formLogic = new NotebookFormLogic(NOTEBOOK_FORM_SELECTOR);
-        this.evapContent = selectOrError(WEBSITE_CONTENT_SELECTOR);
-        this.localStorageKey = NOTEBOOK_LOCALSTORAGE_KEY + "_" + notebookSelector;
+        this.formLogic = new NotebookFormLogic(noteBookFormSelector);
+        this.evapContent = selectOrError(evapContentSelector);
+        this.localStorageKey = localStorageKey + "_" + notebookSelector;
+        this.collapseNotebookButtonSelector = collapseNotebookButtonSelector;
     }
 
     private onShowNotebook = (): void => {
@@ -63,7 +60,7 @@ export class NotebookLogic {
 
         localStorage.setItem(this.localStorageKey, "true");
         this.evapContent.classList.add("notebook-margin");
-        selectOrError(COLLAPSE_TOGGLE_BUTTON_SELECTOR).classList.replace("show", "hide");
+        selectOrError(this.collapseNotebookButtonSelector).classList.replace("show", "hide");
     };
 
     private onHideNotebook = (): void => {
@@ -71,10 +68,11 @@ export class NotebookLogic {
 
         localStorage.setItem(this.localStorageKey, "false");
         this.evapContent.classList.remove("notebook-margin");
-        selectOrError(COLLAPSE_TOGGLE_BUTTON_SELECTOR).classList.replace("hide", "show");
+        selectOrError(this.collapseNotebookButtonSelector).classList.replace("hide", "show");
     };
 
     public attach = (): void => {
+
         if (localStorage.getItem(this.localStorageKey) == "true") {
             this.notebookCard.classList.add("show");
             this.onShowNotebook();
@@ -85,4 +83,11 @@ export class NotebookLogic {
 
         this.formLogic.attach();
     };
+}
+
+
+export function initNotebook(notebookSelector: string, noteBookFormSelector: string, evapContentSelector: string, localStorageKey: string, collapseNotebookButtonSelector: string): void {
+    if (document.querySelector(notebookSelector) && document.querySelector(noteBookFormSelector) && document.querySelector(evapContentSelector) && localStorageKey && collapseNotebookButtonSelector) {
+
+    new NotebookLogic(notebookSelector, noteBookFormSelector, evapContentSelector, localStorageKey, collapseNotebookButtonSelector).attach();}
 }

--- a/evap/static/ts/src/notebook.ts
+++ b/evap/static/ts/src/notebook.ts
@@ -1,12 +1,12 @@
 import "./translation.js";
-import { unwrap, assert, selectOrError } from "./utils.js";
+import { unwrap, assert } from "./utils.js";
 
 class NotebookFormLogic {
     private readonly notebook: HTMLFormElement;
     private readonly updateCooldown = 2000;
 
-    constructor(notebookFormId: string) {
-        this.notebook = selectOrError(notebookFormId);
+    constructor(notebook: HTMLFormElement) {
+        this.notebook = notebook;
     }
 
     private onSubmit = (event: SubmitEvent): void => {
@@ -40,19 +40,25 @@ class NotebookFormLogic {
     };
 }
 
-class NotebookLogic {
+export class NotebookLogic {
     private readonly notebookCard: HTMLElement;
     private readonly evapContent: HTMLElement;
     private readonly formLogic: NotebookFormLogic;
     private readonly localStorageKey: string;
-    private readonly collapseNotebookButtonSelector: string;
+    private readonly collapseNotebookButton: HTMLElement;
 
-    constructor(notebookSelector: string, noteBookFormSelector: string, evapContentSelector: string, localStorageKey: string, collapseNotebookButtonSelector: string) {
-        this.notebookCard = selectOrError(notebookSelector);
-        this.formLogic = new NotebookFormLogic(noteBookFormSelector);
-        this.evapContent = selectOrError(evapContentSelector);
-        this.localStorageKey = localStorageKey + "_" + notebookSelector;
-        this.collapseNotebookButtonSelector = collapseNotebookButtonSelector;
+    constructor(
+        notebook: HTMLElement,
+        noteBookForm: HTMLFormElement,
+        evapContent: HTMLElement,
+        collapseNotebookButton: HTMLElement,
+        localStorageKey: string,
+    ) {
+        this.notebookCard = notebook;
+        this.formLogic = new NotebookFormLogic(noteBookForm);
+        this.evapContent = evapContent;
+        this.localStorageKey = localStorageKey;
+        this.collapseNotebookButton = collapseNotebookButton;
     }
 
     private onShowNotebook = (): void => {
@@ -60,7 +66,7 @@ class NotebookLogic {
 
         localStorage.setItem(this.localStorageKey, "true");
         this.evapContent.classList.add("notebook-margin");
-        selectOrError(this.collapseNotebookButtonSelector).classList.replace("show", "hide");
+        this.collapseNotebookButton.classList.replace("show", "hide");
     };
 
     private onHideNotebook = (): void => {
@@ -68,11 +74,10 @@ class NotebookLogic {
 
         localStorage.setItem(this.localStorageKey, "false");
         this.evapContent.classList.remove("notebook-margin");
-        selectOrError(this.collapseNotebookButtonSelector).classList.replace("hide", "show");
+        this.collapseNotebookButton.classList.replace("hide", "show");
     };
 
     public attach = (): void => {
-
         if (localStorage.getItem(this.localStorageKey) == "true") {
             this.notebookCard.classList.add("show");
             this.onShowNotebook();
@@ -83,11 +88,4 @@ class NotebookLogic {
 
         this.formLogic.attach();
     };
-}
-
-
-export function initNotebook(notebookSelector: string, noteBookFormSelector: string, evapContentSelector: string, localStorageKey: string, collapseNotebookButtonSelector: string): void {
-    if (document.querySelector(notebookSelector) && document.querySelector(noteBookFormSelector) && document.querySelector(evapContentSelector) && localStorageKey && collapseNotebookButtonSelector) {
-
-    new NotebookLogic(notebookSelector, noteBookFormSelector, evapContentSelector, localStorageKey, collapseNotebookButtonSelector).attach();}
 }

--- a/evap/static/ts/src/notebook.ts
+++ b/evap/static/ts/src/notebook.ts
@@ -49,13 +49,13 @@ export class NotebookLogic {
 
     constructor(
         notebook: HTMLElement,
-        noteBookForm: HTMLFormElement,
+        notebookForm: HTMLFormElement,
         evapContent: HTMLElement,
         collapseNotebookButton: HTMLElement,
         localStorageKey: string,
     ) {
         this.notebookCard = notebook;
-        this.formLogic = new NotebookFormLogic(noteBookForm);
+        this.formLogic = new NotebookFormLogic(notebookForm);
         this.evapContent = evapContent;
         this.localStorageKey = localStorageKey;
         this.collapseNotebookButton = collapseNotebookButton;

--- a/evap/static/ts/src/notebook.ts
+++ b/evap/static/ts/src/notebook.ts
@@ -2,12 +2,9 @@ import "./translation.js";
 import { unwrap, assert } from "./utils.js";
 
 class NotebookFormLogic {
-    private readonly notebook: HTMLFormElement;
     private readonly updateCooldown = 2000;
 
-    constructor(notebook: HTMLFormElement) {
-        this.notebook = notebook;
-    }
+    constructor(private readonly notebook: HTMLFormElement) {}
 
     private onSubmit = (event: SubmitEvent): void => {
         event.preventDefault();
@@ -41,24 +38,16 @@ class NotebookFormLogic {
 }
 
 export class NotebookLogic {
-    private readonly notebookCard: HTMLElement;
-    private readonly evapContent: HTMLElement;
     private readonly formLogic: NotebookFormLogic;
-    private readonly localStorageKey: string;
-    private readonly collapseNotebookButton: HTMLElement;
 
     constructor(
-        notebook: HTMLElement,
+        private readonly notebookCard: HTMLElement,
         notebookForm: HTMLFormElement,
-        evapContent: HTMLElement,
-        collapseNotebookButton: HTMLElement,
-        localStorageKey: string,
+        private readonly evapContent: HTMLElement,
+        private readonly collapseNotebookButton: HTMLElement,
+        private readonly localStorageKey: string,
     ) {
-        this.notebookCard = notebook;
         this.formLogic = new NotebookFormLogic(notebookForm);
-        this.evapContent = evapContent;
-        this.localStorageKey = localStorageKey;
-        this.collapseNotebookButton = collapseNotebookButton;
     }
 
     private onShowNotebook = (): void => {


### PR DESCRIPTION
Currently, the javascript that wants to attach the notebook logic to the HTML elements triggers even if the notebook wasn't rendered into the page (when the user is not logged in). As a consequence, on the login page, there is a javascript error in the browser console.

This PR unifies creation of the HTML elements and execution of the corresponding JS code.