### PR TITLE
Javascript import maps

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -23,6 +23,14 @@
                 <link rel="icon" type="image/png" sizes="32x32" href="{% static 'images/favicon_32.png' %}" />
                 <link rel="icon" type="image/png" sizes="16x16" href="{% static 'images/favicon_16.png' %}" />
             {% endif %}
+
+            <script type="importmap">
+                {
+                    "imports": {
+                        "contact_modal": "{% static 'js/contact_modal.js' %}",
+                    }
+                }
+            </script>
         {% endblock %}
     </head>
     <body>

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -28,6 +28,11 @@
                 {
                     "imports": {
                         "contact_modal": "{% static 'js/contact_modal.js' %}",
+                        "infobox": "{% static 'js/infobox.js' %}",
+                        "notebook": "{% static 'js/notebook.js' %}",
+                        "datagrid": "{% static 'js/datagrid.js' %}",
+                        "text-answer-warnings": "{% static 'js/text-answer-warnings.js' %}",
+                        "quick-review-slider": "{% static 'js/quick-review-slider.js' %}"
                     }
                 }
             </script>
@@ -216,7 +221,7 @@
 
         </script>
         <script type="module">
-            import  { NotebookLogic } from "{% static 'js/notebook.js' %}"
+            import  { NotebookLogic } from "notebook"
 
             new NotebookLogic("#notebook").attach();
         </script>

--- a/evap/evaluation/templates/contact_modal.html
+++ b/evap/evaluation/templates/contact_modal.html
@@ -49,7 +49,7 @@
     </div>
 </div>
 <script type="module">
-    import { ContactModalLogic } from "{% static 'js/contact_modal.js' %}";
+    import { ContactModalLogic } from "contact_modal";
 
     new ContactModalLogic("{{ modal_id }}", "{{ title|escapejs }}").attach();
 </script>

--- a/evap/evaluation/templates/contact_modal.html
+++ b/evap/evaluation/templates/contact_modal.html
@@ -1,5 +1,3 @@
-{% load static %}
-
 <div class="modal fade" id="successMessageModal_{{ modal_id }}" tabindex="-1" role="dialog" aria-labelledby="successMessageModalLabel_{{ modal_id }}" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">

--- a/evap/evaluation/templates/infobox.html
+++ b/evap/evaluation/templates/infobox.html
@@ -19,7 +19,7 @@
     </div>
 
     <script type="module">
-        import { InfoboxLogic } from "{% static 'js/infobox.js' %}";
+        import { InfoboxLogic } from "infobox";
 
         new InfoboxLogic("{{ infotext.page }}").attach();
     </script>

--- a/evap/evaluation/templates/infobox.html
+++ b/evap/evaluation/templates/infobox.html
@@ -1,5 +1,3 @@
-{% load static %}
-
 {% if not infotext.is_empty %}
     <div id="infobox-{{ infotext.page }}" class="infobox callout callout-info callout-infobox">
         <div class="callout-header d-flex">

--- a/evap/evaluation/templates/log/changed_fields_entry.html
+++ b/evap/evaluation/templates/log/changed_fields_entry.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load i18n %}
 
 <p class="mt-3">

--- a/evap/evaluation/templates/log/logentries.html
+++ b/evap/evaluation/templates/log/logentries.html
@@ -1,4 +1,3 @@
-{% load static %}
 {% load i18n %}
 
 <ul class="list-group">

--- a/evap/grades/templates/grades_semester_view.html
+++ b/evap/grades/templates/grades_semester_view.html
@@ -1,7 +1,6 @@
 {% extends 'grades_semester_base.html' %}
 
 {% load infotext_templatetags %}
-{% load static %}
 
 {% block content %}
     {{ block.super }}

--- a/evap/grades/templates/grades_semester_view.html
+++ b/evap/grades/templates/grades_semester_view.html
@@ -135,7 +135,7 @@
 
 {% block additional_javascript %}
     <script type="module">
