### PR TITLE
Fix incorrect permissions on `/opt/evap`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ todo
 
 # flake8 configuration
 setup.cfg
+
+# User specific vagrant overrides (needs extra config)
+.Vagrantfile.local

--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -40,9 +40,10 @@ apt-get -q install -y apache2 apache2-dev libapache2-mod-wsgi-py3
 OWNER=$(stat -c %u "$MOUNTPOINT/evap")
 if [ "$OWNER" != 1042 ]; then
   #  if, for any reason, vagrant failed to mount evap under the correct uid, use bindfs to link it to /opt/evap using the wanted user id
+  #  If you are using docker: Make sure /dev/fuse of your host is forwarded into the container
   apt-get -q install -y bindfs
   mkdir -p "$REPO_FOLDER"
-  bindfs --map="$OWNER/1042:@$OWNER/@1042" "$MOUNTPOINT" "$REPO_FOLDER"
+  bindfs --map="$OWNER/1042:@$OWNER/@1042" "$MOUNTPOINT" "$REPO_FOLDER" || exit 1
   echo "sudo bindfs --map=$OWNER/1042:@$OWNER/@1042 '$MOUNTPOINT' '$REPO_FOLDER'" >> /home/$USER/.bashrc
 else
   ln -s "$MOUNTPOINT" "$REPO_FOLDER"

--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -36,20 +36,25 @@ service redis-server restart
 # install apache
 apt-get -q install -y apache2 apache2-dev libapache2-mod-wsgi-py3
 
-# With docker for mac, root will own the mount point (uid=0). chmod does not touch the host file system in these cases.
-OWNER=$(stat -c %U "$MOUNTPOINT/evap")
-if [ "$OWNER" == "root" ]; then chown -R 1042 "$MOUNTPOINT"; fi
+# link the mounted evap folder from the home directory:
+OWNER=$(stat -c %u "$MOUNTPOINT/evap")
+if [ "$OWNER" != 1042 ]; then
+  #  if, for any reason, vagrant failed to mount evap under the correct uid, use bindfs to link it to /opt/evap using the wanted user id
+  apt-get -q install -y bindfs
+  mkdir -p "$REPO_FOLDER"
+  bindfs --map="$OWNER/1042:@$OWNER/@1042" "$MOUNTPOINT" "$REPO_FOLDER"
+  echo "sudo bindfs --map=$OWNER/1042:@$OWNER/@1042 '$MOUNTPOINT' '$REPO_FOLDER'" >> /home/$USER/.bashrc
+else
+  ln -s "$MOUNTPOINT" "$REPO_FOLDER"
+fi
 
 # make user, create home folder, set uid to the same set in the Vagrantfile (required for becoming the synced folder owner), set default shell to bash
-useradd -m -u $(stat -c "%u" "$MOUNTPOINT/evap") -s /bin/bash evap
+useradd -m -u "$(stat -c "%u" "$MOUNTPOINT/evap")" -s /bin/bash evap
 # allow ssh login
 cp -r /home/vagrant/.ssh /home/$USER/.ssh
 chown -R $USER:$USER /home/$USER/.ssh
 # allow sudo without password
 echo "$USER ALL=(ALL) NOPASSWD:ALL" | tee /etc/sudoers.d/evap
-
-# link the mounted evap folder from the home directory
-ln -s "$MOUNTPOINT" "$REPO_FOLDER"
 
 sudo -H -u $USER $EVAP_PYTHON -m venv $ENV_FOLDER
 # venv will use ensurepip to install a new version of pip. We need to update that version.
@@ -100,7 +105,7 @@ apt-get -q install -y libasound2 libgconf-2-4 libgbm1 libgtk-3-0 libnss3 libx11-
 wget https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh --no-verbose --output-document - | sudo -H -u $USER bash
 
 # setup evap
-cd "$MOUNTPOINT"
+cd "$MOUNTPOINT" || exit 1;
 sudo -H -u $USER git submodule update --init
 
 sudo -H -u $USER mkdir node_modules


### PR DESCRIPTION
This PR checks if the mounted `/evap` has **not** the correct owner and group (`1042:1042`).
If not, it uses `bindfs` instead of a symlink to create the `/opt/evap` link with correct permissions.