### PR TITLE
[waiting for django5.1] Content Security Policy

### DIFF
--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -92,7 +92,7 @@
                     <button name="operation" value="save" type="submit" class="btn btn-primary">{% trans 'Save' %}</button>
                     {# webtest does not allow submission with value "approve" if no such button exists #}
                     <button style="display: none" name="operation" value="approve" type="submit"></button>
-                    <button type="button" onclick="approveEvaluationModalShow(0, '');" class="btn btn-success">{% trans 'Save and approve' %}</button>
+                    <button type="button" id="approve-button" class="btn btn-success">{% trans 'Save and approve' %}</button>
                 {% endif %}
                 <a href="{% url 'contributor:index' %}" class="btn btn-light">{% if edit %}{% trans 'Cancel' %}{% else %}{% trans 'Back' %}{% endif %}</a>
             </div>
@@ -136,6 +136,7 @@
             form.appendChild(input);
             form.requestSubmit();
         };
+        document.getElementById("approve-button").addEventListener("click", () => approveEvaluationModalShow(0, ''));
     </script>
 
     {% blocktrans asvar title with evaluation_name=evaluation.full_name %}Request account creation for {{ evaluation_name }}{% endblocktrans %}

--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -125,7 +125,7 @@
     {% blocktrans asvar question%}Do you want to approve this evaluation? This will allow the evaluation team to proceed with the preparation, but you won't be able to make any further changes.{% endblocktrans %}
     {% trans 'Approve evaluation' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='approveEvaluationModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function approveEvaluationModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -151,7 +151,7 @@
     {% include 'evap_evaluation_edit_js.html' %}
 
     {% if preview_html %}
-        <script type="text/javascript">
+        <script type="text/javascript" nonce="{{ CSP_NONCE }}">
             var previewModal = new bootstrap.Modal(document.getElementById('previewModal'));
             previewModal.show();
         </script>

--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -91,7 +91,7 @@
                     <button name="operation" value="preview" type="submit" class="btn btn-light">{% trans 'Preview' %}</button>
                     <button name="operation" value="save" type="submit" class="btn btn-primary">{% trans 'Save' %}</button>
                     {# webtest does not allow submission with value "approve" if no such button exists #}
-                    <button style="display: none" name="operation" value="approve" type="submit"></button>
+                    <button class="d-none" name="operation" value="approve" type="submit"></button>
                     <button type="button" id="approve-button" class="btn btn-success">{% trans 'Save and approve' %}</button>
                 {% endif %}
                 <a href="{% url 'contributor:index' %}" class="btn btn-light">{% if edit %}{% trans 'Cancel' %}{% else %}{% trans 'Back' %}{% endif %}</a>

--- a/evap/contributor/templates/contributor_index.html
+++ b/evap/contributor/templates/contributor_index.html
@@ -157,9 +157,13 @@
                                                         <span class="fas fa-pencil"></span>
                                                     </a>
                                                     {% if not evaluation|has_nonresponsible_editor %}
-                                                        <a href="#" class="btn btn-sm btn-dark" data-bs-toggle="tooltip"
-                                                            data-bs-placement="top" title="{% trans 'Delegate preparation' %}"
-                                                            onclick="delegateSelectionModalShow(`{{ evaluation.full_name }}`, `{% url 'contributor:evaluation_direct_delegation' evaluation.id %}`);return false;"
+                                                        <a href="#"
+                                                            class="btn btn-sm btn-dark delegate-button"
+                                                            data-bs-toggle="tooltip"
+                                                            data-bs-placement="top"
+                                                            title="{% trans 'Delegate preparation' %}"
+                                                            data-evaluation-name="{{ evaluation.full_name }}"
+                                                            data-delegation-url="{% url 'contributor:evaluation_direct_delegation' evaluation.id %}"
                                                         >
                                                             <span class="fas fa-hand-point-left"></span>
                                                         </a>
@@ -241,6 +245,10 @@
                 // show modal
                 var {{ modal_id }} = new bootstrap.Modal(document.getElementById('{{ modal_id }}'));
                 {{ modal_id }}.show();
+            }
+
+            for (const button of document.querySelectorAll(".delegate-button")) {
+                button.addEventListener("click", () => delegateSelectionModalShow(button.dataset.evaluationName, button.dataset.delegationUrl));
             }
         </script>
     {% endwith %}

--- a/evap/contributor/templates/contributor_index.html
+++ b/evap/contributor/templates/contributor_index.html
@@ -46,11 +46,11 @@
                 <table class="table table-seamless-links table-vertically-aligned">
                     <thead>
                     <tr>
-                        <th style="width: 35%">{% trans 'Name' %}</th>
-                        <th style="width: 15%">{% trans 'State' %}</th>
-                        <th style="width: 17%">{% trans 'Evaluation period' %}</th>
-                        <th style="width: 15%">{% trans 'Participants' %}</th>
-                        <th style="width: 18%"></th>
+                        <th class="width-percent-35">{% trans 'Name' %}</th>
+                        <th class="width-percent-15">{% trans 'State' %}</th>
+                        <th class="width-percent-17">{% trans 'Evaluation period' %}</th>
+                        <th class="width-percent-15">{% trans 'Participants' %}</th>
+                        <th class="width-percent-18"></th>
                     </tr>
                     </thead>
                     <tbody>

--- a/evap/contributor/templates/contributor_index.html
+++ b/evap/contributor/templates/contributor_index.html
@@ -226,7 +226,7 @@
             </div>
         </div>
 
-        <script type="text/javascript">
+        <script type="text/javascript" nonce="{{ CSP_NONCE }}">
             function {{ modal_id }}Show(evaluationName, action) {
                 const modal = document.getElementById("{{ modal_id }}");
                 // set form's action location

--- a/evap/development/templates/development_components.html
+++ b/evap/development/templates/development_components.html
@@ -398,11 +398,11 @@
                                 {% spaceless %}
                                     <div class="distribution-bar-container">
                                         <div class="distribution-bar">
-                                            <div class="vote-bg-green" style="width: 52%;">&nbsp;</div>
-                                            <div class="vote-bg-lime" style="width: 26%;">&nbsp;</div>
-                                            <div class="vote-bg-yellow" style="width: 13%;">&nbsp;</div>
-                                            <div class="vote-bg-orange" style="width: 6%;">&nbsp;</div>
-                                            <div class="vote-bg-red" style="width: 3%;">&nbsp;</div>
+                                            <div class="vote-bg-green width-percent-52">&nbsp;</div>
+                                            <div class="vote-bg-lime width-percent-26">&nbsp;</div>
+                                            <div class="vote-bg-yellow width-percent-13">&nbsp;</div>
+                                            <div class="vote-bg-orange width-percent-6">&nbsp;</div>
+                                            <div class="vote-bg-red width-percent-3">&nbsp;</div>
                                         </div>
                                     </div>
                                 {% endspaceless %}
@@ -449,11 +449,11 @@
                                 {% spaceless %}
                                     <div class="distribution-bar-container">
                                         <div class="distribution-bar">
-                                            <div class="vote-bg-green" style="width: 52%;">&nbsp;</div>
-                                            <div class="vote-bg-lime" style="width: 26%;">&nbsp;</div>
-                                            <div class="vote-bg-yellow" style="width: 13%;">&nbsp;</div>
-                                            <div class="vote-bg-orange" style="width: 6%;">&nbsp;</div>
-                                            <div class="vote-bg-red" style="width: 3%;">&nbsp;</div>
+                                            <div class="vote-bg-green width-percent-52">&nbsp;</div>
+                                            <div class="vote-bg-lime width-percent-26">&nbsp;</div>
+                                            <div class="vote-bg-yellow width-percent-13">&nbsp;</div>
+                                            <div class="vote-bg-orange width-percent-6">&nbsp;</div>
+                                            <div class="vote-bg-red width-percent-3">&nbsp;</div>
                                         </div>
                                     </div>
                                 {% endspaceless %}

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -26,7 +26,7 @@
         {% endblock %}
     </head>
     <body>
-        <script type="text/javascript" src="{% static 'bootstrap/dist/js/bootstrap.bundle.min.js' %}"></script>
+        <script type="text/javascript" src="{% static 'bootstrap/dist/js/bootstrap.bundle.min.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
         {% block modals %}
             {% if user.is_authenticated %}
@@ -71,18 +71,18 @@
 
         {% include 'footer.html' %}
 
-        <script src="{% url 'javascript-catalog' %}"></script>
+        <script src="{% url 'javascript-catalog' %}" nonce="{{ CSP_NONCE }}"></script>
 
-        <script type="text/javascript" src="{% static 'js/jquery-2.1.3.min.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/tom-select.complete.min.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/plugins/jquery.formset.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/Sortable.min.js' %}"></script>
+        <script type="text/javascript" src="{% static 'js/jquery-2.1.3.min.js' %}" nonce="{{ CSP_NONCE }}"></script>
+        <script type="text/javascript" src="{% static 'js/tom-select.complete.min.js' %}" nonce="{{ CSP_NONCE }}"></script>
+        <script type="text/javascript" src="{% static 'js/plugins/jquery.formset.js' %}" nonce="{{ CSP_NONCE }}"></script>
+        <script type="text/javascript" src="{% static 'js/Sortable.min.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
-        <script type="module" src="{% static 'js/csrf-utils.js' %}"></script>
-        <script type="module" src="{% static 'js/utils.js' %}"></script>
+        <script type="module" src="{% static 'js/csrf-utils.js' %}" nonce="{{ CSP_NONCE }}"></script>
+        <script type="module" src="{% static 'js/utils.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
-        <script type="module" src="{% static 'js/base-template.js' %}"></script>
-        <script type="text/javascript">
+        <script type="module" src="{% static 'js/base-template.js' %}" nonce="{{ CSP_NONCE }}"></script>
+        <script type="text/javascript" nonce="{{ CSP_NONCE }}">
             activateTooltips = function(selector = "") {
                 var tooltipTriggerList = [].slice.call(document.querySelectorAll(selector + ' [data-bs-toggle="tooltip"]'))
                 var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
@@ -207,7 +207,7 @@
             };
 
         </script>
-        <script type="module">
+        <script type="module" nonce="{{ CSP_NONCE }}">
             import  { NotebookLogic } from "{% static 'js/notebook.js' %}"
 
             new NotebookLogic("#notebook").attach();

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -28,14 +28,6 @@
     <body>
         <script type="text/javascript" src="{% static 'bootstrap/dist/js/bootstrap.bundle.min.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
-        {% block modals %}
-            {% if user.is_authenticated %}
-                {% trans 'Feedback' as title %}
-                {% trans 'You are welcome to submit feedback regarding the evaluation platform or specific evaluations. Please let us know how we can improve your experience on EvaP.' as teaser %}
-                {% include 'contact_modal.html' with modal_id='feedbackModal' user=request.user title=title teaser=teaser %}
-            {% endif %}
-        {% endblock %}
-
         <div class="sticky-top d-print-none z-over-fixed">
             {% include_navbar user LANGUAGE_CODE %}
 
@@ -70,6 +62,14 @@
         </div>
 
         {% include 'footer.html' %}
+
+        {% block modals %}
+            {% if user.is_authenticated %}
+                {% trans 'Feedback' as title %}
+                {% trans 'You are welcome to submit feedback regarding the evaluation platform or specific evaluations. Please let us know how we can improve your experience on EvaP.' as teaser %}
+                {% include 'contact_modal.html' with modal_id='feedbackModal' user=request.user title=title teaser=teaser %}
+            {% endif %}
+        {% endblock %}
 
         <script src="{% url 'javascript-catalog' %}" nonce="{{ CSP_NONCE }}"></script>
 

--- a/evap/evaluation/templates/bootstrap_datetimepicker.html
+++ b/evap/evaluation/templates/bootstrap_datetimepicker.html
@@ -1,11 +1,11 @@
 {% load static %}
 {% get_current_language as LANGUAGE_CODE %}
 
-<script type="text/javascript" src="{% static 'js/moment.min.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/moment_de.js' %}"></script>
-<script type="text/javascript" src="{% static 'js/bootstrap-datetimepicker.min.js' %}"></script>
+<script type="text/javascript" src="{% static 'js/moment.min.js' %}" nonce="{{ CSP_NONCE }}"></script>
+<script type="text/javascript" src="{% static 'js/moment_de.js' %}" nonce="{{ CSP_NONCE }}"></script>
+<script type="text/javascript" src="{% static 'js/bootstrap-datetimepicker.min.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ CSP_NONCE }}">
     // run the bootstrap datepicker plugin
     $("input[name$='date']:not([readonly='True'])").datetimepicker({
         locale: "{{ LANGUAGE_CODE }}",

--- a/evap/evaluation/templates/confirmation_modal.html
+++ b/evap/evaluation/templates/confirmation_modal.html
@@ -20,7 +20,7 @@
     </div>
 </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ CSP_NONCE }}">
     function {{ modal_id }}Show(dataId, dataLabel) {
         // call the modal's action function when action button was pressed and give dataId as parameter
         $('#btn-action-{{ modal_id }}').unbind().click(function(){ {{ modal_id }}Action(dataId); });

--- a/evap/evaluation/templates/confirmation_text_modal.html
+++ b/evap/evaluation/templates/confirmation_text_modal.html
@@ -11,7 +11,7 @@
                 <div class="modal-body">
                     {{ question|safe }}
                     <div class="my-4">
-                        <input type="text" class="form-control" id="{{ modal_id }}ConfirmationText" oninput="{{ modal_id }}CheckValue();" />
+                        <input type="text" class="form-control check-value-input" id="{{ modal_id }}ConfirmationText"/>
                     </div>
                     <div class="modal-submit-group">
                         <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
@@ -41,4 +41,6 @@
             $('#{{ modal_id }}ActionButton').prop('disabled', true);
         }
     }
+
+    document.querySelectorAll(".check-value-input").forEach(input => input.addEventListener("input", {{modal_id}}CheckValue));
 </script>

--- a/evap/evaluation/templates/confirmation_text_modal.html
+++ b/evap/evaluation/templates/confirmation_text_modal.html
@@ -23,7 +23,7 @@
     </div>
 </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ CSP_NONCE }}">
     function {{ modal_id }}Show(dataId, dataLabel) {
         // call the modal's action function when action button was pressed and give dataId as parameter
         $('#{{ modal_id }} #{{ modal_id }}ActionButton').unbind().click(function(){ {{ modal_id }}Action(dataId); });

--- a/evap/evaluation/templates/contact_modal.html
+++ b/evap/evaluation/templates/contact_modal.html
@@ -48,7 +48,7 @@
         </div>
     </div>
 </div>
-<script type="module">
+<script type="module" nonce="{{ CSP_NONCE }}">
     import { ContactModalLogic } from "{% static 'js/contact_modal.js' %}";
 
     new ContactModalLogic("{{ modal_id }}", "{{ title|escapejs }}").attach();

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -18,10 +18,10 @@
         <thead>
             <tr>
                 <th></th>
-                <th style="width: 30%">{% trans 'Contributor' %}</th>
-                <th style="width: 30%">{% trans 'Questionnaires' %}</th>
-                <th style="width: 30%">{% trans 'Options' %}</th>
-                <th style="width: 10%"></th>
+                <th class="width-percent-30">{% trans 'Contributor' %}</th>
+                <th class="width-percent-30">{% trans 'Questionnaires' %}</th>
+                <th class="width-percent-30">{% trans 'Options' %}</th>
+                <th class="width-percent-10"></th>
             </tr>
         </thead>
         <tbody>

--- a/evap/evaluation/templates/evap_evaluation_edit_js.html
+++ b/evap/evaluation/templates/evap_evaluation_edit_js.html
@@ -1,8 +1,8 @@
 {% load static %}
 
 {% if editable %}
-    <script src="{% static 'js/sortable_form.js' %}"></script>
-    <script type="text/javascript">
+    <script src="{% static 'js/sortable_form.js' %}" nonce="{{ CSP_NONCE }}"></script>
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         rowChanged = function(row) {
             name = $(row.find("select[id$=-contributor]")).find(":selected").text();
             nameChanged = name && name != "---------";
@@ -30,7 +30,7 @@
     </script>
 {% endif %}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ CSP_NONCE }}">
     function makeDoesNotContributeChangeHandler(i) {
         return () => {
             const doesNotContributeInput = document.querySelector("input[name=contributions-" + i + "-does_not_contribute]");

--- a/evap/evaluation/templates/faq.html
+++ b/evap/evaluation/templates/faq.html
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         const anchor = window.location.hash.replace("#", "").split('-');
         const id = anchor[1];
         const type = anchor[2];

--- a/evap/evaluation/templates/footer.html
+++ b/evap/evaluation/templates/footer.html
@@ -1,10 +1,10 @@
 <div class="footer d-print-none">
     <div class="color-bar">
-        <div class="vote-bg-green" style="width: 52%;"></div>
-        <div class="vote-bg-lime" style="width: 26%;"></div>
-        <div class="vote-bg-yellow" style="width: 13%;"></div>
-        <div class="vote-bg-orange" style="width: 6%;"></div>
-        <div class="vote-bg-red" style="width: 3%;"></div>
+        <div class="vote-bg-green width-percent-52"></div>
+        <div class="vote-bg-lime width-percent-26"></div>
+        <div class="vote-bg-yellow width-percent-13"></div>
+        <div class="vote-bg-orange width-percent-6"></div>
+        <div class="vote-bg-red width-percent-3"></div>
     </div>
     <nav class="navbar navbar-expand">
         <div class="collapse navbar-collapse justify-content-between">

--- a/evap/evaluation/templates/infobox.html
+++ b/evap/evaluation/templates/infobox.html
@@ -10,7 +10,7 @@
         </div>
         <div class="callout-content small">
             {# Inline script to interrupt loading of the page, so the content does not jump up. #}
-            <script nonce="{{ request.csp_nonce }}">
+            <script nonce="{{ CSP_NONCE }}">
                 if (localStorage["infobox-{{ infotext.page }}"] === "hide")
                     document.querySelector("#infobox-{{ infotext.page }}").classList.add("closed");
             </script>
@@ -18,7 +18,7 @@
         </div>
     </div>
 
-    <script type="module" nonce="{{ request.csp_nonce }}">
+    <script type="module" nonce="{{ CSP_NONCE }}">
         import { InfoboxLogic } from "{% static 'js/infobox.js' %}";
 
         new InfoboxLogic("{{ infotext.page }}").attach();

--- a/evap/evaluation/templates/infobox.html
+++ b/evap/evaluation/templates/infobox.html
@@ -10,7 +10,7 @@
         </div>
         <div class="callout-content small">
             {# Inline script to interrupt loading of the page, so the content does not jump up. #}
-            <script>
+            <script nonce="{{ request.csp_nonce }}">
                 if (localStorage["infobox-{{ infotext.page }}"] === "hide")
                     document.querySelector("#infobox-{{ infotext.page }}").classList.add("closed");
             </script>
@@ -18,7 +18,7 @@
         </div>
     </div>
 
-    <script type="module">
+    <script type="module" nonce="{{ request.csp_nonce }}">
         import { InfoboxLogic } from "{% static 'js/infobox.js' %}";
 
         new InfoboxLogic("{{ infotext.page }}").attach();

--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -133,7 +133,7 @@
     </div>
 </nav>
 
-<script type="text/javascript" nonce="{{ request.csp_nonce }}">
+<script type="text/javascript" nonce="{{ CSP_NONCE }}">
     {% for language_code, language_name in languages %}
         document.getElementById("button-set-language-{{ language_code }}").addEventListener("click", () => { setSpinnerIcon('span-set-language-{{ language_code }}'); });
     {% endfor %}

--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -138,6 +138,8 @@
         document.getElementById("button-set-language-{{ language_code }}").addEventListener("click", () => { setSpinnerIcon('span-set-language-{{ language_code }}'); });
     {% endfor %}
 
-    document.getElementById("button-exit-staff-mode").addEventListener("click", () => { setSpinnerIcon('span-exit-staff-mode'); });
-    document.getElementById("button-enter-staff-mode").addEventListener("click", () => { setSpinnerIcon('span-enter-staff-mode'); });
+    {% if user.has_staff_permission %}
+        document.getElementById("button-exit-staff-mode").addEventListener("click", () => { setSpinnerIcon('span-exit-staff-mode'); });
+        document.getElementById("button-enter-staff-mode").addEventListener("click", () => { setSpinnerIcon('span-enter-staff-mode'); });
+    {% endif %}
 </script>

--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -91,7 +91,7 @@
                         <form class="d-flex" method="post" action="{% url 'evaluation:set_lang' %}">
                             {% csrf_token %}
                             <input name="language" type="hidden" value="{{ language_code }}">
-                            <button data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ language_name }}" type="submit" onclick="setSpinnerIcon('span-set-language-{{ language_code }}')"
+                            <button data-bs-toggle="tooltip" data-bs-placement="bottom" id="button-set-language-{{ language_code }}" title="{{ language_name }}" type="submit"
                                 class="btn btn-sm{% if current_language == language_code %} active{% endif %}">
                                 <span id="span-set-language-{{ language_code }}">{{ language_code|upper }}</span>
                             </button>
@@ -105,13 +105,13 @@
                         <div class="btn-group">
                             <form class="d-flex" method="post" action="{% url 'staff:exit_staff_mode' %}">
                                 {% csrf_token %}
-                                <button data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Regular mode' %}" type="submit" class="btn btn-sm {% if user.is_staff == False %}active{% endif %}" onclick="setSpinnerIcon('span-exit-staff-mode')">
+                                <button data-bs-toggle="tooltip" data-bs-placement="bottom" id="button-exit-staff-mode" title="{% trans 'Regular mode' %}" type="submit" class="btn btn-sm{% if user.is_staff == False %} active{% endif %}">
                                     <span id="span-exit-staff-mode" class="fas fa-user"></span>
                                 </button>
                             </form>
                             <form id="enter-staff-mode-form" class="d-flex" method="post" action="{% url 'staff:enter_staff_mode' %}">
                                 {% csrf_token %}
-                                <button data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Staff mode' %}" type="submit" class="btn btn-sm {% if user.is_staff %}active{% endif %}" onclick="setSpinnerIcon('span-enter-staff-mode')">
+                                <button data-bs-toggle="tooltip" data-bs-placement="bottom" id="button-enter-staff-mode" title="{% trans 'Staff mode' %}" type="submit" class="btn btn-sm{% if user.is_staff %} active{% endif %}">
                                     <span id="span-enter-staff-mode" class="fas fa-briefcase"></span>
                                 </button>
                             </form>
@@ -132,3 +132,12 @@
         </ul>
     </div>
 </nav>
+
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
+    {% for language_code, language_name in languages %}
+        document.getElementById("button-set-language-{{ language_code }}").addEventListener("click", () => { setSpinnerIcon('span-set-language-{{ language_code }}'); });
+    {% endfor %}
+
+    document.getElementById("button-exit-staff-mode").addEventListener("click", () => { setSpinnerIcon('span-exit-staff-mode'); });
+    document.getElementById("button-enter-staff-mode").addEventListener("click", () => { setSpinnerIcon('span-enter-staff-mode'); });
+</script>

--- a/evap/evaluation/templates/progress_bar.html
+++ b/evap/evaluation/templates/progress_bar.html
@@ -3,7 +3,7 @@
 <span class="progress-container{% if warning %} progress-container-warning{% endif %} d-flex">
     {% spaceless %}
         <span class="progress">
-            <span class="progress-bar" style="width: {% widthratio done total 100 %}%;"></span>
+            <span class="progress-bar width-percent-{% widthratio done total 100 %}"></span>
             <span class="progress-bartext">
                 {% if icon %}
                     <small><span class="fas fa-{{ icon }}"></span></small>&nbsp;

--- a/evap/evaluation/templates/startpage_button.html
+++ b/evap/evaluation/templates/startpage_button.html
@@ -6,8 +6,11 @@
     <form id="startpage-form" class="d-flex" method="post" action="{% url 'evaluation:set_startpage' %}">
         {% csrf_token %}
         <input name="page" type="hidden" value="{{ page }}">
-        <button type="submit" class="btn {{ btnClass }} btn-light" onclick="setSpinnerIcon('span-set-startpage')" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Make this my startpage' %}">
+        <button type="submit" class="btn {{ btnClass }} btn-light" id="set-startpage-button" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Make this my startpage' %}">
             <span id="span-set-startpage" class="fas fa-house"></span>
         </button>
     </form>
+    <script type="script/javascript" nonce="{{ CSP_NONCE }}">
+        document.getElementById("set-startpage-button").addEventListener("click", () => setSpinnerIcon("span-set-startpage"));
+    </script>
 {% endif %}

--- a/evap/evaluation/templatetags/infotext_templatetags.py
+++ b/evap/evaluation/templatetags/infotext_templatetags.py
@@ -13,7 +13,4 @@ def show_infotext(context, page_name):
         "student_index": Infotext.Page.STUDENT_INDEX,
     }
 
-    return {
-        "CSP_NONCE": context["request"].csp_nonce,
-        "infotext": Infotext.objects.get(page=to_page_id[page_name])
-    }
+    return {"CSP_NONCE": context["request"].csp_nonce, "infotext": Infotext.objects.get(page=to_page_id[page_name])}

--- a/evap/evaluation/templatetags/infotext_templatetags.py
+++ b/evap/evaluation/templatetags/infotext_templatetags.py
@@ -13,9 +13,7 @@ def show_infotext(context, page_name):
         "student_index": Infotext.Page.STUDENT_INDEX,
     }
 