-        import {TableGrid} from "{% static 'js/datagrid.js' %}";
+        import {TableGrid} from "datagrid";
         const table = document.querySelector(".grade-course-table");
         if (table) {
             new TableGrid({

--- a/evap/results/templates/results_evaluation_detail.html
+++ b/evap/results/templates/results_evaluation_detail.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 
-{% load static %}
 {% load evaluation_filters %}
 {% load results_templatetags %}
 

--- a/evap/results/templates/results_index.html
+++ b/evap/results/templates/results_index.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 
-{% load static %}
 {% load results_templatetags %}
 {% load evaluation_filters %}
 

--- a/evap/results/templates/results_index.html
+++ b/evap/results/templates/results_index.html
@@ -128,7 +128,7 @@
 
 {% block additional_javascript %}
     <script type="module">
-        import {ResultGrid} from "{% static 'js/datagrid.js' %}";
+        import {ResultGrid} from "datagrid";
 
         new ResultGrid({
             storageKey: "results-data-grid",

--- a/evap/staff/templates/staff_evaluation_textanswers_quick.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_quick.html
@@ -192,7 +192,7 @@
 
 {% block additional_javascript %}
     <script type="module">
-        import { QuickReviewSlider } from "{% static 'js/quick-review-slider.js' %}";
+        import { QuickReviewSlider } from "quick-review-slider";
 
         const slider = new QuickReviewSlider(
             document.querySelector(".slider"),

--- a/evap/staff/templates/staff_evaluation_textanswers_quick.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_quick.html
@@ -1,7 +1,5 @@
 {% extends 'staff_evaluation_textanswers.html' %}
 
-{% load static %}
-
 {% block content %}
     {{ block.super }}
 

--- a/evap/staff/templates/staff_questionnaire_index.html
+++ b/evap/staff/templates/staff_questionnaire_index.html
@@ -67,7 +67,7 @@
 
 {% block additional_javascript %}
     <script type="module">
-        import {QuestionnaireGrid} from "{% static 'js/datagrid.js' %}";
+        import {QuestionnaireGrid} from "datagrid";
         document.querySelectorAll(".questionnaire-table").forEach(table => {
             new QuestionnaireGrid({
                 storageKey: "questionnaires-data-grid",

--- a/evap/staff/templates/staff_questionnaire_index.html
+++ b/evap/staff/templates/staff_questionnaire_index.html
@@ -1,7 +1,5 @@
 {% extends 'staff_questionnaire_base.html' %}
 
-{% load static %}
-
 {% block content %}
     {{ block.super }}
     <div class="row mb-3 align-items-center">

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -1,6 +1,5 @@
 {% extends 'staff_semester_base.html' %}
 
-{% load static %}
 {% load evaluation_filters %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -602,7 +602,7 @@
         });
     </script>
     <script type="module">
-        import {EvaluationGrid, TableGrid} from "{% static 'js/datagrid.js' %}";
+        import {EvaluationGrid, TableGrid} from "datagrid";
         const evaluationTable = document.querySelector("#evaluation-table");
         if (evaluationTable) {
             new EvaluationGrid({

--- a/evap/staff/templates/staff_text_answer_warnings.html
+++ b/evap/staff/templates/staff_text_answer_warnings.html
@@ -98,7 +98,7 @@
     {{ text_answer_warnings|text_answer_warning_trigger_strings|json_script:'text-answer-warnings' }}
 
     <script type="module">
-        import {initTextAnswerWarnings} from "{% static 'js/text-answer-warnings.js' %}";
+        import {initTextAnswerWarnings} from "text-answer-warnings";
 
         initTextAnswerWarnings([document.querySelector("#preview-textarea")], JSON.parse(document.getElementById("text-answer-warnings").textContent));
 

--- a/evap/staff/templates/staff_user_index.html
+++ b/evap/staff/templates/staff_user_index.html
@@ -1,7 +1,5 @@
 {% extends 'staff_base.html' %}
 
-{% load static %}
-
 {% block breadcrumb %}
     {{ block.super }}
     <li class="breadcrumb-item">{% trans 'Users' %}</li>

--- a/evap/staff/templates/staff_user_list.html
+++ b/evap/staff/templates/staff_user_list.html
@@ -66,7 +66,7 @@
 
 {% block additional_javascript %}
     <script type="module">
-        import {TableGrid} from "{% static 'js/datagrid.js' %}";
+        import {TableGrid} from "datagrid";
         new TableGrid({
             storageKey: "user-index-data-grid",
             table: document.querySelector(".user-table"),

--- a/evap/staff/templates/staff_user_list.html
+++ b/evap/staff/templates/staff_user_list.html
@@ -1,7 +1,5 @@
 {% extends 'staff_base.html' %}
 
-{% load static %}
-
 {% block breadcrumb %}
     {{ block.super }}
     <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% trans 'Users' %}</a></li>

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -176,7 +176,7 @@
         {{ text_answer_warnings|text_answer_warning_trigger_strings|json_script:'text-answer-warnings' }}
 
         <script type="module">
-            import {initTextAnswerWarnings} from "{% static 'js/text-answer-warnings.js' %}";
+            import {initTextAnswerWarnings} from "text-answer-warnings";
             const lastSavedStorageKey = "student-vote-last-saved-at-{{ evaluation.id }}-{{ request.user.id }}";
             const textResultsPublishConfirmation = {
                 top: document.querySelector("#text_results_publish_confirmation_top"),


### PR DESCRIPTION
Closes #2031

I haven't touched the typescript files yet, because I haven't decided between
- trying to change the imports in the typescript files from `./csrf-utils.js` to `csrf-utils` and teaching typescript how to resolve these modules, and
- just using `./csrf-utils.js` in the import map too.

I think I am slightly preferring the latter. What do you think?