-    print(context["request"].csp_nonce)
-
     return {
-        "request": context["request"],
+        "CSP_NONCE": context["request"].csp_nonce,
         "infotext": Infotext.objects.get(page=to_page_id[page_name])
     }

--- a/evap/evaluation/templatetags/infotext_templatetags.py
+++ b/evap/evaluation/templatetags/infotext_templatetags.py
@@ -5,12 +5,17 @@ from evap.evaluation.models import Infotext
 register = Library()
 
 
-@register.inclusion_tag("infobox.html")
-def show_infotext(page_name):
+@register.inclusion_tag("infobox.html", takes_context=True)
+def show_infotext(context, page_name):
     to_page_id = {
         "contributor_index": Infotext.Page.CONTRIBUTOR_INDEX,
         "grades_pages": Infotext.Page.GRADES_PAGES,
         "student_index": Infotext.Page.STUDENT_INDEX,
     }
 
-    return {"infotext": Infotext.objects.get(page=to_page_id[page_name])}
+    print(context["request"].csp_nonce)
+
+    return {
+        "request": context["request"],
+        "infotext": Infotext.objects.get(page=to_page_id[page_name])
+    }

--- a/evap/evaluation/templatetags/navbar_templatetags.py
+++ b/evap/evaluation/templatetags/navbar_templatetags.py
@@ -25,7 +25,7 @@ def include_navbar(context, user, language):
     ]
 
     return {
-        "request": context["request"],
+        "CSP_NONCE": context["request"].csp_nonce,
         "user": user,
         "current_language": language,
         "languages": LANGUAGES,

--- a/evap/evaluation/templatetags/navbar_templatetags.py
+++ b/evap/evaluation/templatetags/navbar_templatetags.py
@@ -7,8 +7,8 @@ from evap.settings import DEBUG, LANGUAGES
 register = Library()
 
 
-@register.inclusion_tag("navbar.html")
-def include_navbar(user, language):
+@register.inclusion_tag("navbar.html", takes_context=True)
+def include_navbar(context, user, language):
     semesters_with_unarchived_results_or_grade_documents = Semester.objects.filter(
         Q(results_are_archived=False) | Q(grade_documents_are_deleted=False)
     )
@@ -25,6 +25,7 @@ def include_navbar(user, language):
     ]
 
     return {
+        "request": context["request"],
         "user": user,
         "current_language": language,
         "languages": LANGUAGES,

--- a/evap/grades/templates/grades_course_view.html
+++ b/evap/grades/templates/grades_course_view.html
@@ -14,10 +14,10 @@
                 <table class="table table-striped table-vertically-aligned">
                     <thead>
                         <tr>
-                            <th style="width: 40%">{% trans 'Description' %}</th>
-                            <th style="width: 20%">{% trans 'Type' %}</th>
-                            <th style="width: 25%">{% trans 'Last edited' %}</th>
-                            <th style="width: 15%">{% trans 'Actions' %}</th>
+                            <th class="width-percent-40">{% trans 'Description' %}</th>
+                            <th class="width-percent-20">{% trans 'Type' %}</th>
+                            <th class="width-percent-25">{% trans 'Last edited' %}</th>
+                            <th class="width-percent-15">{% trans 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/evap/grades/templates/grades_course_view.html
+++ b/evap/grades/templates/grades_course_view.html
@@ -30,7 +30,7 @@
                                     <a href="{% url 'grades:download_grades' grade_document.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Download' %}"><span class="fas fa-download"></span></a>
                                     {% if user.is_grade_publisher %}
                                         <a href="{% url 'grades:edit_grades' grade_document.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Edit' %}"><span class="fas fa-pencil"></span></a>
-                                        <button type="button" onclick="deleteGradedocumentModalShow({{ grade_document.id }}, '{{ grade_document.description|escapejs }}');" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
+                                        <button type="button" class="btn btn-sm btn-danger delete-grade-document-button" data-grade-document-id="{{ grade_document.id }}" data-grade-document-description="{{ grade_document.description }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
                                             <span class="fas fa-trash"></span>
                                         </button>
                                     {% endif %}
@@ -67,5 +67,8 @@
                 fadeOutThenRemove(document.getElementById('grade_document-row-'+dataId));
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
         };
+        for (const button of document.querySelectorAll("delete-grade-document-button")) {
+            button.addEventListener("click", () => deleteGradedocumentModalShow(button.dataset.gradeDocumentId, button.dataset.gradeDocumentDescription));
+        }
     </script>
 {% endblock %}

--- a/evap/grades/templates/grades_course_view.html
+++ b/evap/grades/templates/grades_course_view.html
@@ -56,7 +56,7 @@
     {% trans 'Do you really want to delete the grade document <strong data-label=""></strong>?' as question %}
     {% trans 'Delete grade document' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='deleteGradedocumentModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function deleteGradedocumentModalAction(dataId) {
             fetch("{% url 'grades:delete_grades' %}", {
                 body: new URLSearchParams({grade_document_id: dataId}),

--- a/evap/grades/templates/grades_semester_view.html
+++ b/evap/grades/templates/grades_semester_view.html
@@ -35,12 +35,12 @@
                 <table class="table table-striped grade-course-table table-vertically-aligned">
                     <thead>
                         <tr>
-                            <th style="width: 35%" class="col-order" data-col="name">{% trans 'Name' %}</th>
-                            <th style="width: 20%" class="col-order" data-col="responsible">{% trans 'Responsible' %}</th>
-                            <th style="width: 10%" class="col-order" data-col="complete">{% trans 'Evaluation completed' %}</th>
-                            <th style="width: 10%" class="col-order" data-col="midterm-grades">{% trans 'Midterm grade documents' %}</th>
-                            <th style="width: 10%" class="col-order" data-col="final-grades">{% trans 'Final grade documents' %}</th>
-                            <th style="width: 15%" class="text-end">{% trans 'Actions' %}</th>
+                            <th class="width-percent-35 col-order" data-col="name">{% trans 'Name' %}</th>
+                            <th class="width-percent-20 col-order" data-col="responsible">{% trans 'Responsible' %}</th>
+                            <th class="width-percent-10 col-order" data-col="complete">{% trans 'Evaluation completed' %}</th>
+                            <th class="width-percent-10 col-order" data-col="midterm-grades">{% trans 'Midterm grade documents' %}</th>
+                            <th class="width-percent-10 col-order" data-col="final-grades">{% trans 'Final grade documents' %}</th>
+                            <th class="width-percent-15 text-end">{% trans 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/evap/grades/templates/grades_semester_view.html
+++ b/evap/grades/templates/grades_semester_view.html
@@ -64,7 +64,7 @@
                                     {% if num_final_grades > 0 %}
                                         <span class="fas fa-file"></span> {{ num_final_grades }}
                                     {% elif course.gets_no_grade_documents %}
-                                       <a href="#" onclick="confirmLateruploadModalShow({{ course.id }}, '{{ course.name|escapejs }}');">
+                                        <a href="#" class="confirm-later-upload-button" data-course-id="{{ course.id }}" data-course-name="{{ course.name }}">
                                             <span class="fas fa-xmark light-link" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Grade documents for this course will not be uploaded. Click to change.' %}"></span>
                                         </a>
                                     {% endif %}
@@ -72,7 +72,7 @@
                                 <td class="text-end" style="min-width:72px">
                                     {% if not course.gets_no_grade_documents %}
                                         {% if num_final_grades == 0 %}
-                                            <button type="button" onclick="confirmNouploadModalShow({{ course.id }}, '{{ course.name|escapejs }}');" class="btn btn-sm btn-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Confirm that final grades have been submitted but will not be uploaded.' %}">
+                                            <button type="button" class="btn btn-sm btn-secondary confirm-noupload-button" data-bs-toggle="tooltip" data-bs-placement="top" data-course-id="{{ course.id }}" data-course-name="{{ course.name }}" title="{% trans 'Confirm that final grades have been submitted but will not be uploaded.' %}">
                                                 <span class="fas fa-xmark"></span>
                                             </button>
                                             <div class="btn-group" role="group" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Upload grade document' %}">
@@ -110,6 +110,9 @@
         function confirmNouploadModalAction(dataId) {
             updateGradeStatusOfCourse(dataId, true);
         }
+        for(const button of document.querySelectorAll(".confirm-noupload-button")) {
+            button.addEventListener("click", () => confirmNouploadModalShow(button.dataset.courseId, button.dataset.courseName));
+        }
 
         function updateGradeStatusOfCourse(dataId, status) {
             fetch("{% url 'grades:set_no_grades'%}", {
@@ -129,7 +132,10 @@
     <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function confirmLateruploadModalAction(dataId) {
             updateGradeStatusOfCourse(dataId, false);
-        };
+        }
+        for (const button of document.querySelectorAll(".confirm-later-upload-button")) {
+            button.addEventListener("click", () => confirmLateruploadModalShow(button.dataset.courseId, button.dataset.courseName));
+        }
     </script>
 {% endblock %}
 

--- a/evap/grades/templates/grades_semester_view.html
+++ b/evap/grades/templates/grades_semester_view.html
@@ -106,7 +106,7 @@
     {% trans 'Please confirm that the final grades for the course <strong data-label=""></strong> have been submitted but will not be uploaded.' as question %}
     {% trans 'Confirm' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='confirmNouploadModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function confirmNouploadModalAction(dataId) {
             updateGradeStatusOfCourse(dataId, true);
         }
@@ -126,7 +126,7 @@
     {% trans 'Please confirm that a grade document for the course <strong data-label=""></strong> will be uploaded later on.' as question %}
     {% trans 'Confirm' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='confirmLateruploadModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function confirmLateruploadModalAction(dataId) {
             updateGradeStatusOfCourse(dataId, false);
         };
@@ -134,7 +134,7 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="module">
+    <script type="module" nonce="{{ CSP_NONCE }}">
         import {TableGrid} from "{% static 'js/datagrid.js' %}";
         const table = document.querySelector(".grade-course-table");
         if (table) {

--- a/evap/results/templates/results_index.html
+++ b/evap/results/templates/results_index.html
@@ -127,7 +127,7 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="module">
+    <script type="module" nonce="{{ CSP_NONCE }}">
         import {ResultGrid} from "{% static 'js/datagrid.js' %}";
 
         new ResultGrid({

--- a/evap/rewards/templates/rewards_index.html
+++ b/evap/rewards/templates/rewards_index.html
@@ -26,10 +26,10 @@
                         <table class="table table-striped table-vertically-aligned mb-3">
                             <thead>
                                 <tr>
-                                    <th style="width: 20%">{% trans 'Date' %}</th>
-                                    <th style="width: 40%">{% trans 'Event' %}</th>
-                                    <th style="width: 20%">{% trans 'Available until' %}</th>
-                                    <th style="width: 20%">{% trans 'Redeem points' %}</th>
+                                    <th class="width-percent-20">{% trans 'Date' %}</th>
+                                    <th class="width-percent-40">{% trans 'Event' %}</th>
+                                    <th class="width-percent-20">{% trans 'Available until' %}</th>
+                                    <th class="width-percent-20">{% trans 'Redeem points' %}</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -67,10 +67,10 @@
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <th style="width: 20%">{% trans 'Date' %}</th>
-                            <th style="width: 40%">{% trans 'Action' %}</th>
-                            <th style="width: 20%" class="text-end">{% trans 'Granted points' %}</th>
-                            <th style="width: 20%" class="text-end">{% trans 'Redeemed points' %}</th>
+                            <th class="width-percent-20">{% trans 'Date' %}</th>
+                            <th class="width-percent-40">{% trans 'Action' %}</th>
+                            <th class="width-percent-20 text-end">{% trans 'Granted points' %}</th>
+                            <th class="width-percent-20 text-end">{% trans 'Redeemed points' %}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
@@ -24,7 +24,7 @@
                             <a href="{% url 'rewards:reward_point_redemption_event_export' event.id %}" class="btn btn-sm btn-primary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Export Redemptions' %}"><span class="fas fa-download"></span></a>
                             <a href="{% url 'rewards:reward_point_redemption_event_edit' event.id %}" class="btn btn-sm btn-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Edit' %}"><span class="fas fa-pencil"></span></a>
                             {% if event.can_delete %}
-                                <button type="button" onclick="deleteEventModalShow({{ event.id }}, '{{ event.name|escapejs }}');" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
+                                <button type="button" class="btn btn-sm btn-danger delete-event-button" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}" data-event-id="{{ event.id }}" data-event-name="{{ event.name }}">
                                     <span class="fas fa-trash"></span>
                                 </button>
                             {% else %}

--- a/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
@@ -6,11 +6,11 @@
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th style="width: 20%">{% trans 'Event date' %}</th>
-                    <th style="width: 20%">{% trans 'Redemption end date' %}</th>
-                    <th style="width: 30%">{% trans 'Event name' %}</th>
-                    <th style="width: 15%">{% trans 'Redemptions' %}</th>
-                    <th class="text-end" style="width: 15%">{% trans 'Actions' %}</th>
+                    <th class="width-percent-20">{% trans 'Event date' %}</th>
+                    <th class="width-percent-20">{% trans 'Redemption end date' %}</th>
+                    <th class="width-percent-30">{% trans 'Event name' %}</th>
+                    <th class="width-percent-15">{% trans 'Redemptions' %}</th>
+                    <th class="width-percent-15 text-end">{% trans 'Actions' %}</th>
                 </tr>
             </thead>
             <tbody>

--- a/evap/rewards/templates/rewards_reward_point_redemption_events.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_events.html
@@ -33,8 +33,7 @@
     {% trans 'Do you really want to delete the event <strong data-label=""></strong>?' as question %}
     {% trans 'Delete event' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='deleteEventModal' title=title question=question action_text=action_text btn_type='danger' %}
-
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function deleteEventModalAction(dataId) {
             fetch("{% url 'rewards:reward_point_redemption_event_delete' %}", {
                 body: new URLSearchParams({event_id: dataId}),

--- a/evap/rewards/templates/rewards_reward_point_redemption_events.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_events.html
@@ -44,5 +44,8 @@
                 fadeOutThenRemove(document.querySelector('#event-row-'+dataId));
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
         };
+        for(const button of document.querySelectorAll(".delete-event-button")) {
+            button.addEventListener("click", () => deleteEventModalShow(button.dataset.eventId, button.dataset.eventName));
+        }
     </script>
 {% endblock %}

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -405,9 +405,10 @@ OIDC_OP_JWKS_ENDPOINT = "https://example.com/certs"
 
 
 ### Content Security Policy
-# settings from https://csp.withgoogle.com/docs/strict-csp.html#example
 CSP_OBJECT_SRC = ("'none'", )
-CSP_SCRIPT_SRC = ("'unsafe-inline'", "'strict-dynamic'", "https:", "http:")
+CSP_SCRIPT_SRC = ("'strict-dynamic'", )  # scripts require a correct nonce or to be loaded by a trusted script
+CSP_STYLE_SRC = ("'unsafe-inline'", "'self'") # inline-styles are allowed
+CSP_IMG_SRC = ("'self'", "data:") # images from same host or as data: url are allowed
 CSP_BASE_URI = ("'none'", )
 CSP_INCLUDE_NONCE_IN=['script-src']
 

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -237,6 +237,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "csp.middleware.CSPMiddleware",
     "mozilla_django_oidc.middleware.SessionRefresh",
     "evap.middleware.RequireLoginMiddleware",
     "evap.middleware.user_language_middleware",
@@ -252,6 +253,7 @@ _TEMPLATE_OPTIONS = {
         "django.template.context_processors.static",
         "django.template.context_processors.request",
         "django.contrib.messages.context_processors.messages",
+        "csp.context_processors.nonce",
         "evap.context_processors.slogan",
         "evap.context_processors.debug",
         "evap.context_processors.notebook_form",
@@ -401,6 +403,13 @@ OIDC_OP_TOKEN_ENDPOINT = "https://example.com/token"  # nosec
 OIDC_OP_USER_ENDPOINT = "https://example.com/me"
 OIDC_OP_JWKS_ENDPOINT = "https://example.com/certs"
 
+
+### Content Security Policy
+# settings from https://csp.withgoogle.com/docs/strict-csp.html#example
+CSP_OBJECT_SRC = ("'none'", )
+CSP_SCRIPT_SRC = ("'unsafe-inline'", "'strict-dynamic'", "https:", "http:")
+CSP_BASE_URI = ("'none'", )
+CSP_INCLUDE_NONCE_IN=['script-src']
 
 ### Other
 

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -405,12 +405,12 @@ OIDC_OP_JWKS_ENDPOINT = "https://example.com/certs"
 
 
 ### Content Security Policy
-CSP_OBJECT_SRC = ("'none'", )
-CSP_SCRIPT_SRC = ("'strict-dynamic'", )  # scripts require a correct nonce or to be loaded by a trusted script
-CSP_STYLE_SRC = ("'unsafe-inline'", "'self'") # inline-styles are allowed
-CSP_IMG_SRC = ("'self'", "data:") # images from same host or as data: url are allowed
-CSP_BASE_URI = ("'none'", )
-CSP_INCLUDE_NONCE_IN=['script-src']
+CSP_OBJECT_SRC = ("'none'",)
+CSP_SCRIPT_SRC = ("'strict-dynamic'",)  # scripts require a correct nonce or to be loaded by a trusted script
+CSP_STYLE_SRC = ("'unsafe-inline'", "'self'")  # inline-styles are allowed
+CSP_IMG_SRC = ("'self'", "data:")  # images from same host or as data: url are allowed
+CSP_BASE_URI = ("'none'",)
+CSP_INCLUDE_NONCE_IN = ["script-src"]
 
 ### Other
 

--- a/evap/staff/templates/staff_course_type_index.html
+++ b/evap/staff/templates/staff_course_type_index.html
@@ -24,10 +24,10 @@
                     <thead>
                         <tr>
                             <th class="movable"></th>
-                            <th style="width: 30%">{% trans 'Name (German)' %}</th>
-                            <th style="width: 30%">{% trans 'Name (English)' %}</th>
-                            <th style="width: 30%">{% trans 'Import names' %}</th>
-                            <th class="text-end" style="width: 10%">{% trans 'Actions' %}</th>
+                            <th class="width-percent-30">{% trans 'Name (German)' %}</th>
+                            <th class="width-percent-30">{% trans 'Name (English)' %}</th>
+                            <th class="width-percent-30">{% trans 'Import names' %}</th>
+                            <th class="width-percent-10 text-end">{% trans 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/evap/staff/templates/staff_course_type_index.html
+++ b/evap/staff/templates/staff_course_type_index.html
@@ -73,9 +73,9 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script src="{% static 'js/sortable_form.js' %}"></script>
+    <script src="{% static 'js/sortable_form.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         rowChanged = function(row) {
             nameDe = $(row.find('input[id$=-name_de]')).val();
             nameEn = $(row.find('input[id$=-name_en]')).val();

--- a/evap/staff/templates/staff_degree_index.html
+++ b/evap/staff/templates/staff_degree_index.html
@@ -69,9 +69,9 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script src="{% static 'js/sortable_form.js' %}"></script>
+    <script src="{% static 'js/sortable_form.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         rowChanged = function(row) {
             nameDe = $(row.find('input[id$=-name_de]')).val();
             nameEn = $(row.find('input[id$=-name_en]')).val();

--- a/evap/staff/templates/staff_degree_index.html
+++ b/evap/staff/templates/staff_degree_index.html
@@ -20,10 +20,10 @@
                     <thead>
                         <tr>
                             <th class="movable"></th>
-                            <th style="width: 25%">{% trans 'Name (German)' %}</th>
-                            <th style="width: 25%">{% trans 'Name (English)' %}</th>
-                            <th style="width: 40%">{% trans 'Import names' %}</th>
-                            <th class="text-end" style="width: 10%">{% trans 'Actions' %}</th>
+                            <th class="width-percent-25">{% trans 'Name (German)' %}</th>
+                            <th class="width-percent-25">{% trans 'Name (English)' %}</th>
+                            <th class="width-percent-40">{% trans 'Import names' %}</th>
+                            <th class="width-percent-10 text-end">{% trans 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/evap/staff/templates/staff_email_preview_form.html
+++ b/evap/staff/templates/staff_email_preview_form.html
@@ -2,8 +2,7 @@
     <div class="card-body">
          {% if heading %}<h4 class="card-title">{{ heading }}</h4>{% endif %}
         <div class="form-check mb-2">
-            <input class="form-check-input" id="send_email{{ id_suffix }}" type="checkbox" name="send_email{{ id_suffix }}"
-                checked onclick="document.getElementById('email_form').classList.toggle('d-none');" />
+            <input class="form-check-input" id="send_email{{ id_suffix }}" type="checkbox" name="send_email{{ id_suffix }}" checked/>
             <label class="form-check-label" for="send_email{{ id_suffix }}">{% trans 'Send email notifications' %}</label>
         </div>
         <div class="email-form" id="email_form{{ id_suffix}}">
@@ -34,3 +33,6 @@
         </div>
     </div>
 </div>
+<script type="text/javascript" nonce="{{ CSP_NONCE }}">
+    document.getElementById("send_email{{ id_suffix }}").addEventListener("click", () => document.getElementById("email_form").classList.toggle("d-none"));
+</script>

--- a/evap/staff/templates/staff_evaluation_person_management.html
+++ b/evap/staff/templates/staff_evaluation_person_management.html
@@ -17,7 +17,7 @@
                         <h6 class="card-subtitle mb-2 text-muted">{% trans 'From Excel file' %}</h6>
                         <p class="card-text">
                             {% trans 'Upload Excel file with participant data' %} (<a href="{% url 'staff:download_sample_file' 'sample_user.xlsx' %}">{% trans 'Download sample file' %}</a>,
-                            <button type="button" class="btn btn-link" onclick="copyHeaders(['Title', 'First name', 'Last name', 'Email'])">{% trans 'Copy headers to clipboard' %}</button>).
+                            <button type="button" class="btn btn-link copy-user-headers-button">{% trans 'Copy headers to clipboard' %}</button>).
                             {% trans 'This will create all containing users.' %}
                         </p>
                         {% include 'bootstrap_form.html' with form=participant_excel_form wide=True %}
@@ -66,7 +66,7 @@
                         <p class="card-text">
                             {% trans 'Upload Excel file with contributor data' %}
                             (<a href="{% url 'staff:download_sample_file' 'sample_user.xlsx' %}">{% trans 'Download sample file' %}</a>,
-                            <button type="button" class="btn btn-link" onclick="copyHeaders(['Title', 'First name', 'Last name', 'Email'])">{% trans 'Copy headers to clipboard' %}</button>).
+                            <button type="button" class="btn btn-link copy-user-headers-button">{% trans 'Copy headers to clipboard' %}</button>).
                             {% trans 'This will create all containing users.' %}
                         </p>
                         {% include 'bootstrap_form.html' with form=contributor_excel_form wide=True %}
@@ -277,4 +277,10 @@
 
 {% block additional_javascript %}
     <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}" nonce="{{ CSP_NONCE }}"></script>
+
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
+        for(const button of document.querySelectorAll(".copy-user-headers-button")) {
+            button.addEventListener("click", () => copyHeaders(['Title', 'First name', 'Last name', 'Email']));
+        }
+    </script>
 {% endblock %}

--- a/evap/staff/templates/staff_evaluation_person_management.html
+++ b/evap/staff/templates/staff_evaluation_person_management.html
@@ -134,7 +134,7 @@
     {% blocktrans asvar question %}Do you really want to import the Excel file with participant data?{% endblocktrans %}
     {% trans 'Import participants' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='importParticipantsModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function importParticipantsModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -151,7 +151,7 @@
     {% blocktrans asvar question %}Do you really want to delete all existing participants and replace them with participant data from the Excel file?{% endblocktrans %}
     {% trans 'Replace participants' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='replaceParticipantsModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function replaceParticipantsModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -168,7 +168,7 @@
     {% blocktrans asvar question %}Do you really want to copy the participants?{% endblocktrans %}
     {% trans 'Copy participants' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='copyParticipantsModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function copyParticipantsModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -185,7 +185,7 @@
     {% blocktrans asvar question %}Do you really want to delete all existing participants and copy the participants into the evaluation?{% endblocktrans %}
     {% trans 'Replace participants' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='copyReplaceParticipantsModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function copyReplaceParticipantsModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -202,7 +202,7 @@
     {% blocktrans asvar question %}Do you really want to import the Excel file with contributor data?{% endblocktrans %}
     {% trans 'Import contributors' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='importContributorsModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function importContributorsModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -219,7 +219,7 @@
     {% blocktrans asvar question %}Do you really want to delete all existing contributors and replace them with contributor data from the Excel file?{% endblocktrans %}
     {% trans 'Replace contributors' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='replaceContributorsModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function replaceContributorsModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -236,7 +236,7 @@
     {% blocktrans asvar question %}Do you really want to copy the contributors?{% endblocktrans %}
     {% trans 'Copy contributors' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='copyContributorsModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function copyContributorsModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -253,7 +253,7 @@
     {% blocktrans asvar question %}Do you really want to delete all existing contributors and copy the contributors into the evaluation?{% endblocktrans %}
     {% trans 'Replace contributors' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='copyReplaceContributorsModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function copyReplaceContributorsModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -269,5 +269,5 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}" nonce="{{ CSP_NONCE }}"></script>
 {% endblock %}

--- a/evap/staff/templates/staff_evaluation_person_management.html
+++ b/evap/staff/templates/staff_evaluation_person_management.html
@@ -28,8 +28,8 @@
                         {% else %}
                             <button name="operation" value="test-participants" type="submit" class="btn btn-sm btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
                             <div class="mt-2">
-                                <button name="operation" value="import-participants" type="button" onclick="importParticipantsModalShow('import-participants');" class="btn btn-sm btn-primary me-1 form-submit-btn";>{% trans 'Import previously uploaded file' %}</button>
-                                <button name="operation" value="import-replace-participants" type="button" onclick="replaceParticipantsModalShow('import-replace-participants');" class="btn btn-sm btn-danger form-submit-btn">{% trans 'Replace participants' %}</button>
+                                <button name="operation" value="import-participants" type="button" id="import-participants-button" class="btn btn-sm btn-primary me-1 form-submit-btn";>{% trans 'Import previously uploaded file' %}</button>
+                                <button name="operation" value="import-replace-participants" type="button" id="import-replace-participants-button" class="btn btn-sm btn-danger form-submit-btn">{% trans 'Replace participants' %}</button>
                             </div>
                         {% endif %}
                     </div>
@@ -47,8 +47,8 @@
                         {% include 'bootstrap_form.html' with form=participant_copy_form wide=True %}
                     </div>
                     <div class="card-footer text-center">
-                        <button name="operation" value="copy-participants" type="button" onclick="copyParticipantsModalShow('copy-participants');" class="btn btn-sm btn-primary form-submit-btn">{% trans 'Copy participants' %}</button>
-                        <button name="operation" value="copy-replace-participants" type="button" onclick="copyReplaceParticipantsModalShow('copy-replace-participants');" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% trans 'Replace participants' %}</button>
+                        <button name="operation" value="copy-participants" type="button" id="copy-participants-button" class="btn btn-sm btn-primary form-submit-btn">{% trans 'Copy participants' %}</button>
+                        <button name="operation" value="copy-replace-participants" type="button" id="copy-replace-participants-button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% trans 'Replace participants' %}</button>
                     </div>
                 </div>
             </form>
@@ -77,8 +77,8 @@
                         {% else %}
                             <button name="operation" value="test-contributors" type="submit" class="btn btn-sm btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
                             <div class="mt-2">
-                                <button name="operation" value="import-contributors" type="button" onclick="importContributorsModalShow('import-contributors');" class="btn btn-sm btn-primary form-submit-btn">{% trans 'Import previously uploaded file' %}</button>
-                                <button name="operation" value="import-replace-contributors" type="button" onclick="replaceContributorsModalShow('import-replace-contributors');" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% trans 'Replace contributors' %}</button>
+                                <button name="operation" value="import-contributors" type="button" id="import-contributors-button" class="btn btn-sm btn-primary form-submit-btn">{% trans 'Import previously uploaded file' %}</button>
+                                <button name="operation" value="import-replace-contributors" type="button" id="import-replace-contributors-button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% trans 'Replace contributors' %}</button>
                             </div>
                         {% endif %}
                     </div>
@@ -96,8 +96,8 @@
                         {% include 'bootstrap_form.html' with form=contributor_copy_form wide=True %}
                     </div>
                     <div class="card-footer text-center">
-                        <button name="operation" value="copy-contributors" type="button" onclick="copyContributorsModalShow('copy-contributors');" class="btn btn-sm btn-primary form-submit-btn">{% trans 'Copy contributors' %}</button>
-                        <button name="operation" value="copy-replace-contributors" type="button" onclick="copyReplaceContributorsModalShow('copy-replace-contributors');" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% trans 'Replace contributors' %}</button>
+                        <button name="operation" value="copy-contributors" type="button" id="copy-contributors-button" class="btn btn-sm btn-primary form-submit-btn">{% trans 'Copy contributors' %}</button>
+                        <button name="operation" value="copy-replace-contributors" type="button" id="copy-replace-contributors-button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% trans 'Replace contributors' %}</button>
                     </div>
                 </div>
             </form>
@@ -129,7 +129,7 @@
 {% endblock %}
 
 {% block modals %}
-{{ block.super }}
+    {{ block.super }}
     {% trans 'Import participants' as title %}
     {% blocktrans asvar question %}Do you really want to import the Excel file with participant data?{% endblocktrans %}
     {% trans 'Import participants' as action_text %}
@@ -144,7 +144,8 @@
             const form = document.getElementById("participant-import-form");
             form.appendChild(input);
             form.requestSubmit();
-        };
+        }
+        document.getElementById("import-participants-button").addEventListener("click", () => importParticipantsModalShow('import-participants'));
     </script>
 
     {% trans 'Replace participants' as title %}
@@ -161,7 +162,8 @@
             const form = document.getElementById("participant-import-form");
             form.appendChild(input);
             form.requestSubmit();
-        };
+        }
+        document.getElementById("import-replace-participants-button").addEventListener("click", () => replaceParticipantsModalShow('import-replace-participants'));
     </script>
 
     {% trans 'Copy participants' as title %}
@@ -178,7 +180,8 @@
             const form = document.getElementById("participant-copy-form");
             form.appendChild(input);
             form.requestSubmit();
-        };
+        }
+        document.getElementById("copy-participants-button").addEventListener("click", () => copyParticipantsModalShow('copy-participants'));
     </script>
 
     {% trans 'Replace participants' as title %}
@@ -195,7 +198,8 @@
             const form = document.getElementById("participant-copy-form");
             form.appendChild(input);
             form.requestSubmit();
-        };
+        }
+        document.getElementById("copy-replace-participants-button").addEventListener("click", () => copyReplaceParticipantsModalShow('copy-replace-participants'));
     </script>
 
     {% trans 'Import contributors' as title %}
@@ -212,7 +216,8 @@
             const form = document.getElementById("contributor-import-form");
             form.appendChild(input);
             form.requestSubmit();
-        };
+        }
+        document.getElementById("import-contributors-button").addEventListener("click", () => importContributorsModalShow('import-contributors'));
     </script>
 
     {% trans 'Replace contributors' as title %}
@@ -229,7 +234,8 @@
             const form = document.getElementById("contributor-import-form");
             form.appendChild(input);
             form.requestSubmit();
-        };
+        }
+        document.getElementById("import-replace-contributors-button").addEventListener("click", () => replaceContributorsModalShow('import-replace-contributors'));
     </script>
 
     {% trans 'Copy contributors' as title %}
@@ -246,7 +252,8 @@
             const form = document.getElementById("contributor-copy-form");
             form.appendChild(input);
             form.requestSubmit();
-        };
+        }
+        document.getElementById("copy-contributors-button").addEventListener("click", () => copyContributorsModalShow('copy-contributors'));
     </script>
 
     {% trans 'Replace contributors' as title %}
@@ -263,9 +270,9 @@
             const form = document.getElementById("contributor-copy-form");
             form.appendChild(input);
             form.requestSubmit();
-        };
+        }
+        document.getElementById("copy-replace-contributors-button").addEventListener("click", () => copyReplaceContributorsModalShow('copy-replace-contributors'));
     </script>
-
 {% endblock %}
 
 {% block additional_javascript %}

--- a/evap/staff/templates/staff_evaluation_textanswers_full.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_full.html
@@ -35,7 +35,7 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         document
             .querySelectorAll(".full-update-textanswer-form input[type='radio'], .full-textanswer-flag-form input[type='radio']")
             .forEach(input => input.addEventListener("change", () => input.form.requestSubmit()));

--- a/evap/staff/templates/staff_evaluation_textanswers_quick.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_quick.html
@@ -191,7 +191,7 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="module">
+    <script type="module" nonce="{{ CSP_NONCE }}">
         import { QuickReviewSlider } from "{% static 'js/quick-review-slider.js' %}";
 
         const slider = new QuickReviewSlider(

--- a/evap/staff/templates/staff_faq_index.html
+++ b/evap/staff/templates/staff_faq_index.html
@@ -59,9 +59,9 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script src="{% static 'js/sortable_form.js' %}"></script>
+    <script src="{% static 'js/sortable_form.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         rowChanged = function(row) {
             nameDe = $(row.find('input[id$=-title_de]')).val();
             nameEn = $(row.find('input[id$=-title_en]')).val();

--- a/evap/staff/templates/staff_faq_index.html
+++ b/evap/staff/templates/staff_faq_index.html
@@ -20,9 +20,9 @@
                     <thead>
                         <tr>
                             <th class="movable"></th>
-                            <th style="width: 45%">{% trans 'Section title (German)' %}</th>
-                            <th style="width: 45%">{% trans 'Section title (English)' %}</th>
-                            <th class="text-end" style="width: 10%">{% trans 'Actions' %}</th>
+                            <th class="width-percent-45">{% trans 'Section title (German)' %}</th>
+                            <th class="width-percent-45">{% trans 'Section title (English)' %}</th>
+                            <th class="width-percent-10 text-end">{% trans 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/evap/staff/templates/staff_faq_section.html
+++ b/evap/staff/templates/staff_faq_section.html
@@ -59,9 +59,9 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script src="{% static 'js/sortable_form.js' %}"></script>
+    <script src="{% static 'js/sortable_form.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         rowChanged = function(row) {
             qDe = $(row.find('input[id$=-question_de]')).val();
             qEn = $(row.find('input[id$=-question_en]')).val();

--- a/evap/staff/templates/staff_faq_section.html
+++ b/evap/staff/templates/staff_faq_section.html
@@ -21,9 +21,9 @@
                     <thead>
                         <tr>
                             <th class="movable"></th>
-                            <th style="width: 45%">{% trans 'Question/Answer (German)' %}</th>
-                            <th style="width: 45%">{% trans 'Question/Answer (English)' %}</th>
-                            <th class="text-end" style="width: 10%">{% trans 'Actions' %}</th>
+                            <th class="width-percent-45">{% trans 'Question/Answer (German)' %}</th>
+                            <th class="width-percent-45">{% trans 'Question/Answer (English)' %}</th>
+                            <th class="width-percent-10 text-end">{% trans 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/evap/staff/templates/staff_questionnaire_form.html
+++ b/evap/staff/templates/staff_questionnaire_form.html
@@ -81,8 +81,8 @@
 
 {% block additional_javascript %}
     {% if editable %}
-        <script src="{% static 'js/sortable_form.js' %}"></script>
-        <script type="text/javascript">
+        <script src="{% static 'js/sortable_form.js' %}" nonce="{{ CSP_NONCE }}"></script>
+        <script type="text/javascript" nonce="{{ CSP_NONCE }}">
             rowChanged = function(row) {
                 nameDe = $(row.find('textarea[id$=-text_de]')).val();
                 nameEn = $(row.find('textarea[id$=-text_en]')).val();

--- a/evap/staff/templates/staff_questionnaire_form.html
+++ b/evap/staff/templates/staff_questionnaire_form.html
@@ -30,10 +30,10 @@
                         <thead>
                             <tr>
                                 <th></th>
-                                <th style="width: 37%">{% trans 'Question text (German)' %}</th>
-                                <th style="width: 37%">{% trans 'Question text (English)' %}</th>
-                                <th style="width: 20%">{% trans 'Question type' %}</th>
-                                <th style="width: 6%"></th>
+                                <th class="width-percent-37">{% trans 'Question text (German)' %}</th>
+                                <th class="width-percent-37">{% trans 'Question text (English)' %}</th>
+                                <th class="width-percent-20">{% trans 'Question type' %}</th>
+                                <th class="width-percent-6"></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/evap/staff/templates/staff_questionnaire_index.html
+++ b/evap/staff/templates/staff_questionnaire_index.html
@@ -97,6 +97,9 @@
                 questionnaire.querySelectorAll(`button[data-visibility="${visibility}"]`).forEach(button => {button.classList.add("active");});
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
         }
+        for (const button of document.querySelectorAll(".change-visibility-button")) {
+            button.addEventListener("click", () => changeVisibility(button));
+        }
 
         function changeLocked(element) {
             const questionnaire = element.closest(".questionnaire");
@@ -111,6 +114,9 @@
                 questionnaire.querySelectorAll(`button[data-is-locked]`).forEach(button => {button.classList.remove("active");});
                 questionnaire.querySelectorAll(`button[data-is-locked="${is_locked}"]`).forEach(button => {button.classList.add("active");});
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
+        }
+        for (const button of document.querySelectorAll(".change-is-locked-button")) {
+            button.addEventListener("click", () => changeLocked(button));
         }
     </script>
 {% endblock %}

--- a/evap/staff/templates/staff_questionnaire_index.html
+++ b/evap/staff/templates/staff_questionnaire_index.html
@@ -62,6 +62,9 @@
                 fadeOutThenRemove(document.querySelector('#questionnaire-row-'+dataId));
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
         };
+        for (const button of document.querySelectorAll(".delete-questionnaire-button")) {
+            button.addEventListener("click", () => deleteQuestionnaireModalShow(button.dataset.questionnaireId, button.dataset.questionnaireName));
+        }
     </script>
 {% endblock %}
 

--- a/evap/staff/templates/staff_questionnaire_index.html
+++ b/evap/staff/templates/staff_questionnaire_index.html
@@ -51,7 +51,7 @@
     {% trans 'Do you really want to delete the questionnaire <strong data-label=""></strong>?' as question %}
     {% trans 'Delete questionnaire' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='deleteQuestionnaireModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function deleteQuestionnaireModalAction(dataId) {
             fetch("{% url 'staff:questionnaire_delete' %}", {
                 body: new URLSearchParams({questionnaire_id: dataId}),
@@ -66,7 +66,7 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="module">
+    <script type="module" nonce="{{ CSP_NONCE }}">
         import {QuestionnaireGrid} from "{% static 'js/datagrid.js' %}";
         document.querySelectorAll(".questionnaire-table").forEach(table => {
             new QuestionnaireGrid({
@@ -79,7 +79,7 @@
         });
     </script>
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function changeVisibility(element) {
             const questionnaire = element.closest(".questionnaire");
             const visibility = element.dataset.visibility;

--- a/evap/staff/templates/staff_questionnaire_index_list.html
+++ b/evap/staff/templates/staff_questionnaire_index_list.html
@@ -52,7 +52,7 @@
                                 <a href="{% url 'staff:questionnaire_copy' questionnaire.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Copy' %}"><span class="fas fa-copy fa-fw"></span></a>
                                 <a href="{% url 'staff:questionnaire_view' questionnaire.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Preview' %}"><span class="fas fa-eye fa-fw"></span></a>
                                 {% if questionnaire.can_be_deleted_by_manager %}
-                                    <button type="button" onclick="deleteQuestionnaireModalShow({{ questionnaire.id }}, '{{ questionnaire.name|escapejs }}');" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
+                                <button type="button" class="btn btn-sm btn-danger delete-questionnaire-button" data-questionnaire-id="{{ questionnaire.id }}" data-questionnaire-name="{{ questionnaire.name }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
                                         <span class="fas fa-trash"></span>
                                     </button>
                                 {% else %}

--- a/evap/staff/templates/staff_questionnaire_index_list.html
+++ b/evap/staff/templates/staff_questionnaire_index_list.html
@@ -34,16 +34,16 @@
                             <td>
                                 {% if type != 'contributor' %}
                                     <div class="btn-switch btn-group icon-buttons">
-                                        <button data-is-locked="0" type="button" onclick="changeLocked(this);" class="btn btn-sm btn-light{% if questionnaire.is_locked == False %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Allow editors to change the selection of this questionnaire' %}"><span class="fas fa-fw fa-lock-open" aria-hidden="true"></span></button>
-                                        <button data-is-locked="1" type="button" onclick="changeLocked(this);" class="btn btn-sm btn-light{% if questionnaire.is_locked == True %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Prevent editors from changing the selection of this questionnaire' %}"><span class="fas fa-fw fa-lock" aria-hidden="true"></span></button>
+                                        <button data-is-locked="0" type="button" class="btn btn-sm change-is-locked-button btn-light{% if questionnaire.is_locked == False %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Allow editors to change the selection of this questionnaire' %}"><span class="fas fa-fw fa-lock-open" aria-hidden="true"></span></button>
+                                        <button data-is-locked="1" type="button" class="btn btn-sm change-is-locked-button btn-light{% if questionnaire.is_locked == True %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Prevent editors from changing the selection of this questionnaire' %}"><span class="fas fa-fw fa-lock" aria-hidden="true"></span></button>
                                     </div>
                                 {% endif %}
                             </td>
                             <td>
                                 <div class="btn-group icon-buttons">
-                                    <button data-visibility="0" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 0 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% blocktrans %}Hide in lists{% endblocktrans %}"><span class="fas fa-fw fa-eye-slash" aria-hidden="true"></span></button>
-                                    <button data-visibility="1" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 1 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Show only for managers' %}"><span class="fas fa-fw fa-briefcase" aria-hidden="true"></span></button>
-                                    <button data-visibility="2" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 2 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Show for managers and editors' %}"><span class="fas fa-fw fa-person-chalkboard" aria-hidden="true"></span></button>
+                                    <button data-visibility="0" type="button" class="btn btn-sm change-visibility-button btn-light{% if questionnaire.visibility == 0 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% blocktrans %}Hide in lists{% endblocktrans %}"><span class="fas fa-fw fa-eye-slash" aria-hidden="true"></span></button>
+                                    <button data-visibility="1" type="button" class="btn btn-sm change-visibility-button btn-light{% if questionnaire.visibility == 1 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Show only for managers' %}"><span class="fas fa-fw fa-briefcase" aria-hidden="true"></span></button>
+                                    <button data-visibility="2" type="button" class="btn btn-sm change-visibility-button btn-light{% if questionnaire.visibility == 2 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Show for managers and editors' %}"><span class="fas fa-fw fa-person-chalkboard" aria-hidden="true"></span></button>
                                 </div>
                             </td>
                             <td class="text-end">

--- a/evap/staff/templates/staff_questionnaire_index_list.html
+++ b/evap/staff/templates/staff_questionnaire_index_list.html
@@ -10,15 +10,15 @@
                 <table class="table table-vertically-aligned table-striped questionnaire-table">
                     <thead>
                         <tr class="table-header">
-                            <th class="movable" style="width: 3%"></th>
-                            <th style="width: 52%">{% trans 'Questionnaire' %}</th>
-                            <th style="width: 10%">
+                            <th class="width-percent-3 movable"></th>
+                            <th class="width-percent-52">{% trans 'Questionnaire' %}</th>
+                            <th class="width-percent-10">
                                 {% if type != 'contributor' %}
                                     {% trans 'Locked' %}
                                 {% endif %}
                             </th>
-                            <th style="width: 15%">{% trans 'Visibility' %}</th>
-                            <th class="text-end" style="width: 20%">{% trans 'Actions' %}</th>
+                            <th class="width-percent-15">{% trans 'Visibility' %}</th>
+                            <th class="width-percent-20 text-end">{% trans 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/evap/staff/templates/staff_semester_export.html
+++ b/evap/staff/templates/staff_semester_export.html
@@ -22,9 +22,9 @@
                 <table id="exportsheets-table" class="table">
                     <thead>
                         <tr>
-                            <th style="width: 25%">{% trans 'Degrees' %}</th>
-                            <th style="width: 65%">{% trans 'Course types' %}</th>
-                            <th style="width: 10%"></th>
+                            <th class="width-percent-25">{% trans 'Degrees' %}</th>
+                            <th class="width-percent-65">{% trans 'Course types' %}</th>
+                            <th class="width-percent-10"></th>
                         </tr>
                     </thead>
                     <tbody>

--- a/evap/staff/templates/staff_semester_export.html
+++ b/evap/staff/templates/staff_semester_export.html
@@ -72,9 +72,9 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script src="{% static 'js/sortable_form.js' %}"></script>
+    <script src="{% static 'js/sortable_form.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         rowChanged = function(row) {
             id = row.find("input[id$=-id]").val();
             return id;

--- a/evap/staff/templates/staff_semester_import.html
+++ b/evap/staff/templates/staff_semester_import.html
@@ -47,7 +47,7 @@
     {% trans 'Do you really want to import semester data from the Excel file?' as question %}
     {% trans 'Import semester data' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='importSemesterModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function importSemesterModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -64,5 +64,5 @@
 
 {% block additional_javascript %}
     {% include 'bootstrap_datetimepicker.html' %}
-    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}" nonce="{{ CSP_NONCE }}"></script>
 {% endblock %}

--- a/evap/staff/templates/staff_semester_import.html
+++ b/evap/staff/templates/staff_semester_import.html
@@ -19,7 +19,7 @@
                 <p>
                     {% trans 'Upload Excel file' %}
                     (<a href="{% url 'staff:download_sample_file' 'sample.xlsx' %}">{% trans 'Download sample file' %}</a>,
-                    <button type="button" class="btn btn-link" onClick="copyHeaders(['Degree', 'Participant last name', 'Participant first name', 'Participant email address', 'Course kind', 'Course is graded', 'Course name (de)', 'Course name (en)', 'Responsible title', 'Responsible last name', 'Responsible first name', 'Responsible email address'])">
+                    <button type="button" class="btn btn-link" id="copy-headers-button">
                         {% trans 'Copy headers to clipboard' %}</button>).
                     {% trans 'This will create all containing participants, contributors and courses and connect them. It will also set the entered values as default for all evaluations.' %}
                 </p>
@@ -65,4 +65,11 @@
 {% block additional_javascript %}
     {% include 'bootstrap_datetimepicker.html' %}
     <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}" nonce="{{ CSP_NONCE }}"></script>
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
+        document.getElementById("copy-headers-button").addEventListener("click", () => copyHeaders([
+            'Degree', 'Participant last name', 'Participant first name', 'Participant email address', 'Course kind',
+            'Course is graded', 'Course name (de)', 'Course name (en)', 'Responsible title', 'Responsible last name',
+            'Responsible first name', 'Responsible email address'])
+        );
+    </script>
 {% endblock %}

--- a/evap/staff/templates/staff_semester_import.html
+++ b/evap/staff/templates/staff_semester_import.html
@@ -34,7 +34,7 @@
                     <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
                 {% else %}
                     <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
-                    <button name="operation" value="import" type="button" onclick="importSemesterModalShow('import');" class="btn btn-primary form-submit-btn">{% trans 'Import previously uploaded file' %}</button>
+                    <button name="operation" value="import" type="button" id="button-show-import-modal" class="btn btn-primary form-submit-btn">{% trans 'Import previously uploaded file' %}</button>
                 {% endif %}
             </div>
         </div>
@@ -58,8 +58,8 @@
             form.appendChild(input);
             form.requestSubmit();
         };
+        document.getElementById("button-show-import-modal").addEventListener("click", () => importSemesterModalShow('import'));
     </script>
-
 {% endblock %}
 
 {% block additional_javascript %}

--- a/evap/staff/templates/staff_semester_preparation_reminder.html
+++ b/evap/staff/templates/staff_semester_preparation_reminder.html
@@ -13,7 +13,7 @@
     {% if responsible_list %}
         <div class="d-flex mb-3">
             <div class="me-auto">
-                <button type="button" id="remindAllButton" onClick="remindAllModalShow()" class="btn btn-sm btn-light">{% trans 'Remind all' %}</button>
+                <button type="button" id="remindAllButton" class="btn btn-sm btn-light">{% trans 'Remind all' %}</button>
             </div>
         </div>
     {% endif %}
@@ -90,5 +90,6 @@
                 location.reload();
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
         }
+        document.getElementById("remindAllButton").addEventListener("click", () => remindAllModalShow());
     </script>
 {% endblock %}

--- a/evap/staff/templates/staff_semester_preparation_reminder.html
+++ b/evap/staff/templates/staff_semester_preparation_reminder.html
@@ -37,9 +37,9 @@
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <th style="width: 57%">{% trans 'Name' %}</th>
-                            <th style="width: 18%">{% trans 'Start of evaluation' %}</th>
-                            <th style="width: 25%">{% trans 'Last modified by' %}</th>
+                            <th class="width-percent-57">{% trans 'Name' %}</th>
+                            <th class="width-percent-18">{% trans 'Start of evaluation' %}</th>
+                            <th class="width-percent-25">{% trans 'Last modified by' %}</th>
                        </tr>
                     </thead>
                     <tbody>

--- a/evap/staff/templates/staff_semester_preparation_reminder.html
+++ b/evap/staff/templates/staff_semester_preparation_reminder.html
@@ -76,7 +76,7 @@
     {% trans 'Do you really want to remind everyone?' as question %}
     {% trans 'Remind all' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='remindAllModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function remindAllModalAction() {
             const remindAllButton = document.getElementById('remindAllButton');
             remindAllButton.disabled = true;

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -84,11 +84,11 @@
                 <table class="table">
                     <thead>
                         <tr>
-                            <th style="width: 19%">{% trans 'Degree' %}</th>
-                            <th style="width: 30%">{% trans 'Evaluation period' %}</th>
-                            <th style="width: 17%">{% trans 'Finished evaluations' %}</th>
-                            <th style="width: 17%">{% trans 'Reviewed text answers' %}</th>
-                            <th style="width: 17%">{% trans 'Participation' %}</th>
+                            <th class="width-percent-19">{% trans 'Degree' %}</th>
+                            <th class="width-percent-30">{% trans 'Evaluation period' %}</th>
+                            <th class="width-percent-17">{% trans 'Finished evaluations' %}</th>
+                            <th class="width-percent-17">{% trans 'Reviewed text answers' %}</th>
+                            <th class="width-percent-17">{% trans 'Participation' %}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -62,7 +62,7 @@
 
     <div class="card collapsible mb-3">
         <div class="card-header d-flex">
-            <a class="collapse-toggle collapsed" data-bs-toggle="collapse" href="#overviewCard" aria-expanded="false" aria-controls="overviewCard" onclick="saveCollapseState()">{% trans 'Overview' %}</a>
+            <a id="collapseButton" class="collapse-toggle collapsed" data-bs-toggle="collapse" href="#overviewCard" aria-expanded="false" aria-controls="overviewCard">{% trans 'Overview' %}</a>
             {% if request.user.is_manager %}
                 <div class="ms-auto">
                     {% if not semester.participations_are_archived %}
@@ -123,12 +123,12 @@
         <div class="card-header d-flex">
             <ul class="nav nav-pills" role="tablist">
                 <li class="nav-item">
-                    <a class="nav-link active" id="evaluationsTab" data-bs-toggle="pill" href="#evaluations" role="tab" onclick="saveSelectedTab('evaluations');">
+                    <a class="nav-link active" id="evaluationsTab" data-bs-toggle="pill" href="#evaluations" role="tab">
                         <span class="fas fa-clipboard-check"></span> {% trans 'Evaluations' %}
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" id="coursesTab" data-bs-toggle="pill" href="#courses" role="tab" onclick="saveSelectedTab('courses');">
+                    <a class="nav-link" id="coursesTab" data-bs-toggle="pill" href="#courses" role="tab">
                         <span class="fas fa-chalkboard-user"></span> {% trans 'Courses' %}
                     </a>
                 </li>
@@ -304,14 +304,8 @@
 
                     {% if request.user.is_manager and not semester.participations_are_archived %}
                         <div class="my-2">
-                            <button type="button" class="btn btn-sm btn-secondary"
-                                onclick="document.querySelectorAll('#evaluation_operation_form input[type=checkbox][name=evaluation]').forEach(c => {c.checked = true;})">
-                                {% trans 'Select all' %}
-                            </button>
-                            <button type="button" class="btn btn-sm btn-secondary"
-                                onclick="document.querySelectorAll('#evaluation_operation_form input[type=checkbox][name=evaluation]').forEach(c => {c.checked = false;})">
-                                {% trans 'Select none' %}
-                            </button>
+                            <button type="button" class="btn btn-sm btn-secondary" id="selectAllButton">{% trans 'Select all' %}</button>
+                            <button type="button" class="btn btn-sm btn-secondary" id="selectNoneButton">{% trans 'Select none' %}</button>
                         </div>
                         <div>
                             <button name="target_state" value="{{ Evaluation.State.PREPARED }}" type="submit" class="btn btn-sm btn-light"
@@ -600,6 +594,7 @@
             var state = localStorage['show_overview'] === 'true';
             localStorage['show_overview'] = (!state).toString();
         }
+        document.getElementById("collapseButton").addEventListener("click", saveCollapseState);
 
         if(localStorage['selected_tab'] === 'courses') {
             var coursesTab = document.getElementById('coursesTab');
@@ -610,10 +605,18 @@
         function saveSelectedTab(tab) {
             localStorage['selected_tab'] = tab;
         }
+        document.getElementById("evaluationsTab").addEventListener("click", () => saveSelectedTab("evaluations"));
+        document.getElementById("coursesTab").addEventListener("click", () => saveSelectedTab("courses"));
 
         window.addEventListener("pageshow", () => {
             document.querySelectorAll('#evaluation_operation_form input[type=checkbox]').forEach(checkbox => {checkbox.checked = false;}); // prevent wrong autofills
         });
+
+        document.getElementById("selectAllButton").addEventListener("click", () =>
+            document.querySelectorAll('#evaluation_operation_form input[type=checkbox][name=evaluation]').forEach(c => {c.checked = true;}));
+
+        document.getElementById("selectNoneButton").addEventListener("click", () =>
+            document.querySelectorAll('#evaluation_operation_form input[type=checkbox][name=evaluation]').forEach(c => {c.checked = false;}));
     </script>
     <script type="module" nonce="{{ CSP_NONCE }}">
         import {EvaluationGrid, TableGrid} from "{% static 'js/datagrid.js' %}";

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -448,7 +448,7 @@
     {% trans 'Do you want to make this the active semester?' as question %}
     {% trans 'Make active' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='makeActiveSemesterModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function makeActiveSemesterModalAction(dataId) {
             const makeActiveSemesterButton = document.getElementById('makeActiveSemesterButton');
             makeActiveSemesterButton.disabled = true;
@@ -468,7 +468,7 @@
     {% blocktrans asvar question %}Do you really want to delete the semester <strong data-label=""></strong>? All courses and evaluations will be deleted as well as all results. If you are sure, enter the name of the semester below.{% endblocktrans %}
     {% trans 'Delete semester' as action_text %}
     {% include 'confirmation_text_modal.html' with modal_id='deleteSemesterModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function deleteSemesterModalAction(dataId) {
             const deleteButton = document.getElementById('deleteSemesterButton');
             deleteButton.disabled = true;
@@ -488,7 +488,7 @@
     {% blocktrans asvar question %}Do you really want to archive all participations in the semester <strong data-label=""></strong>? Further changes to the evaluations won't be possible and you can't undo this action.{% endblocktrans %}
     {% trans 'Archive participations' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='archiveParticipationsModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function archiveParticipationsModalAction(dataId) {
             fetch("{% url 'staff:semester_archive_participations' %}", {
                 body: new URLSearchParams({semester_id: dataId}),
@@ -504,7 +504,7 @@
     {% blocktrans asvar question %}Do you really want to delete the grade documents in the semester <strong data-label=""></strong>? This will delete all existing grade documents for this semester's courses and will disable new uploads. You can't undo this action.{% endblocktrans %}
     {% trans 'Delete grade documents' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='deleteGradeDocumentsModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function deleteGradeDocumentsModalAction(dataId) {
             fetch("{% url 'staff:semester_delete_grade_documents' %}", {
                 body: new URLSearchParams({semester_id: dataId}),
@@ -520,7 +520,7 @@
     {% blocktrans asvar question %}Do you really want to archive the results in the semester <strong data-label=""></strong>? This will make the results of all evaluations inaccessible for all users except their contributors and managers. You can't undo this action.{% endblocktrans %}
     {% trans 'Archive results' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='archiveResultsModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function archiveResultsModalAction(dataId) {
             fetch("{% url 'staff:semester_archive_results' %}", {
                 body: new URLSearchParams({semester_id: dataId}),
@@ -536,7 +536,7 @@
     {% trans 'Do you really want to delete the evaluation <strong data-label=""></strong>?' as question %}
     {% trans 'Delete evaluation' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='deleteEvaluationModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function deleteEvaluationModalAction(dataId) {
             fetch("{% url 'staff:evaluation_delete' %}", {
                 body: new URLSearchParams({evaluation_id: dataId}),
@@ -552,7 +552,7 @@
     {% trans 'Do you really want to delete the course <strong data-label=""></strong>?' as question %}
     {% trans 'Delete course' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='deleteCourseModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function deleteCourseModalAction(dataId) {
             fetch("{% url 'staff:course_delete' %}", {
                 body: new URLSearchParams({course_id: dataId}),
@@ -568,7 +568,7 @@
     {% blocktrans asvar question %}Do you want to activate the reward points for the semester <strong data-label=""></strong>? The activation will allow participants to receive reward points when voting and will also grant all eligible points for participants who have already voted so far. The process will take a while.{% endblocktrans %}
     {% trans 'Activate reward points' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='activateRewardPointsModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function activateRewardPointsModalAction() {
             document.getElementById("form_activation_status").requestSubmit();
         }
@@ -576,7 +576,7 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         var overviewCard = document.getElementById('overviewCard');
         var overviewCardCollapse = new bootstrap.Collapse(overviewCard, {
             toggle: localStorage['show_overview'] === 'true'
@@ -601,7 +601,7 @@
             document.querySelectorAll('#evaluation_operation_form input[type=checkbox]').forEach(checkbox => {checkbox.checked = false;}); // prevent wrong autofills
         });
     </script>
-    <script type="module">
+    <script type="module" nonce="{{ CSP_NONCE }}">
         import {EvaluationGrid, TableGrid} from "{% static 'js/datagrid.js' %}";
         const evaluationTable = document.querySelector("#evaluation-table");
         if (evaluationTable) {

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -16,7 +16,7 @@
             &nbsp;
             <a href="{% url 'staff:semester_edit' semester.id %}" class="btn btn-sm btn-secondary">{% trans 'Edit' %}</a>
             <button
-                onClick="makeActiveSemesterModalShow({{ semester.id }})" class="btn btn-sm btn-light"
+                class="btn btn-sm btn-light"
                 id="makeActiveSemesterButton" type="button"
                 {% if semester.is_active %}
                     disabled
@@ -25,7 +25,7 @@
                 {% endif %}>
                 {% trans 'Make active' %}
             </button>
-            <button type="button" id="deleteSemesterButton"{% if not semester.can_be_deleted_by_manager %} disabled{% endif %} onclick="deleteSemesterModalShow({{ semester.id }}, '{{ semester.name|escapejs }}');" class="btn btn-sm btn-danger">{% trans 'Delete' %}</button>
+            <button type="button" id="deleteSemesterButton"{% if not semester.can_be_deleted_by_manager %} disabled{% endif %} class="btn btn-sm btn-danger">{% trans 'Delete' %}</button>
         {% endif %}
     </h3>
 
@@ -37,7 +37,7 @@
             <div class="collapse{% if semester.participations_are_archived or semester.grade_documents_are_deleted or semester.results_are_archived %} show{% endif %}" id="archivingCard">
                 <div class="card-body">
                     {% if semester.participations_can_be_archived %}
-                        <button type="button" onclick="archiveParticipationsModalShow({{ semester.id }}, '{{ semester.name|escapejs }}');" class="btn btn-sm btn-warning">{% trans 'Archive participations' %}</button>
+                        <button type="button" id="archiveParticipationsButton" class="btn btn-sm btn-warning">{% trans 'Archive participations' %}</button>
                     {% elif semester.participations_are_archived %}
                         <button type="button" disabled class="btn btn-sm btn-success">{% trans 'Participations have been archived' %}</button>
                     {% else %}
@@ -46,12 +46,12 @@
                             {% trans 'Archive participations' %}</button>
                     {% endif %}
                     {% if semester.grade_documents_can_be_deleted %}
-                        <button type="button" onclick="deleteGradeDocumentsModalShow({{ semester.id }}, '{{ semester.name|escapejs }}');" class="btn btn-sm btn-warning">{% trans 'Delete grade documents' %}</button>
+                        <button type="button" id="deleteGradeDocumentsButton" class="btn btn-sm btn-warning">{% trans 'Delete grade documents' %}</button>
                     {% elif semester.grade_documents_are_deleted %}
                         <button type="button" class="btn btn-sm btn-success disabled">{% trans 'Grade documents have been deleted' %}</button>
                     {% endif %}
                     {% if semester.results_can_be_archived %}
-                        <button type="button" onclick="archiveResultsModalShow({{ semester.id }}, '{{ semester.name|escapejs }}');" class="btn btn-sm btn-warning">{% trans 'Archive results' %}</button>
+                        <button type="button" id="archiveResultsButton" class="btn btn-sm btn-warning">{% trans 'Archive results' %}</button>
                     {% elif semester.results_are_archived %}
                         <button type="button" disabled class="btn btn-sm btn-success">{% trans 'Results have been archived' %}</button>
                     {% endif %}
@@ -72,7 +72,7 @@
                     <div class="btn-switch ms-2">
                         <div class="btn-switch-label">{% trans 'Reward points active' %}</div>
                         <div class="btn-switch btn-group icon-buttons">
-                            <button type="button" onclick="activateRewardPointsModalShow({{ semester.id }}, '{{ semester.name|escapejs }}');" class="btn btn-sm btn-light{% if rewards_active %} active{% endif %}"><span class="fas fa-check" aria-hidden="true"></span></button>
+                            <button type="button" id="activateRewardPointsButton" class="btn btn-sm btn-light{% if rewards_active %} active{% endif %}"><span class="fas fa-check" aria-hidden="true"></span></button>
                             <button type="submit" name="activation_status" value="off" form="form_activation_status" class="btn btn-sm btn-light{% if not rewards_active %} active{% endif %}"><span class="fas fa-xmark" aria-hidden="true"></span></button>
                         </div>
                     </div>
@@ -421,7 +421,7 @@
                                             </a>
                                         {% endif %}
                                         {% if course.can_be_deleted_by_manager %}
-                                            <button type="button" onclick="deleteCourseModalShow({{ course.id }}, '{{ course.name|escapejs }}');" class="btn btn-sm btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
+                                            <button type="button" data-course-id="{{ course.id }}" data-course-name="{{ course.name }}" class="btn btn-sm btn-outline-danger delete-course-button" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
                                                 <span class="fas fa-trash" aria-hidden="true"></span>
                                             </button>
                                         {% endif %}
@@ -463,14 +463,15 @@
                 location.reload();
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
         }
+        makeActiveSemesterButton.addEventListener("click", () => makeActiveSemesterModalShow({{ semester.id }}));
     </script>
     {% trans 'Delete semester' as title %}
     {% blocktrans asvar question %}Do you really want to delete the semester <strong data-label=""></strong>? All courses and evaluations will be deleted as well as all results. If you are sure, enter the name of the semester below.{% endblocktrans %}
     {% trans 'Delete semester' as action_text %}
     {% include 'confirmation_text_modal.html' with modal_id='deleteSemesterModal' title=title question=question action_text=action_text btn_type='danger' %}
     <script type="text/javascript" nonce="{{ CSP_NONCE }}">
+        const deleteButton = document.getElementById('deleteSemesterButton');
         function deleteSemesterModalAction(dataId) {
-            const deleteButton = document.getElementById('deleteSemesterButton');
             deleteButton.disabled = true;
             deleteButton.textContent = "{% trans 'Deleting...' %}";
 
@@ -482,8 +483,10 @@
                 assert(response.ok);
                 location.replace("{% url 'staff:index' %}");
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
-        };
+        }
+        deleteButton.addEventListener("click", () => deleteSemesterModalShow({{ semester.id }}, '{{ semester.name|escapejs }}'));
     </script>
+
     {% trans 'Archive participations' as title %}
     {% blocktrans asvar question %}Do you really want to archive all participations in the semester <strong data-label=""></strong>? Further changes to the evaluations won't be possible and you can't undo this action.{% endblocktrans %}
     {% trans 'Archive participations' as action_text %}
@@ -498,8 +501,13 @@
                 assert(response.ok);
                 location.reload();
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
-        };
+        }
+        const archiveButton = document.getElementById("archiveParticipationsButton");
+        if(archiveButton !== null) {
+            archiveButton.addEventListener("click", () => archiveParticipationsModalShow({{ semester.id }}, '{{ semester.name|escapejs }}'));
+        }
     </script>
+
     {% trans 'Delete grade documents' as title %}
     {% blocktrans asvar question %}Do you really want to delete the grade documents in the semester <strong data-label=""></strong>? This will delete all existing grade documents for this semester's courses and will disable new uploads. You can't undo this action.{% endblocktrans %}
     {% trans 'Delete grade documents' as action_text %}
@@ -514,7 +522,8 @@
                 assert(response.ok);
                 location.reload();
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
-        };
+        }
+        document.getElementById("deleteGradeDocumentsButton").addEventListener("click", () => deleteGradeDocumentsModalShow({{ semester.id }}, '{{ semester.name|escapejs }}'));
     </script>
     {% trans 'Archive results' as title %}
     {% blocktrans asvar question %}Do you really want to archive the results in the semester <strong data-label=""></strong>? This will make the results of all evaluations inaccessible for all users except their contributors and managers. You can't undo this action.{% endblocktrans %}
@@ -530,7 +539,8 @@
                 assert(response.ok);
                 location.reload();
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
-        };
+        }
+        document.getElementById("archiveResultsButton").addEventListener("click", () => archiveResultsModalShow({{ semester.id }}, '{{ semester.name|escapejs }}'));
     </script>
     {% trans 'Delete evaluation' as title %}
     {% trans 'Do you really want to delete the evaluation <strong data-label=""></strong>?' as question %}
@@ -546,7 +556,7 @@
                 assert(response.ok);
                 fadeOutThenRemove(document.getElementById('evaluation-row-'+dataId))
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
-        };
+        }
     </script>
     {% trans 'Delete course' as title %}
     {% trans 'Do you really want to delete the course <strong data-label=""></strong>?' as question %}
@@ -562,7 +572,10 @@
                 assert(response.ok);
                 fadeOutThenRemove(document.getElementById('#course-row-'+dataId))
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
-        };
+        }
+        for (const button of document.querySelectorAll(".delete-course-button")) {
+            button.addEventListener("click", () => deleteCourseModalShow(button.dataset.courseId, button.dataset.courseName));
+        }
     </script>
     {% trans 'Activate reward points' as title %}
     {% blocktrans asvar question %}Do you want to activate the reward points for the semester <strong data-label=""></strong>? The activation will allow participants to receive reward points when voting and will also grant all eligible points for participants who have already voted so far. The process will take a while.{% endblocktrans %}
@@ -572,6 +585,7 @@
         function activateRewardPointsModalAction() {
             document.getElementById("form_activation_status").requestSubmit();
         }
+        document.getElementById("activateRewardPointsButton").addEventListener("click", () => activateRewardPointsModalShow({{ semester.id }}, '{{ semester.name|escapejs }}'));
     </script>
 {% endblock %}
 

--- a/evap/staff/templates/staff_semester_view_evaluation.html
+++ b/evap/staff/templates/staff_semester_view_evaluation.html
@@ -208,9 +208,12 @@
             </a>
         {% endif %}
         {% if request.user.is_manager and evaluation.can_be_deleted_by_manager %}
-            <button type="button" onclick="deleteEvaluationModalShow({{ evaluation.id }}, '{{ evaluation.full_name|escapejs }}');" class="btn btn-sm btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
+            <button type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
                 <span class="fas fa-trash" aria-hidden="true"></span>
             </button>
+            <script type="text/javascript" nonce="{{ CSP_NONCE }}">
+                document.currentScript.previousSibling.addEventListener("click", () => deleteEvaluationModalShow({{ evaluation.id }}, '{{ evaluation.full_name|escapejs }}'));
+            </script>
         {% endif %}
     {% endif %}
 </td>

--- a/evap/staff/templates/staff_template_form.html
+++ b/evap/staff/templates/staff_template_form.html
@@ -21,7 +21,7 @@
                 <div class="col-3">
                     <p>{% trans 'The following variables are available for this email template:' %}</p>
                     {% for variable in available_variables %}
-                        <button type="button" class="btn btn-sm btn-link text-dark pe-1" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Copy to clipboard' %}" onClick="copyToClipboard('{{ variable }}')">
+                        <button type="button" class="btn btn-sm btn-link text-dark pe-1 copy-to-clipboard-btn" data-variable="{{ variable }}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Copy to clipboard' %}">
                             <span class="fas fa-clipboard"></span>
                         </button>
                         <code>{{ variable }}</code>
@@ -41,4 +41,10 @@
 
 {% block additional_javascript %}
     <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}" nonce="{{ CSP_NONCE }}"></script>
+
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
+        for(const button of document.querySelectorAll(".copy-to-clipboard-btn")) {
+            button.addEventListener("click", (event) => copyToClipboard(event.srcElement.dataset.variable));
+        }
+    </script>
 {% endblock %}

--- a/evap/staff/templates/staff_template_form.html
+++ b/evap/staff/templates/staff_template_form.html
@@ -44,7 +44,7 @@
 
     <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         for(const button of document.querySelectorAll(".copy-to-clipboard-btn")) {
-            button.addEventListener("click", (event) => copyToClipboard(event.srcElement.dataset.variable));
+            button.addEventListener("click", event => copyToClipboard(button.dataset.variable));
         }
     </script>
 {% endblock %}

--- a/evap/staff/templates/staff_template_form.html
+++ b/evap/staff/templates/staff_template_form.html
@@ -40,5 +40,5 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}" nonce="{{ CSP_NONCE }}"></script>
 {% endblock %}

--- a/evap/staff/templates/staff_text_answer_warnings.html
+++ b/evap/staff/templates/staff_text_answer_warnings.html
@@ -21,8 +21,8 @@
                     <colgroup>
                         <col />
                         <col />
-                        <col style="width: 30%" />
-                        <col style="width: 30%" />
+                        <col class="width-percent-30" />
+                        <col class="width-percent-30" />
                         <col />
                     </colgroup>
                     <thead>

--- a/evap/staff/templates/staff_text_answer_warnings.html
+++ b/evap/staff/templates/staff_text_answer_warnings.html
@@ -93,11 +93,11 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script src="{% static 'js/sortable_form.js' %}"></script>
+    <script src="{% static 'js/sortable_form.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
     {{ text_answer_warnings|text_answer_warning_trigger_strings|json_script:'text-answer-warnings' }}
 
-    <script type="module">
+    <script type="module" nonce="{{ CSP_NONCE }}">
         import {initTextAnswerWarnings} from "{% static 'js/text-answer-warnings.js' %}";
 
         initTextAnswerWarnings([document.querySelector("#preview-textarea")], JSON.parse(document.getElementById("text-answer-warnings").textContent));

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -21,7 +21,7 @@
             <div class="ms-auto d-print-none">
                 {% if has_due_evaluations %}
                     <div>
-                        <button type="button" class="btn btn-sm btn-light" onclick="resendEmailModalShow({{ form.instance.id }}, '{{ form.instance.full_name|escapejs }}');">{% trans 'Resend evaluation started email' %}</button>
+                        <button type="button" class="btn btn-sm btn-light" id="resend-email-button">{% trans 'Resend evaluation started email' %}</button>
                     </div>
                 {% else %}
                     <div title="{% trans 'This user currently has no due evaluations.' %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
@@ -103,9 +103,7 @@
             <div class="card-body">
                 <button type="submit" class="btn btn-primary">{% trans 'Save user' %}</button>
                 {% if form.instance and form.instance.can_be_deleted_by_manager %}
-                    <button type="button" class="btn btn-danger" onclick="deleteModalShow({{ form.instance.id }}, '{{ form.instance.full_name|escapejs }}');">
-                        {% trans 'Delete user' %}
-                    </button>
+                    <button type="button" class="btn btn-danger" id="delete-button">{% trans 'Delete user' %}</button>
                 {% else %}
                     <span tabindex="0" data-bs-toggle="tooltip" title="{% blocktrans %}This user contributes to an evaluation, participates in an evaluation whose participations haven't been archived yet or has special rights and as such cannot be deleted.{% endblocktrans %}">
                     <button type="button" disabled class="btn btn-danger">
@@ -134,6 +132,8 @@
                 window.location="{% url 'staff:user_index' %}"
             }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
         }
+
+        document.getElementById("delete-button").addEventListener("click", () => deleteModalShow({{ form.instance.id }}, '{{ form.instance.full_name|escapejs }}'));
     </script>
     {% if form.instance.id %}
         {% trans 'Send notification email' as title %}
@@ -150,7 +150,9 @@
                     assert(response.ok);
                     window.location="{% url 'staff:user_edit' user_id %}"
                 }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
-            };
+            }
+
+            document.getElementById("resend-email-button").addEventListener("click", () => copyReplaceContributorsModalShow('copy-replace-contributors'));
         </script>
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -123,7 +123,7 @@
     {% trans 'Do you really want to delete the user <strong data-label=""></strong>?<br/>This person will also be removed from every other user having this person as a delegated or CC-user.' as question %}
     {% trans 'Delete user' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='deleteModal' title=title question=question action_text=action_text btn_type='danger' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function deleteModalAction(dataId) {
             fetch("{% url 'staff:user_delete' %}", {
                 body: new URLSearchParams({user_id: dataId}),
@@ -140,7 +140,7 @@
         {% trans 'The email will notify the user about all their due evaluations. Do you want to send the email now?' as question %}
         {% trans 'Send email' as action_text %}
         {% include 'confirmation_modal.html' with modal_id='resendEmailModal' title=title question=question action_text=action_text btn_type='success' %}
-        <script type="text/javascript">
+        <script type="text/javascript" nonce="{{ CSP_NONCE }}">
             function resendEmailModalAction(dataId) {
                 fetch("{% url 'staff:user_resend_email' %}", {
                     body: new URLSearchParams({user_id: dataId}),

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -41,12 +41,12 @@
 {% endblock %}
 
 {% block modals %}
-{{ block.super }}
+    {{ block.super }}
     {% trans 'Import Users' as title %}
     {% blocktrans asvar question %}Do you really want to import the users from the Excel file?{% endblocktrans %}
     {% trans 'Import Users' as action_text %}
     {% include 'confirmation_modal.html' with modal_id='importUserModal' title=title question=question action_text=action_text btn_type='primary' %}
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
         function importUserModalAction(dataId) {
             const input = document.createElement("input");
             input.type = "hidden";
@@ -62,5 +62,5 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}" nonce="{{ CSP_NONCE }}"></script>
 {% endblock %}

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -33,7 +33,7 @@
                     <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
                 {% else %}
                     <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
-                    <button name="operation" value="import" type="button" onclick="importUserModalShow('import');" class="btn btn-primary form-submit-btn">{% trans 'Import previously uploaded file' %}</button>
+                    <button name="operation" value="import" type="button" id="import-users-button" class="btn btn-primary form-submit-btn">{% trans 'Import previously uploaded file' %}</button>
                 {% endif %}
             </div>
         </div>
@@ -56,7 +56,8 @@
             const form = document.getElementById("user-import-form");
             form.appendChild(input);
             form.requestSubmit();
-        };
+        }
+        document.getElementById("import-users-button").addEventListener("click", () => importUserModalShow("import"));
     </script>
 
 {% endblock %}

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -21,7 +21,7 @@
                 <p>
                     {% trans 'Upload Excel file' %}
                     (<a href="{% url 'staff:download_sample_file' 'sample_user.xlsx' %}">{% trans 'Download sample file' %}</a>,
-                    <button type="button" class="btn btn-link" onclick="copyHeaders(['Title', 'First name', 'Last name', 'Email'])">{% trans 'Copy headers to clipboard' %}</button>).
+                    <button type="button" class="btn btn-link" id="copy-user-headers-button">{% trans 'Copy headers to clipboard' %}</button>).
                     {% trans 'This will create all contained users.' %}
                 </p>
                 {% include 'bootstrap_form.html' with form=excel_form %}
@@ -64,4 +64,7 @@
 
 {% block additional_javascript %}
     <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}" nonce="{{ CSP_NONCE }}"></script>
+    <script type="text/javascript" nonce="{{ CSP_NONCE }}">
+        document.getElementById("copy-user-headers-button").addEventListener("click", () => copyHeaders(['Title', 'First name', 'Last name', 'Email']));
+    </script>
 {% endblock %}

--- a/evap/staff/templates/staff_user_list.html
+++ b/evap/staff/templates/staff_user_list.html
@@ -41,10 +41,10 @@
             <table class="table table-vertically-aligned table-seamless-links user-table">
                 <thead>
                     <tr>
-                        <th style="width: 25%">{% trans 'Name' %}</th>
-                        <th style="width: 35%">{% trans 'Email' %}</th>
-                        <th style="width: 30%">{% trans 'Information' %}</th>
-                        <th style="width: 10%"></th>
+                        <th class="width-percent-25">{% trans 'Name' %}</th>
+                        <th class="width-percent-35">{% trans 'Email' %}</th>
+                        <th class="width-percent-30">{% trans 'Information' %}</th>
+                        <th class="width-percent-10"></th>
                     </tr>
                 </thead>
                 <tbody>

--- a/evap/staff/templates/staff_user_list.html
+++ b/evap/staff/templates/staff_user_list.html
@@ -65,7 +65,7 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="module">
+    <script type="module" nonce="{{ CSP_NONCE }}">
         import {TableGrid} from "{% static 'js/datagrid.js' %}";
         new TableGrid({
             storageKey: "user-index-data-grid",

--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -21,10 +21,10 @@
             <table class="table mb-3">
                 <thead>
                     <tr>
-                        <th style="width: 25%"></th>
-                        <th style="width: 25%">{% trans 'Main user' %}</th>
-                        <th style="width: 25%">{% trans 'Other user' %}</th>
-                        <th style="width: 25%">{% trans 'Merged user' %}</th>
+                        <th class="width-percent-25"></th>
+                        <th class="width-percent-25">{% trans 'Main user' %}</th>
+                        <th class="width-percent-25">{% trans 'Other user' %}</th>
+                        <th class="width-percent-25">{% trans 'Merged user' %}</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/evap/static/scss/_utilities.scss
+++ b/evap/static/scss/_utilities.scss
@@ -71,3 +71,9 @@ a.no-underline:hover {
 .z-over-fixed {
     z-index: $zindex-fixed + 1;
 }
+
+@for $i from 1 through 100 {
+    .width-percent-#{$i} {
+        width: $i * 1%;
+    }
+}

--- a/evap/static/scss/_utilities.scss
+++ b/evap/static/scss/_utilities.scss
@@ -72,8 +72,8 @@ a.no-underline:hover {
     z-index: $zindex-fixed + 1;
 }
 
-@for $i from 1 through 100 {
+@for $i from 0 through 100 {
     .width-percent-#{$i} {
-        width: $i * 1%;
+        width: $i * 1% !important;
     }
 }

--- a/evap/student/templates/student_index_semester_evaluations_list.html
+++ b/evap/student/templates/student_index_semester_evaluations_list.html
@@ -17,9 +17,9 @@
                 <table class="table table-seamless-links table-vertically-aligned table-headerless">
                     <colgroup>
                         <col />
-                        <col style="width: 60%" />
-                        <col style="width: 20%" />
-                        <col style="width: 20%" />
+                        <col class="width-percent-60" />
+                        <col class="width-percent-20" />
+                        <col class="width-percent-20" />
                     </colgroup>
                     <tbody>
                         {% regroup semester.evaluations by course as course_evaluations %}

--- a/evap/student/templates/student_index_unfinished_evaluations_list.html
+++ b/evap/student/templates/student_index_unfinished_evaluations_list.html
@@ -6,7 +6,7 @@
             <tr{% if evaluation.state == evaluation.State.IN_EVALUATION and not evaluation.voted_for and evaluation.is_in_evaluation_period %}
                     class="hover-row hover-row-info" data-url="{% url 'student:vote' evaluation.id %}"
                 {% else %} class="deactivate"{% endif %}>
-                <td style="width: 62%">
+                <td class="width-percent-62">
                     <div>
                         <span class="evaluation-name fw-bold {% if evaluation.state == evaluation.State.IN_EVALUATION and not evaluation.voted_for %} text-primary{% endif %}">
                             {{ evaluation.full_name }}
@@ -20,10 +20,10 @@
                     </span>
                     <i class="small">{{ evaluation.course.responsibles_names }}</i>
                 </td>
-                <td style="width: 18%">
+                <td class="width-percent-18">
                     {% include 'student_index_evaluation_period.html' %}
                 </td>
-                <td style="width: 20%" class="text-end">
+                <td class="width-percent-20 text-end">
                     {% if evaluation.state == evaluation.State.IN_EVALUATION and not evaluation.voted_for and evaluation.is_in_evaluation_period  %}
                         <a class="btn btn-sm btn-primary btn-row-hover" href="{% url 'student:vote' evaluation.id %}">{% trans 'Evaluate' %}</a>
                     {% endif %}

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -171,11 +171,11 @@
 
 {% block additional_javascript %}
     {% if not preview %}
-        <script type="text/javascript" src="{% static 'js/sisyphus.min.js' %}"></script>
+        <script type="text/javascript" src="{% static 'js/sisyphus.min.js' %}" nonce="{{ CSP_NONCE }}"></script>
 
         {{ text_answer_warnings|text_answer_warning_trigger_strings|json_script:'text-answer-warnings' }}
 
-        <script type="module">
+        <script type="module" nonce="{{ CSP_NONCE }}">
             import {initTextAnswerWarnings} from "{% static 'js/text-answer-warnings.js' %}";
             const lastSavedStorageKey = "student-vote-last-saved-at-{{ evaluation.id }}-{{ request.user.id }}";
             const textResultsPublishConfirmation = {
@@ -378,6 +378,6 @@
                 });
             }
         </script>
-        <script type="module" src="{% static 'js/student-vote.js' %}"></script>
+        <script type="module" src="{% static 'js/student-vote.js' %}" nonce="{{ CSP_NONCE }}"></script>
     {% endif %}
 {% endblock %}

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -158,7 +158,7 @@
                             <span class="fas fa-circle-info" data-bs-toggle="tooltip" title="{% trans 'The evaluation can be continued later using the same device and the same browser. But you have to submit it to send it to the server and make it count. After submitting, you can not edit the evaluation anymore.' %}"></span>
                         </div>
                         <button id="vote-submit-btn" type="submit" class="btn btn-success tab-selectable">{% trans 'Submit questionnaire' %}</button>
-                        <p id="submit-error-warning" style="display: none" class="text-danger">
+                        <p id="submit-error-warning" class="text-danger d-none">
                             <span class="fas fa-triangle-exclamation"></span>
                             {% blocktrans %}The server can't be reached. Your answers have been stored in your browser and it's safe to leave the page. Please try again later to submit the questionnaire.{% endblocktrans %}
                         </p>
@@ -283,7 +283,7 @@
                     }
                 }).catch(error => {
                     // show a warning if the post isn't successful
-                    document.getElementById('submit-error-warning').style.display = 'block';
+                    document.getElementById('submit-error-warning').classList.remove("d-none");
                     submitButton.innerText = originalText;
                     submitButton.disabled = false;
                 });

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 django-extensions==3.2.3
 django-fsm==2.8.1
 django~=5.0
+django-csp==3.7
 mozilla-django-oidc==3.0.0
 openpyxl==3.1.2
 psycopg2-binary==2.9.9


### PR DESCRIPTION
Additional layer to prevent JavaScript injection. Still allows inline CSS and images to be exploited.

* [ ] To fix CSS, we need to figure out how we can handle dynamically generated colors. Using `attr()` in CSS doesn't work with current browsers, at least for colors. The only workaround I currently see is having custom javascript that translates `data-X` helper attributes for color into "inline" style (using the `.style` attribute) -- seems a bit ugly to me
* [ ] To fix images, we'd need to move the `data:` images we currently have (3 svg paths in CSS files) into separate files. These are currently inlined into CSS to use our color definitions.
* [ ] Modal changes conflict with #1985 -- we can just remove the modal changes from this PR once the "new" modals are merged.
* [ ] Consider setting up CSP failure reporting, maybe using some external service that tracks / aggregates them for us? Would leak user data though. mozilla-django-csp at least had a report-view in the past, but the documentation looks they don't want to maintain that anymore