### PR TITLE
Use `translate` and `blocktranslate` template tags

### DIFF
--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -2,7 +2,7 @@
 
 {% load evaluation_filters %}
 
-{% block title %}{% trans 'Your EvaP' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'Your EvaP' %} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb_bar %}
     <div class="breadcrumb-bar">
@@ -31,21 +31,21 @@
         {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
-                <h5 class="card-title">{% trans 'Course data' %}</h5>
+                <h5 class="card-title">{% translate 'Course data' %}</h5>
                 <div class="d-flex">
-                    <label class="col-md-3 pe-4 form-label">{% trans 'Name (German)' %}</label>
+                    <label class="col-md-3 pe-4 form-label">{% translate 'Name (German)' %}</label>
                     <div class="col-md-7 form-static-text">{{ evaluation.course.name_de }}</div>
                 </div>
                 <div class="d-flex">
-                    <label class="col-md-3 pe-4 form-label">{% trans 'Name (English)' %}</label>
+                    <label class="col-md-3 pe-4 form-label">{% translate 'Name (English)' %}</label>
                     <div class="col-md-7 form-static-text">{{ evaluation.course.name_en }}</div>
                 </div>
                 <div class="d-flex">
-                    <label class="col-md-3 pe-4 form-label">{% trans 'Responsibles' %}</label>
+                    <label class="col-md-3 pe-4 form-label">{% translate 'Responsibles' %}</label>
                     <div class="col-md-7 form-static-text">{{ evaluation.course.responsibles_names }}</div>
                 </div>
                 <div class="d-flex">
-                    <label class="col-md-3 pe-4 form-label">{% trans 'Degrees' %}</label>
+                    <label class="col-md-3 pe-4 form-label">{% translate 'Degrees' %}</label>
                     <div class="col-md-7 form-static-text">
                         {% for degree in evaluation.course.degrees.all %}
                             <span class="badge bg-primary">{{ degree }}</span>
@@ -53,7 +53,7 @@
                     </div>
                 </div>
                 <div class="d-flex">
-                    <label class="col-md-3 pe-4 form-label">{% trans 'Course type' %}</label>
+                    <label class="col-md-3 pe-4 form-label">{% translate 'Course type' %}</label>
                     <div class="col-md-7 form-static-text">
                         <span class="badge bg-secondary">{{ evaluation.course.type }}</span>
                     </div>
@@ -63,17 +63,17 @@
         <div class="card mb-3">
             <div class="card-body table-responsive">
                 <div class="d-flex">
-                    <h5 class="card-title me-auto">{% trans 'Evaluation data' %}</h5>
+                    <h5 class="card-title me-auto">{% translate 'Evaluation data' %}</h5>
                     {% if evaluation.allow_editors_to_edit %}
                         <div>
                             <button type="button" class="btn btn-sm btn-light mb-3 createAccountRequestModalShowButton">
-                                {% trans 'Request creation of new account' %}
+                                {% translate 'Request creation of new account' %}
                             </button>
                         </div>
                     {% else %}
                         <div>
                             <button type="button" class="btn btn-sm btn-light changeEvaluationRequestModalShowButton">
-                                {% trans 'Request changes' %}
+                                {% translate 'Request changes' %}
                             </button>
                         </div>
                     {% endif %}
@@ -90,22 +90,22 @@
         <div class="card card-submit-area card-submit-area-3 text-center mb-3">
             <div class="card-body">
                 {% if editable %}
-                    <button name="operation" value="preview" type="submit" class="btn btn-light">{% trans 'Preview' %}</button>
-                    <button name="operation" value="save" type="submit" class="btn btn-primary">{% trans 'Save' %}</button>
+                    <button name="operation" value="preview" type="submit" class="btn btn-light">{% translate 'Preview' %}</button>
+                    <button name="operation" value="save" type="submit" class="btn btn-primary">{% translate 'Save' %}</button>
 
                     <confirmation-modal type="submit" name="operation" value="approve">
-                        <span slot="title">{% trans 'Approve evaluation' %}</span>
-                        <span slot="action-text">{% trans 'Approve evaluation' %}</span>
+                        <span slot="title">{% translate 'Approve evaluation' %}</span>
+                        <span slot="action-text">{% translate 'Approve evaluation' %}</span>
                         <span slot="question">
                             {% blocktrans trimmed %}
                                 Do you want to approve this evaluation? This will allow the evaluation team to proceed with the preparation, but you won't be able to make any further changes.
                             {% endblocktrans %}
                         </span>
 
-                        <button slot="show-button" type="button" class="btn btn-success">{% trans 'Save and approve' %}</button>
+                        <button slot="show-button" type="button" class="btn btn-success">{% translate 'Save and approve' %}</button>
                     </confirmation-modal>
                 {% endif %}
-                <a href="{% url 'contributor:index' %}" class="btn btn-light">{% if edit %}{% trans 'Cancel' %}{% else %}{% trans 'Back' %}{% endif %}</a>
+                <a href="{% url 'contributor:index' %}" class="btn btn-light">{% if edit %}{% translate 'Cancel' %}{% else %}{% translate 'Back' %}{% endif %}</a>
             </div>
         </div>
     </form>
@@ -115,14 +115,14 @@
             <div class="modal-dialog modal-xl" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title" id="previewModalLabel">{% trans 'Preview' %}</h5>
+                        <h5 class="modal-title" id="previewModalLabel">{% translate 'Preview' %}</h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         {{ preview_html }}
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% trans 'Close' %}</button>
+                        <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% translate 'Close' %}</button>
                     </div>
                 </div>
             </div>
@@ -134,11 +134,11 @@
     {{ block.super }}
 
     {% blocktrans asvar title with evaluation_name=evaluation.full_name %}Request account creation for {{ evaluation_name }}{% endblocktrans %}
-    {% trans 'Please tell us which new account we should create. We need the name and email for all new accounts.' as teaser %}
+    {% translate 'Please tell us which new account we should create. We need the name and email for all new accounts.' as teaser %}
     {% include 'contact_modal.html' with modal_id='createAccountRequestModal' user=request.user title=title teaser=teaser %}
 
     {% blocktrans asvar title with evaluation_name=evaluation.full_name %}Request evaluation changes for {{ evaluation_name }}{% endblocktrans %}
-    {% trans 'Please tell us what changes to the evaluation we should make.' as teaser %}
+    {% translate 'Please tell us what changes to the evaluation we should make.' as teaser %}
     {% include 'contact_modal.html' with modal_id='changeEvaluationRequestModal' user=request.user title=title teaser=teaser %}
 {% endblock %}
 

--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -18,9 +18,9 @@
 
     <div class="callout callout-info small">
         {% if editable %}
-            {% blocktrans %}Please review the evaluation's details below, add all contributors and select suitable questionnaires. Once everything is okay, please approve the evaluation on the bottom of the page.{% endblocktrans %}
+            {% blocktranslate %}Please review the evaluation's details below, add all contributors and select suitable questionnaires. Once everything is okay, please approve the evaluation on the bottom of the page.{% endblocktrans %}
         {% else %}
-            {% blocktrans %}You cannot edit this evaluation because it has already been approved.{% endblocktrans %}
+            {% blocktranslate %}You cannot edit this evaluation because it has already been approved.{% endblocktrans %}
         {% endif %}
     </div>
     <h3>
@@ -97,7 +97,7 @@
                         <span slot="title">{% translate 'Approve evaluation' %}</span>
                         <span slot="action-text">{% translate 'Approve evaluation' %}</span>
                         <span slot="question">
-                            {% blocktrans trimmed %}
+                            {% blocktranslate trimmed %}
                                 Do you want to approve this evaluation? This will allow the evaluation team to proceed with the preparation, but you won't be able to make any further changes.
                             {% endblocktrans %}
                         </span>
@@ -133,11 +133,11 @@
 {% block modals %}
     {{ block.super }}
 
-    {% blocktrans asvar title with evaluation_name=evaluation.full_name %}Request account creation for {{ evaluation_name }}{% endblocktrans %}
+    {% blocktranslate asvar title with evaluation_name=evaluation.full_name %}Request account creation for {{ evaluation_name }}{% endblocktrans %}
     {% translate 'Please tell us which new account we should create. We need the name and email for all new accounts.' as teaser %}
     {% include 'contact_modal.html' with modal_id='createAccountRequestModal' user=request.user title=title teaser=teaser %}
 
-    {% blocktrans asvar title with evaluation_name=evaluation.full_name %}Request evaluation changes for {{ evaluation_name }}{% endblocktrans %}
+    {% blocktranslate asvar title with evaluation_name=evaluation.full_name %}Request evaluation changes for {{ evaluation_name }}{% endblocktrans %}
     {% translate 'Please tell us what changes to the evaluation we should make.' as teaser %}
     {% include 'contact_modal.html' with modal_id='changeEvaluationRequestModal' user=request.user title=title teaser=teaser %}
 {% endblock %}

--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -18,9 +18,9 @@
 
     <div class="callout callout-info small">
         {% if editable %}
-            {% blocktranslate %}Please review the evaluation's details below, add all contributors and select suitable questionnaires. Once everything is okay, please approve the evaluation on the bottom of the page.{% endblocktrans %}
+            {% blocktranslate %}Please review the evaluation's details below, add all contributors and select suitable questionnaires. Once everything is okay, please approve the evaluation on the bottom of the page.{% endblocktranslate %}
         {% else %}
-            {% blocktranslate %}You cannot edit this evaluation because it has already been approved.{% endblocktrans %}
+            {% blocktranslate %}You cannot edit this evaluation because it has already been approved.{% endblocktranslate %}
         {% endif %}
     </div>
     <h3>
@@ -99,7 +99,7 @@
                         <span slot="question">
                             {% blocktranslate trimmed %}
                                 Do you want to approve this evaluation? This will allow the evaluation team to proceed with the preparation, but you won't be able to make any further changes.
-                            {% endblocktrans %}
+                            {% endblocktranslate %}
                         </span>
 
                         <button slot="show-button" type="button" class="btn btn-success">{% translate 'Save and approve' %}</button>
@@ -133,11 +133,11 @@
 {% block modals %}
     {{ block.super }}
 
-    {% blocktranslate asvar title with evaluation_name=evaluation.full_name %}Request account creation for {{ evaluation_name }}{% endblocktrans %}
+    {% blocktranslate asvar title with evaluation_name=evaluation.full_name %}Request account creation for {{ evaluation_name }}{% endblocktranslate %}
     {% translate 'Please tell us which new account we should create. We need the name and email for all new accounts.' as teaser %}
     {% include 'contact_modal.html' with modal_id='createAccountRequestModal' user=request.user title=title teaser=teaser %}
 
-    {% blocktranslate asvar title with evaluation_name=evaluation.full_name %}Request evaluation changes for {{ evaluation_name }}{% endblocktrans %}
+    {% blocktranslate asvar title with evaluation_name=evaluation.full_name %}Request evaluation changes for {{ evaluation_name }}{% endblocktranslate %}
     {% translate 'Please tell us what changes to the evaluation we should make.' as teaser %}
     {% include 'contact_modal.html' with modal_id='changeEvaluationRequestModal' user=request.user title=title teaser=teaser %}
 {% endblock %}

--- a/evap/contributor/templates/contributor_index.html
+++ b/evap/contributor/templates/contributor_index.html
@@ -4,7 +4,7 @@
 {% load results_templatetags %}
 {% load evaluation_filters %}
 
-{% block title %}{% trans 'Your EvaP' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'Your EvaP' %} - {{ block.super }}{% endblock %}
 
 {% block content %}
     {{ block.super }}
@@ -13,17 +13,17 @@
 
     <div class="d-flex mb-3">
         <div class="ms-auto d-print-none">
-            <a href="{% url 'contributor:export' %}" class="btn btn-sm btn-light">{% trans 'Export results' %}</a>
+            <a href="{% url 'contributor:export' %}" class="btn btn-sm btn-light">{% translate 'Export results' %}</a>
         </div>
         {% if user.is_delegate %}
             <div class="btn-switch btn-switch-light ms-2 d-print-none">
-                <div class="btn-switch-label text-break break-spaces"><span class="fas fa-people-arrows-left-right"></span> {% trans 'Delegated evaluations' %}</div>
+                <div class="btn-switch-label text-break break-spaces"><span class="fas fa-people-arrows-left-right"></span> {% translate 'Delegated evaluations' %}</div>
                 <div class="btn-switch btn-group">
                     <a href="{% url 'contributor:index' %}?show_delegated=true" role="button" class="btn btn-sm btn-light{% if show_delegated %} active{% endif %}">
-                        {% trans 'Show' %}
+                        {% translate 'Show' %}
                     </a>
                     <a href="{% url 'contributor:index' %}?show_delegated=false" role="button" class="btn btn-sm btn-light{% if not show_delegated %} active{% endif %}">
-                        {% trans 'Hide' %}
+                        {% translate 'Hide' %}
                     </a>
                 </div>
             </div>
@@ -46,10 +46,10 @@
                 <table class="table table-seamless-links table-vertically-aligned">
                     <thead>
                     <tr>
-                        <th style="width: 35%">{% trans 'Name' %}</th>
-                        <th style="width: 15%">{% trans 'State' %}</th>
-                        <th style="width: 17%">{% trans 'Evaluation period' %}</th>
-                        <th style="width: 15%">{% trans 'Participants' %}</th>
+                        <th style="width: 35%">{% translate 'Name' %}</th>
+                        <th style="width: 15%">{% translate 'State' %}</th>
+                        <th style="width: 17%">{% translate 'Evaluation period' %}</th>
+                        <th style="width: 15%">{% translate 'Participants' %}</th>
                         <th style="width: 18%"></th>
                     </tr>
                     </thead>
@@ -72,7 +72,7 @@
                                     <td></td>
                                     <td>
                                         {% if course.not_all_evaluations_are_published %}
-                                            <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Course result is not yet available.' %}">
+                                            <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Course result is not yet available.' %}">
                                                 {% include 'distribution_with_grade_disabled.html' with icon="fas fa-hourglass" %}
                                             </div>
                                         {% else %}
@@ -93,17 +93,17 @@
                                         <div class="evaluation-name">
                                             {% if evaluation.delegated_evaluation %}
                                                 <span class="text-secondary" data-bs-toggle="tooltip" data-bs-placement="top"
-                                                        title="{% trans 'You are a delegate of a contributor who can edit the evaluation.' %}">
+                                                        title="{% translate 'You are a delegate of a contributor who can edit the evaluation.' %}">
                                                     <span class="fas fa-fw fa-people-arrows-left-right"></span>
                                                 </span>
                                             {% elif evaluation.contributes_to %}
                                                 <span class="text-primary" data-bs-toggle="tooltip" data-bs-placement="top"
-                                                        title="{% trans 'You are listed as a contributor for this evaluation.' %}">
+                                                        title="{% translate 'You are listed as a contributor for this evaluation.' %}">
                                                     <span class="fas fa-person-chalkboard"></span>
                                                 </span>
                                             {% else %}
                                                 <span class="text-secondary" data-bs-toggle="tooltip" data-bs-placement="top"
-                                                        title="{% trans 'You are not listed as a contributor for this evaluation.' %}">
+                                                        title="{% translate 'You are not listed as a contributor for this evaluation.' %}">
                                                     <span class="fas fa-user-slash"></span>
                                                 </span>
                                             {% endif %}
@@ -120,9 +120,9 @@
                                         {% if course.evaluation_count == 1 %}
                                             {% include 'evaluation_badges.html' with mode='contributor' %}
                                         {% else %}
-                                            {% if evaluation.is_midterm_evaluation %}<span class="badge bg-dark">{% trans 'Midterm evaluation' %}</span>{% endif %}
+                                            {% if evaluation.is_midterm_evaluation %}<span class="badge bg-dark">{% translate 'Midterm evaluation' %}</span>{% endif %}
                                             {% if evaluation.is_single_result %}
-                                                <span class="badge bg-success">{% trans 'Single result' %}</span>
+                                                <span class="badge bg-success">{% translate 'Single result' %}</span>
                                             {% endif %}
                                         {% endif %}
                                     </td>
@@ -153,12 +153,12 @@
                                             {% if evaluation|is_user_editor_or_delegate:user %}
                                                 {% if evaluation.state == evaluation.State.PREPARED %}
                                                     <a href="{% url 'contributor:evaluation_edit' evaluation.id %}" class="btn btn-primary btn-row-hover"
-                                                        data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Edit or approve' %}">
+                                                        data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Edit or approve' %}">
                                                         <span class="fas fa-pencil"></span>
                                                     </a>
                                                     {% if not evaluation|has_nonresponsible_editor %}
                                                         <button class="btn btn-sm btn-dark" data-bs-toggle="tooltip"
-                                                            data-bs-placement="top" title="{% trans 'Delegate preparation' %}"
+                                                            data-bs-placement="top" title="{% translate 'Delegate preparation' %}"
                                                             data-evaluation-name="{{ evaluation.full_name }}"
                                                             data-delegation-url="{% url 'contributor:evaluation_direct_delegation' evaluation.id %}"
                                                         >
@@ -168,19 +168,19 @@
                                                 {% elif evaluation.state == evaluation.State.EDITOR_APPROVED or evaluation.state == evaluation.State.APPROVED %}
                                                     <a href="{% url 'contributor:evaluation_view' evaluation.id %}" class="btn btn-sm btn-light"
                                                         data-bs-toggle="tooltip" data-bs-placement="top"
-                                                        title="{% trans 'You already approved the evaluation, the edit form will be disabled.' %}">
+                                                        title="{% translate 'You already approved the evaluation, the edit form will be disabled.' %}">
                                                         <span class="fas fa-pencil"></span>
                                                     </a>
                                                 {% endif %}
                                             {% endif %}
                                             {% if evaluation|is_user_responsible_or_contributor_or_delegate:user %}
                                                 <a href="{% url 'contributor:evaluation_preview' evaluation.id %}" class="btn btn-sm btn-light"
-                                                    data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Preview' %}">
+                                                    data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Preview' %}">
                                                     <span class="fas fa-eye"></span>
                                                 </a>
                                             {% endif %}
                                         {% elif evaluation.state != evaluation.State.PUBLISHED and evaluation.is_single_result %}
-                                            <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'You will receive an email when the results are published.' %}">
+                                            <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'You will receive an email when the results are published.' %}">
                                                 {% include 'distribution_with_grade_disabled.html' with icon="fas fa-hourglass" weight_info=evaluation|weight_info %}
                                             </div>
                                         {% elif evaluation.state == evaluation.State.PUBLISHED %}
@@ -208,17 +208,17 @@
                     <form method="POST">
                         {% csrf_token %}
                         <div class="modal-header">
-                            <h5 class="modal-title" id="{{ modal_id }}Label">{% trans 'Delegate preparation' %}</h5>
+                            <h5 class="modal-title" id="{{ modal_id }}Label">{% translate 'Delegate preparation' %}</h5>
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">
-                            {% trans 'Do you really want to delegate the preparation of the evaluation <strong data-label=""></strong>?' %}
+                            {% translate 'Do you really want to delegate the preparation of the evaluation <strong data-label=""></strong>?' %}
                             <div class="my-4">
                                 {% include 'bootstrap_form.html' with form=delegate_selection_form wide=True %}
                             </div>
                             <div class="modal-submit-group">
-                                <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
-                                <button type="submit" id="btn-action" class="btn btn-primary ms-2">{% trans 'Delegate preparation' %}</button>
+                                <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% translate 'Cancel' %}</button>
+                                <button type="submit" id="btn-action" class="btn btn-primary ms-2">{% translate 'Delegate preparation' %}</button>
                             </div>
                         </div>
 

--- a/evap/development/templates/development_components.html
+++ b/evap/development/templates/development_components.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 
-{% block title %}{% trans 'Development' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'Development' %} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb_bar %}
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
             {% block breadcrumb %}
-                <li class="breadcrumb-item">{% trans 'Development' %}</li>
+                <li class="breadcrumb-item">{% translate 'Development' %}</li>
             {% endblock %}
         </ul>
     </div>

--- a/evap/evaluation/templates/400.html
+++ b/evap/evaluation/templates/400.html
@@ -6,5 +6,5 @@
 
 {% block content %}
     {{ block.super }}
-    <strong>{% trans 'Something seems to be broken here.' %}</strong>
+    <strong>{% translate 'Something seems to be broken here.' %}</strong>
 {% endblock %}

--- a/evap/evaluation/templates/403.html
+++ b/evap/evaluation/templates/403.html
@@ -6,5 +6,5 @@
 
 {% block content %}
     {{ block.super }}
-    <strong>{% trans 'You seem to not be allowed to view this page.' %}</strong>
+    <strong>{% translate 'You seem to not be allowed to view this page.' %}</strong>
 {% endblock %}

--- a/evap/evaluation/templates/404.html
+++ b/evap/evaluation/templates/404.html
@@ -6,5 +6,5 @@
 
 {% block content %}
     {{ block.super }}
-    <strong>{% trans 'The page you are looking for seems to be missing.' %}</strong>
+    <strong>{% translate 'The page you are looking for seems to be missing.' %}</strong>
 {% endblock %}

--- a/evap/evaluation/templates/500.html
+++ b/evap/evaluation/templates/500.html
@@ -6,5 +6,5 @@
 
 {% block content %}
     {{ block.super }}
-    <strong>{% trans 'Something seems to be broken here. The admins have been notified and will follow up with you.' %}</strong>
+    <strong>{% translate 'Something seems to be broken here. The admins have been notified and will follow up with you.' %}</strong>
 {% endblock %}

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -32,8 +32,8 @@
 
         {% block modals %}
             {% if user.is_authenticated %}
-                {% trans 'Feedback' as title %}
-                {% trans 'You are welcome to submit feedback regarding the evaluation platform or specific evaluations. Please let us know how we can improve your experience on EvaP.' as teaser %}
+                {% translate 'Feedback' as title %}
+                {% translate 'You are welcome to submit feedback regarding the evaluation platform or specific evaluations. Please let us know how we can improve your experience on EvaP.' as teaser %}
                 {% include 'contact_modal.html' with modal_id='feedbackModal' user=request.user title=title teaser=teaser %}
             {% endif %}
         {% endblock %}
@@ -45,7 +45,7 @@
             {% endblock %}
         </div>
 
-        <img class="print-brand-image d-none d-print-block" src="{% static 'images/evap.png' %}" alt="{% trans 'Evaluation Platform' %}" />
+        <img class="print-brand-image d-none d-print-block" src="{% static 'images/evap.png' %}" alt="{% translate 'Evaluation Platform' %}" />
 
         {% if user.is_authenticated %}
             {% include 'notebook.html' %}
@@ -147,16 +147,16 @@
                     }
                     const baseOptions = {
                         createOnBlur: true,
-                        placeholder: "{% trans 'Please select...' %}",
+                        placeholder: "{% translate 'Please select...' %}",
                         hidePlaceholder: true,
                         minimumInputLength,
                         render: {
                             option_create: (data, escape) => `<div class="create">${ escape(data.input) }</div>`,
                             no_results: (data, escape) => {
                                 if(data.input.length < minimumInputLength) {
-                                    return `<div class="no-results">{% trans "Please enter ${ minimumInputLength } characters or more..." %}</div>`;
+                                    return `<div class="no-results">{% translate "Please enter ${ minimumInputLength } characters or more..." %}</div>`;
                                 } else {
-                                    return '<div class="no-results">{% trans "No results found" %}</div>';
+                                    return '<div class="no-results">{% translate "No results found" %}</div>';
                                 }
                             }
                         },
@@ -169,8 +169,8 @@
                         baseOptions.render.item = (data, escape) => `<div class="w-100"><span class="w-100">${ escape(data.text) }</span></div>`;
                     }
                     if(element.multiple) {
-                        baseOptions.plugins.clear_button = {"title": "{% trans 'Remove all items' %}"};
-                        baseOptions.plugins.remove_button = {"title": "{% trans 'Remove this item' %}"};
+                        baseOptions.plugins.clear_button = {"title": "{% translate 'Remove all items' %}"};
+                        baseOptions.plugins.remove_button = {"title": "{% translate 'Remove this item' %}"};
                     }
                     new MinimumInputLengthTomSelect(element, Object.assign({}, baseOptions, additionalOptions));
                 });

--- a/evap/evaluation/templates/confirmation_modal_template.html
+++ b/evap/evaluation/templates/confirmation_modal_template.html
@@ -15,7 +15,7 @@
                     <slot name="extra-inputs"></slot>
                 </section>
                 <section class="button-area">
-                    <button class="btn btn-light" autofocus>{% trans 'Cancel' %}</button>
+                    <button class="btn btn-light" autofocus>{% translate 'Cancel' %}</button>
                     <slot name="submit-group">
                         <button class="btn ms-2" data-event-type="confirm">
                             <slot name="action-text"></slot>

--- a/evap/evaluation/templates/confirmation_text_modal.html
+++ b/evap/evaluation/templates/confirmation_text_modal.html
@@ -14,7 +14,7 @@
                         <input type="text" class="form-control" id="{{ modal_id }}ConfirmationText" oninput="{{ modal_id }}CheckValue();" />
                     </div>
                     <div class="modal-submit-group">
-                        <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
+                        <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% translate 'Cancel' %}</button>
                         <button type="button" id="{{ modal_id }}ActionButton" class="btn btn-{{ btn_type }} ms-2" data-bs-dismiss="modal" disabled>{{ action_text }}</button>
                     </div>
                 </div>

--- a/evap/evaluation/templates/contact_modal.html
+++ b/evap/evaluation/templates/contact_modal.html
@@ -4,10 +4,10 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="successMessageModalLabel_{{ modal_id }}">{% trans 'Message sent' %}</h5>
+                <h5 class="modal-title" id="successMessageModalLabel_{{ modal_id }}">{% translate 'Message sent' %}</h5>
             </div>
             <div class="modal-body">
-                {% trans 'Your message was successfully sent.' %}
+                {% translate 'Your message was successfully sent.' %}
             </div>
         </div>
     </div>
@@ -24,24 +24,24 @@
                 <div class="modal-body">
                     {{ teaser }}
                     <div class="modal-grid">
-                        <label for="{{ modal_id }}SenderName" class="control-label my-auto pe-4">{% trans 'Sender' %}</label>
+                        <label for="{{ modal_id }}SenderName" class="control-label my-auto pe-4">{% translate 'Sender' %}</label>
                         {% if modal_id == "feedbackModal" and allow_anonymous_feedback_messages %}
                             <div class="btn-group text-wrap" role="group" aria-label="{{ modal_id }} Radio Group">
                                 <input type="radio" class="btn-check" name="{{ modal_id }}RadioGroup" id="{{ modal_id }}SenderName" checked>
                                 <label class="btn btn-sm btn-outline-primary text-break" for="{{ modal_id }}SenderName">{{ user.full_name }}</label>
                                 <input type="radio" class="btn-check" name="{{ modal_id }}RadioGroup" id="{{ modal_id }}AnonymousName">
-                                <label class="btn btn-sm btn-outline-primary text-break" for="{{ modal_id }}AnonymousName">{% trans 'Anonymous' %}</label>
+                                <label class="btn btn-sm btn-outline-primary text-break" for="{{ modal_id }}AnonymousName">{% translate 'Anonymous' %}</label>
                             </div>
                         {% else %}
                             <input type="text" class="form-control mx-auto text-break" id="{{ modal_id }}SenderName" disabled value="{{ user.full_name }}"/>
                         {% endif %}
-                        <label for="{{ modal_id }}Subject" class="control-label my-auto pe-4 text-break">{% trans 'Subject' %}</label>
+                        <label for="{{ modal_id }}Subject" class="control-label my-auto pe-4 text-break">{% translate 'Subject' %}</label>
                         <input type="text" class="form-control mx-auto" id="{{ modal_id }}Subject" disabled value="{{ title }}"/>
                     </div>
                     <textarea autofocus class="form-control modal-textfield my-4" id="{{ modal_id }}MessageText"></textarea>
                     <div class="modal-submit-group">
-                        <button type="button" class="btn btn-light me-1" data-bs-dismiss="modal">{% trans 'Cancel' %}</button>
-                        <button type="submit" id="{{ modal_id }}ActionButton" class="btn btn-primary ms-1">{% trans 'Send Message' %}</button>
+                        <button type="button" class="btn btn-light me-1" data-bs-dismiss="modal">{% translate 'Cancel' %}</button>
+                        <button type="submit" id="{{ modal_id }}ActionButton" class="btn btn-primary ms-1">{% translate 'Send Message' %}</button>
                     </div>
                 </div>
             </form>

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -2,11 +2,11 @@
 
 <fieldset>
     <div class="d-flex mb-2">
-        <h5 class="card-title me-auto">{% trans 'Contributors' %}</h5>
+        <h5 class="card-title me-auto">{% translate 'Contributors' %}</h5>
         {% if not manager %}
             <div>
                 <button type="button" class="btn btn-sm btn-light" id="createAccountRequestModalShowButton">
-                    {% trans 'Request creation of new account' %}
+                    {% translate 'Request creation of new account' %}
                 </button>
             </div>
         {% endif %}
@@ -18,9 +18,9 @@
         <thead>
             <tr>
                 <th></th>
-                <th style="width: 30%">{% trans 'Contributor' %}</th>
-                <th style="width: 30%">{% trans 'Questionnaires' %}</th>
-                <th style="width: 30%">{% trans 'Options' %}</th>
+                <th style="width: 30%">{% translate 'Contributor' %}</th>
+                <th style="width: 30%">{% translate 'Questionnaires' %}</th>
+                <th style="width: 30%">{% translate 'Options' %}</th>
                 <th style="width: 10%"></th>
             </tr>
         </thead>
@@ -50,13 +50,13 @@
                         {% include 'questionnaires_widget.html' with field=form.questionnaires questionnaires_with_answers=questionnaires_with_answers_per_contributor|get:form.instance.contributor %}
                     </td>
                     <td>
-                        {% trans 'Responsibility' %}:<br />
+                        {% translate 'Responsibility' %}:<br />
                         {% include 'role_buttons.html' with form=form %}
                         <br /><br />
-                        {% trans 'Text answer visibility' %}:<br />
+                        {% translate 'Text answer visibility' %}:<br />
                         {% include 'textanswer_visibility_buttons.html' with form=form %}
                         <br /><br />
-                        <span class="{% if form.label.errors %}error-label{% endif %}">{% trans 'Label' %}:
+                        <span class="{% if form.label.errors %}error-label{% endif %}">{% translate 'Label' %}:
                             <span data-bs-toggle="tooltip" data-bs-placement="right" class="fas fa-circle-info"
                                 title="{% blocktrans %}This text will be shown next to the contributor's name in the questionnaire.{% endblocktrans %}">
                             </span>

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -38,7 +38,7 @@
                         {% endfor %}
                         {% include 'bootstrap_form_errors.html' with errors=form.contributor.errors %}
                         {{ form.contributor }}
-                        <div class="form-check mt-2" data-bs-toggle="tooltip" data-bs-placement="right" title="{% blocktranslate %}Select this option if no questions about this person shall be included in the evaluation. This can be used if the person does not visibly contribute and is solely added to receive permissions for editing the evaluation or viewing text answers.{% endblocktrans %}">
+                        <div class="form-check mt-2" data-bs-toggle="tooltip" data-bs-placement="right" title="{% blocktranslate %}Select this option if no questions about this person shall be included in the evaluation. This can be used if the person does not visibly contribute and is solely added to receive permissions for editing the evaluation or viewing text answers.{% endblocktranslate %}">
                             <input class="form-check-input" id="{{ form.does_not_contribute.id_for_label }}" name="{{ form.does_not_contribute.html_name }}"
                                 type="checkbox"{% if form.does_not_contribute.value %} checked{% endif %}
                                 {% if form.does_not_contribute.field.disabled %} disabled{% endif %} />
@@ -58,7 +58,7 @@
                         <br /><br />
                         <span class="{% if form.label.errors %}error-label{% endif %}">{% translate 'Label' %}:
                             <span data-bs-toggle="tooltip" data-bs-placement="right" class="fas fa-circle-info"
-                                title="{% blocktranslate %}This text will be shown next to the contributor's name in the questionnaire.{% endblocktrans %}">
+                                title="{% blocktranslate %}This text will be shown next to the contributor's name in the questionnaire.{% endblocktranslate %}">
                             </span>
                         </span>
                         <br />

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -38,7 +38,7 @@
                         {% endfor %}
                         {% include 'bootstrap_form_errors.html' with errors=form.contributor.errors %}
                         {{ form.contributor }}
-                        <div class="form-check mt-2" data-bs-toggle="tooltip" data-bs-placement="right" title="{% blocktrans %}Select this option if no questions about this person shall be included in the evaluation. This can be used if the person does not visibly contribute and is solely added to receive permissions for editing the evaluation or viewing text answers.{% endblocktrans %}">
+                        <div class="form-check mt-2" data-bs-toggle="tooltip" data-bs-placement="right" title="{% blocktranslate %}Select this option if no questions about this person shall be included in the evaluation. This can be used if the person does not visibly contribute and is solely added to receive permissions for editing the evaluation or viewing text answers.{% endblocktrans %}">
                             <input class="form-check-input" id="{{ form.does_not_contribute.id_for_label }}" name="{{ form.does_not_contribute.html_name }}"
                                 type="checkbox"{% if form.does_not_contribute.value %} checked{% endif %}
                                 {% if form.does_not_contribute.field.disabled %} disabled{% endif %} />
@@ -58,7 +58,7 @@
                         <br /><br />
                         <span class="{% if form.label.errors %}error-label{% endif %}">{% translate 'Label' %}:
                             <span data-bs-toggle="tooltip" data-bs-placement="right" class="fas fa-circle-info"
-                                title="{% blocktrans %}This text will be shown next to the contributor's name in the questionnaire.{% endblocktrans %}">
+                                title="{% blocktranslate %}This text will be shown next to the contributor's name in the questionnaire.{% endblocktrans %}">
                             </span>
                         </span>
                         <br />

--- a/evap/evaluation/templates/course_badges.html
+++ b/evap/evaluation/templates/course_badges.html
@@ -2,4 +2,4 @@
     <span class="badge bg-primary">{{ degree }}</span>
 {% endfor %}
 <span class="badge bg-secondary">{{ course.type }}</span>
-{% if course.is_private %}<span class="badge bg-dark">{% trans 'private' %}</span>{% endif %}
+{% if course.is_private %}<span class="badge bg-dark">{% translate 'private' %}</span>{% endif %}

--- a/evap/evaluation/templates/evaluation_badges.html
+++ b/evap/evaluation/templates/evaluation_badges.html
@@ -7,14 +7,14 @@
     <span class="badge bg-secondary badge-course-type">{{ evaluation.course.type }}</span>
 {% endif %}
 {% if evaluation.is_single_result %}
-    <span class="badge bg-success">{% trans 'Single result' %}</span>
+    <span class="badge bg-success">{% translate 'Single result' %}</span>
 {% endif %}
-{% if evaluation.is_midterm_evaluation %}<span class="badge bg-dark">{% trans 'Midterm evaluation' %}</span>{% endif %}
+{% if evaluation.is_midterm_evaluation %}<span class="badge bg-dark">{% translate 'Midterm evaluation' %}</span>{% endif %}
 {% if mode == 'manager' and not evaluation.is_single_result %}
-    {% if not evaluation.wait_for_grade_upload_before_publishing %}<span class="badge bg-dark">{% trans 'not graded' %}</span>{% endif %}
-    {% if not evaluation.is_rewarded %}<span class="badge bg-dark">{% trans 'not rewarded' %}</span>{% endif %}
-    {% if evaluation.course.is_private %}<span class="badge bg-dark">{% trans 'private' %}</span>{% endif %}
+    {% if not evaluation.wait_for_grade_upload_before_publishing %}<span class="badge bg-dark">{% translate 'not graded' %}</span>{% endif %}
+    {% if not evaluation.is_rewarded %}<span class="badge bg-dark">{% translate 'not rewarded' %}</span>{% endif %}
+    {% if evaluation.course.is_private %}<span class="badge bg-dark">{% translate 'private' %}</span>{% endif %}
     {% if evaluation.course.has_external_responsible %}
-        <span class="badge bg-warning">{% trans 'External responsible' %}</span>
+        <span class="badge bg-warning">{% translate 'External responsible' %}</span>
     {% endif %}
 {% endif %}

--- a/evap/evaluation/templates/external_user_confirm_login.html
+++ b/evap/evaluation/templates/external_user_confirm_login.html
@@ -18,7 +18,7 @@
                 <form class="d-flex flex-column" role="form" method="POST">
                     {% csrf_token %}
                     <div class="d-flex justify-content-center">
-                        <button type="submit" class="btn btn-primary login-button">{% blocktranslate %}Login as {{ username }}{% endblocktrans %}</button>
+                        <button type="submit" class="btn btn-primary login-button">{% blocktranslate %}Login as {{ username }}{% endblocktranslate %}</button>
                     </div>
                 </form>
             </div>

--- a/evap/evaluation/templates/external_user_confirm_login.html
+++ b/evap/evaluation/templates/external_user_confirm_login.html
@@ -18,7 +18,7 @@
                 <form class="d-flex flex-column" role="form" method="POST">
                     {% csrf_token %}
                     <div class="d-flex justify-content-center">
-                        <button type="submit" class="btn btn-primary login-button">{% blocktrans %}Login as {{ username }}{% endblocktrans %}</button>
+                        <button type="submit" class="btn btn-primary login-button">{% blocktranslate %}Login as {{ username }}{% endblocktrans %}</button>
                     </div>
                 </form>
             </div>

--- a/evap/evaluation/templates/external_user_confirm_login.html
+++ b/evap/evaluation/templates/external_user_confirm_login.html
@@ -4,16 +4,16 @@
 {{ block.super }}
 
 <div class="jumbotron-evap">
-    <h1 class="display-4">{% trans 'Welcome to the evaluation platform!' %}</h1>
+    <h1 class="display-4">{% translate 'Welcome to the evaluation platform!' %}</h1>
     <hr class="my-4" />
     <div class="card-deck-external-login-confirm">
         <div class="card border-primary mx-auto">
             <div class="card-body">
                 <h4 class="card-title text-primary">
-                    {% trans 'Confirm your login' %}
+                    {% translate 'Confirm your login' %}
                 </h4>
                 <p class="card-text">
-                    {% trans 'By clicking this button, you will be logged in and your login link will be invalidated.' %}
+                    {% translate 'By clicking this button, you will be logged in and your login link will be invalidated.' %}
                 </p>
                 <form class="d-flex flex-column" role="form" method="POST">
                     {% csrf_token %}

--- a/evap/evaluation/templates/faq.html
+++ b/evap/evaluation/templates/faq.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 
-{% block title %}{% trans 'FAQ' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'FAQ' %} - {{ block.super }}{% endblock %}
 
 {% block content %}
-    <h2 class="mb-4">{% trans 'Frequently Asked Questions (FAQs)' %}</h2>
+    <h2 class="mb-4">{% translate 'Frequently Asked Questions (FAQs)' %}</h2>
 
     <div class="accordion accordion-flush pb-4" id="accordionFAQ">
         {% for section in sections %}

--- a/evap/evaluation/templates/footer.html
+++ b/evap/evaluation/templates/footer.html
@@ -10,10 +10,10 @@
         <div class="collapse navbar-collapse justify-content-between">
             <ul class="navbar-nav justify-content-start">
                 <li class="nav-item my-auto">
-                    <a class="nav-link nav-link-multiline" href="{% url 'evaluation:legal_notice' %}">{% trans 'Legal Notice' %}<br />{% trans 'Data Privacy' %}</a>
+                    <a class="nav-link nav-link-multiline" href="{% url 'evaluation:legal_notice' %}">{% translate 'Legal Notice' %}<br />{% translate 'Data Privacy' %}</a>
                 </li>
                 <li class="d-none d-sm-block nav-item">
-                    <a class="nav-link" href="https://github.com/e-valuation/EvaP" target="_blank"><span class="fas fa-arrow-up-right-from-square"></span> {% trans 'GitHub project' %}</a>
+                    <a class="nav-link" href="https://github.com/e-valuation/EvaP" target="_blank"><span class="fas fa-arrow-up-right-from-square"></span> {% translate 'GitHub project' %}</a>
                 </li>
             </ul>
             <div class="d-none d-lg-block navbar-nav justify-content-center text-center">
@@ -23,7 +23,7 @@
                 {% if user.is_authenticated %}
                     <span class="feedback-button">
                         <button id="feedbackModalShowButton" type="button" class="btn btn-dark">
-                            {% trans 'Problems/Feedback' %}
+                            {% translate 'Problems/Feedback' %}
                         </button>
                     </span>
                 {% endif %}

--- a/evap/evaluation/templates/index.html
+++ b/evap/evaluation/templates/index.html
@@ -4,24 +4,24 @@
     {{ block.super }}
 
     <div class="jumbotron-evap">
-        <h1 class="display-4">{% trans 'Welcome to the evaluation platform!' %}</h1>
+        <h1 class="display-4">{% translate 'Welcome to the evaluation platform!' %}</h1>
         <hr class="my-4" />
         <div class="card-deck-login">
             <div class="card border-primary">
                 <div class="card-body">
                     <h4 class="card-title text-primary">
-                        {% trans 'HPI login' %}
+                        {% translate 'HPI login' %}
                     </h4>
                     {% if openid_active %}
                         <p class="card-text">
-                            {% trans 'Log in using Keycloak.' %}
+                            {% translate 'Log in using Keycloak.' %}
                         </p>
                         <div class="text-center mt-5">
-                            <a href="{% url 'oidc_authentication_init' %}{% if 'next' in request.GET %}?next={{ request.GET.next }}{% endif %}" class="btn btn-primary login-button" autofocus>{% trans 'Login' %}</a>
+                            <a href="{% url 'oidc_authentication_init' %}{% if 'next' in request.GET %}?next={{ request.GET.next }}{% endif %}" class="btn btn-primary login-button" autofocus>{% translate 'Login' %}</a>
                         </div>
                     {% else %}
                         <p class="card-text">
-                            {% trans 'Log in using email and password.' %}
+                            {% translate 'Log in using email and password.' %}
                         </p>
                         <form id="email-login-form" class="d-flex flex-column" role="form"
                             action="{% url 'evaluation:index' %}{% if 'next' in request.GET %}?next={{ request.GET.next }}{% endif %}" method="POST">
@@ -31,7 +31,7 @@
                                 {% include 'bootstrap_form_field.html' with field=field wide=True %}
                             {% endfor %}
                             <div class="d-flex justify-content-center">
-                                <button type="submit" class="btn btn-primary login-button">{% trans 'Login' %}</button>
+                                <button type="submit" class="btn btn-primary login-button">{% translate 'Login' %}</button>
                             </div>
                         </form>
                     {% endif %}
@@ -43,16 +43,16 @@
                     {% csrf_token %}
                     <input type="hidden" name="submit_type" value="new_key" />
                     <h4 class="card-title text-dark">
-                        {% trans 'D-School, E-School and externals' %}
+                        {% translate 'D-School, E-School and externals' %}
                     </h4>
                     <p class="card-text mb-lg-auto">
-                        {% trans 'Here you can request a one-time login URL. We will send it to your email address.' %}
+                        {% translate 'Here you can request a one-time login URL. We will send it to your email address.' %}
                     </p>
                     {% include 'bootstrap_form_field.html' with field=new_key_form.email wide=True %}
                     <div class="d-flex justify-content-center">
-                        <button type="submit" class="btn btn-dark login-button">{% trans 'Request login URL' %}</button>
+                        <button type="submit" class="btn btn-dark login-button">{% translate 'Request login URL' %}</button>
                         <button type="button" class="btn btn-light ms-1" data-bs-toggle="modal" data-bs-target="#loginProblemsModal">
-                            {% trans 'Help' %}
+                            {% translate 'Help' %}
                         </button>
                     </div>
                 </form>
@@ -67,13 +67,13 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="loginProblemsModalLabel">{% trans 'Login problems' %}</h5>
+                <h5 class="modal-title" id="loginProblemsModalLabel">{% translate 'Login problems' %}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                {% trans 'You should have received an evaluation invitation via email that included a URL to login on this platform. You can also request a new login URL on this page. If you encounter any problems with your login, please let us know by answering to the evaluation email you received.' %}
+                {% translate 'You should have received an evaluation invitation via email that included a URL to login on this platform. You can also request a new login URL on this page. If you encounter any problems with your login, please let us know by answering to the evaluation email you received.' %}
                 <div class="modal-submit-group">
-                    <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% trans 'Close' %}</button>
+                    <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% translate 'Close' %}</button>
                 </div>
             </div>
         </div>

--- a/evap/evaluation/templates/legal_notice.html
+++ b/evap/evaluation/templates/legal_notice.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 
-{% block title %}{% trans 'Legal Notice' %}/{% trans 'Data Privacy Notice' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'Legal Notice' %}/{% translate 'Data Privacy Notice' %} - {{ block.super }}{% endblock %}
 
 {% block content %}
-    <h1>{% trans 'Legal Notice' %}/{% trans 'Data Privacy Notice' %}</h1>
+    <h1>{% translate 'Legal Notice' %}/{% translate 'Data Privacy Notice' %}</h1>
     <div class="card">
         <div class="card-body">
             {% include 'legal_notice_text.html' %}

--- a/evap/evaluation/templates/log/changed_fields_entry.html
+++ b/evap/evaluation/templates/log/changed_fields_entry.html
@@ -16,7 +16,7 @@
                 {% elif action.type == "clear" %}
                     {{ action.label }} {% translate "cleared" %}
                 {% elif action.type == "delete" %}
-                    {% blocktranslate with label=action.label count count=action.items|length %}{{ label }} was{% plural %}{{ label }} were{% endblocktrans %}:
+                    {% blocktranslate with label=action.label count count=action.items|length %}{{ label }} was{% plural %}{{ label }} were{% endblocktranslate %}:
                     {{ action.items|join:", " }}
                 {% elif action.type == "change" %}
                     {{ action.label }}: {{ action.items.0 }} &#8594; {{ action.items.1 }}

--- a/evap/evaluation/templates/log/changed_fields_entry.html
+++ b/evap/evaluation/templates/log/changed_fields_entry.html
@@ -16,7 +16,7 @@
                 {% elif action.type == "clear" %}
                     {{ action.label }} {% translate "cleared" %}
                 {% elif action.type == "delete" %}
-                    {% blocktrans with label=action.label count count=action.items|length %}{{ label }} was{% plural %}{{ label }} were{% endblocktrans %}:
+                    {% blocktranslate with label=action.label count count=action.items|length %}{{ label }} was{% plural %}{{ label }} were{% endblocktrans %}:
                     {{ action.items|join:", " }}
                 {% elif action.type == "change" %}
                     {{ action.label }}: {{ action.items.0 }} &#8594; {{ action.items.1 }}

--- a/evap/evaluation/templates/log/changed_fields_entry.html
+++ b/evap/evaluation/templates/log/changed_fields_entry.html
@@ -10,11 +10,11 @@
         {% for action in actions %}
             <li>
                 {% if action.type == "add" %}
-                    {{ action.label }} {% trans "added" %}: {{ action.items|join:", " }}
+                    {{ action.label }} {% translate "added" %}: {{ action.items|join:", " }}
                 {% elif action.type == "remove" %}
-                    {{ action.label }} {% trans "removed" %}: {{ action.items|join:", " }}
+                    {{ action.label }} {% translate "removed" %}: {{ action.items|join:", " }}
                 {% elif action.type == "clear" %}
-                    {{ action.label }} {% trans "cleared" %}
+                    {{ action.label }} {% translate "cleared" %}
                 {% elif action.type == "delete" %}
                     {% blocktrans with label=action.label count count=action.items|length %}{{ label }} was{% plural %}{{ label }} were{% endblocktrans %}:
                     {{ action.items|join:", " }}

--- a/evap/evaluation/templates/log/logentries.html
+++ b/evap/evaluation/templates/log/logentries.html
@@ -13,7 +13,7 @@
                     {% if log_group.0.user.is_manager %}
                         <span class="far fa-id-card fa-fw"
                               data-bs-toggle="tooltip"
-                              title="{% trans "This change was performed by a manager." %}">
+                              title="{% translate "This change was performed by a manager." %}">
                         </span>
                     {% else %}
                         <span class="fas fa-user fa-fw"></span>

--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -19,18 +19,18 @@
         <ul class="navbar-nav justify-content-center">
             {% if user.is_authenticated %}
                 {% if user.is_participant %}
-                    <li class="nav-item"><a class="nav-link" href="{% url 'student:index' %}">{% trans 'Evaluate' %}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{% url 'student:index' %}">{% translate 'Evaluate' %}</a></li>
                 {% endif %}
                 {% if user.is_responsible_or_contributor_or_delegate %}
-                    <li class="nav-item"><a class="nav-link" href="{% url 'contributor:index' %}">{% trans 'Contributions' %}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{% url 'contributor:index' %}">{% translate 'Contributions' %}</a></li>
                 {% endif %}
                 {% if user|can_reward_points_be_used_by %}
-                    <li class="nav-item"><a class="nav-link" href="{% url 'rewards:index' %}">{% trans 'Rewards' %}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{% url 'rewards:index' %}">{% translate 'Rewards' %}</a></li>
                 {% endif %}
                 {% if user.is_manager %}
-                    <li class="nav-item"><a class="nav-link" href="{% url 'staff:index' %}">{% trans 'Overview' %}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{% url 'staff:index' %}">{% translate 'Overview' %}</a></li>
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="navbarSemestersDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Semesters' %}</a>
+                        <a class="nav-link dropdown-toggle" href="#" id="navbarSemestersDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% translate 'Semesters' %}</a>
                         <div class="dropdown-menu" aria-labelledby="navbarSemestersDropdownMenuLink">
                             {% for semester in result_semesters %}
                                 <a class="dropdown-item" href="{% url 'staff:semester_view' semester.id %}">{{ semester.name }}</a>
@@ -39,7 +39,7 @@
                     </li>
                 {% elif user.is_reviewer %}
                     <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarReviewDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Review' %}</a>
+                    <a class="nav-link dropdown-toggle" href="#" id="navbarReviewDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% translate 'Review' %}</a>
                         <div class="dropdown-menu" aria-labelledby="navbarReviewDropdownMenuLink">
                             {% for semester in result_semesters %}
                                 <a class="dropdown-item" href="{% url 'staff:semester_view' semester.id %}">{{ semester.name }}</a>
@@ -48,17 +48,17 @@
                     </li>
                 {% endif %}
                 {% if not user.is_external %}
-                    <li class="nav-item"><a class="nav-link" href="{% url 'results:index' %}">{% trans 'Results' %}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{% url 'results:index' %}">{% translate 'Results' %}</a></li>
                 {% endif %}
                 {%  if user.is_manager %}
-                    <li class="nav-item"><a class="nav-link" href="{% url 'staff:user_index' %}">{% trans 'Users' %}</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{% url 'staff:questionnaire_index' %}">{% trans 'Questionnaires' %}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{% url 'staff:questionnaire_index' %}">{% translate 'Questionnaires' %}</a></li>
                 {% endif %}
                 {% if user.is_grade_publisher %}
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="{% url 'grades:index' %}" id="navbarPublishDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Publish grades' %}</a>
+                        <a class="nav-link dropdown-toggle" href="{% url 'grades:index' %}" id="navbarPublishDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% translate 'Publish grades' %}</a>
                         <div class="dropdown-menu" aria-labelledby="navbarPublishDropdownMenuLink">
-                            <a class="dropdown-item" href="{% url 'grades:index' %}">{% trans 'Semesters' %}</a>
+                            <a class="dropdown-item" href="{% url 'grades:index' %}">{% translate 'Semesters' %}</a>
                             {% for semester in grade_document_semesters %}
                                 <a class="dropdown-item dropdown-item-indent" href="{% url 'grades:semester_view' semester.id %}">{{ semester.name }}</a>
                             {% endfor %}
@@ -67,16 +67,16 @@
                 {% endif %}
                 {% if user.is_manager %}
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="navbarStaffDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'More' %}</a>
+                        <a class="nav-link dropdown-toggle" href="#" id="navbarStaffDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% translate 'More' %}</a>
                         <div class="dropdown-menu" aria-labelledby="navbarStaffDropdownMenuLink">
-                            <a class="dropdown-item" href="{% url 'staff:course_type_index' %}">{% trans 'Course types' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:degree_index' %}">{% trans 'Degrees' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:index' %}">{% trans 'Email templates' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:faq_index' %}">{% trans 'FAQ' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:infotexts' %}">{% trans 'Infotexts' %}</a>
-                            <a class="dropdown-item" href="{% url 'rewards:reward_point_redemption_events' %}">{% trans 'Reward point redemption events' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:course_type_index' %}">{% translate 'Course types' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:degree_index' %}">{% translate 'Degrees' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:index' %}">{% translate 'Email templates' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:faq_index' %}">{% translate 'FAQ' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:infotexts' %}">{% translate 'Infotexts' %}</a>
+                            <a class="dropdown-item" href="{% url 'rewards:reward_point_redemption_events' %}">{% translate 'Reward point redemption events' %}</a>
                             <a class="dropdown-item" href="{% url 'staff:text_answer_warnings' %}">
-                                {% trans 'Text answer warnings' %}
+                                {% translate 'Text answer warnings' %}
                             </a>
                         </div>
                     </li>
@@ -84,7 +84,7 @@
             {% endif %}
         </ul>
         <ul class="navbar-nav justify-content-end">
-            <li class="nav-item"><a class="nav-link" href="{% url 'evaluation:faq' %}">{% trans 'FAQ' %}</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'evaluation:faq' %}">{% translate 'FAQ' %}</a></li>
             <li class="nav-item btn-switch-navbar my-auto ps-2 pb-3 {% if user.is_participant and user.is_responsible_or_contributor_or_delegate or user.is_reviewer %}pb-xl-0{% else %}pb-lg-0{% endif %}">
                 <div class="btn-group">
                     {% for language_code, language_name in languages %}
@@ -105,13 +105,13 @@
                         <div class="btn-group">
                             <form class="d-flex" method="post" action="{% url 'staff:exit_staff_mode' %}">
                                 {% csrf_token %}
-                                <button data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Regular mode' %}" type="submit" class="btn btn-sm {% if user.is_staff == False %}active{% endif %}" onclick="setSpinnerIcon('span-exit-staff-mode')">
+                                <button data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% translate 'Regular mode' %}" type="submit" class="btn btn-sm {% if user.is_staff == False %}active{% endif %}" onclick="setSpinnerIcon('span-exit-staff-mode')">
                                     <span id="span-exit-staff-mode" class="fas fa-user"></span>
                                 </button>
                             </form>
                             <form id="enter-staff-mode-form" class="d-flex" method="post" action="{% url 'staff:enter_staff_mode' %}">
                                 {% csrf_token %}
-                                <button data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Staff mode' %}" type="submit" class="btn btn-sm {% if user.is_staff %}active{% endif %}" onclick="setSpinnerIcon('span-enter-staff-mode')">
+                                <button data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% translate 'Staff mode' %}" type="submit" class="btn btn-sm {% if user.is_staff %}active{% endif %}" onclick="setSpinnerIcon('span-enter-staff-mode')">
                                     <span id="span-enter-staff-mode" class="fas fa-briefcase"></span>
                                 </button>
                             </form>
@@ -121,10 +121,10 @@
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="navbarUserDropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="fas fa-user"></span> {{ user.full_name }}</a>
                     <div class="dropdown-menu dropdown-menu-end dropdown-menu-tight" aria-labelledby="navbarUserDropdownMenuLink">
-                        <a class="dropdown-item" href="{% url 'evaluation:profile_edit' %}">{% trans 'Profile' %}</a>
+                        <a class="dropdown-item" href="{% url 'evaluation:profile_edit' %}">{% translate 'Profile' %}</a>
                         <form method="post" action="{% url 'django-auth-logout' %}" id="logout-form">
                             {% csrf_token %}
-                            <button type="submit" class="dropdown-item">{% trans 'Logout' %}</button>
+                            <button type="submit" class="dropdown-item">{% translate 'Logout' %}</button>
                         </form>
                     </div>
                 </li>

--- a/evap/evaluation/templates/notebook.html
+++ b/evap/evaluation/templates/notebook.html
@@ -20,7 +20,7 @@
                             <span class="visible-if-successful">{% translate 'Saved successfully' %}</span>
                         </button>
                         <div class="align-self-center right-to-element">
-                            <span class="ms-2 fas fa-circle-info" data-bs-toggle="tooltip" data-bs-placement="right" title="{% blocktrans %}Here you can store private notes that you want to keep ready for future evaluations. The notes will be stored in plain text in your account on the EvaP server, but will not be shown to anyone but you.{% endblocktrans %}"></span>
+                            <span class="ms-2 fas fa-circle-info" data-bs-toggle="tooltip" data-bs-placement="right" title="{% blocktranslate %}Here you can store private notes that you want to keep ready for future evaluations. The notes will be stored in plain text in your account on the EvaP server, but will not be shown to anyone but you.{% endblocktrans %}"></span>
                         </div>
                     </div>
                 </div>

--- a/evap/evaluation/templates/notebook.html
+++ b/evap/evaluation/templates/notebook.html
@@ -4,7 +4,7 @@
         <div class="card">
             <div class="offcanvas-header pt-3 ps-3 pe-3">
                 <h5 class="card-title m-0">
-                    {% trans 'Notebook' %}
+                    {% translate 'Notebook' %}
                 </h5>
                 <button type="button" class="btn-close text-reset" data-bs-toggle="collapse" data-bs-target="#notebook" id="notebookButtonClose"></button>
             </div>
@@ -15,9 +15,9 @@
                     {{ notebook_form.notes }}
                     <div class="d-flex justify-content-center pt-3">
                         <button class="btn btn-primary" type="submit">
-                            <span class="visible-if-ready">{% trans 'Save' %}</span>
-                            <span class="visible-if-sending">{% trans 'Sending...' %}</span>
-                            <span class="visible-if-successful">{% trans 'Saved successfully' %}</span>
+                            <span class="visible-if-ready">{% translate 'Save' %}</span>
+                            <span class="visible-if-sending">{% translate 'Sending...' %}</span>
+                            <span class="visible-if-successful">{% translate 'Saved successfully' %}</span>
                         </button>
                         <div class="align-self-center right-to-element">
                             <span class="ms-2 fas fa-circle-info" data-bs-toggle="tooltip" data-bs-placement="right" title="{% blocktrans %}Here you can store private notes that you want to keep ready for future evaluations. The notes will be stored in plain text in your account on the EvaP server, but will not be shown to anyone but you.{% endblocktrans %}"></span>

--- a/evap/evaluation/templates/notebook.html
+++ b/evap/evaluation/templates/notebook.html
@@ -20,7 +20,7 @@
                             <span class="visible-if-successful">{% translate 'Saved successfully' %}</span>
                         </button>
                         <div class="align-self-center right-to-element">
-                            <span class="ms-2 fas fa-circle-info" data-bs-toggle="tooltip" data-bs-placement="right" title="{% blocktranslate %}Here you can store private notes that you want to keep ready for future evaluations. The notes will be stored in plain text in your account on the EvaP server, but will not be shown to anyone but you.{% endblocktrans %}"></span>
+                            <span class="ms-2 fas fa-circle-info" data-bs-toggle="tooltip" data-bs-placement="right" title="{% blocktranslate %}Here you can store private notes that you want to keep ready for future evaluations. The notes will be stored in plain text in your account on the EvaP server, but will not be shown to anyone but you.{% endblocktranslate %}"></span>
                         </div>
                     </div>
                 </div>

--- a/evap/evaluation/templates/profile.html
+++ b/evap/evaluation/templates/profile.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 
-{% block title %}{% trans 'Profile' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'Profile' %} - {{ block.super }}{% endblock %}
 
 {% block content %}
     {{ block.super }}
-    <h3>{% trans 'Profile' %}</h3>
+    <h3>{% translate 'Profile' %}</h3>
 
     <form id="profile-form" method="POST" class="form-horizontal multiselect-form">
         {% csrf_token %}
@@ -12,7 +12,7 @@
             <div class="col">
                 <div class="card h-100">
                     <div class="card-body">
-                        <h4 class="card-title mb-4">{% trans 'Personal information' %}</h4>
+                        <h4 class="card-title mb-4">{% translate 'Personal information' %}</h4>
                         {% for field in profile_form %}
                             {% if field != profile_form.delegates %}
                                 {% include 'bootstrap_form_field.html' with field=field %}
@@ -25,19 +25,19 @@
                 <div class="col">
                     <div class="card h-100">
                         <div class="card-body">
-                            <h4 class="card-title mb-4">{% trans 'Delegates and emails' %}</h4>
+                            <h4 class="card-title mb-4">{% translate 'Delegates and emails' %}</h4>
                             <table class="table table-vertically-aligned table-headerless">
                                 <tr>
                                     <td>
-                                        <strong>{% trans 'Your delegates' %}</strong><br />
+                                        <strong>{% translate 'Your delegates' %}</strong><br />
                                         {% include 'bootstrap_form_field_widget.html' with field=profile_form.delegates %}
-                                        <div class="form-text">{% trans 'Your delegates will receive emails sent to you in CC, will be able to prepare evaluations on your behalf, and will see the results of your evaluations.' %}</div>
+                                        <div class="form-text">{% translate 'Your delegates will receive emails sent to you in CC, will be able to prepare evaluations on your behalf, and will see the results of your evaluations.' %}</div>
                                     </td>
                                 </tr>
                                 {% if delegate_of %}
                                     <tr>
                                         <td>
-                                            <strong>{% trans 'You are a delegate of' %}</strong><br />
+                                            <strong>{% translate 'You are a delegate of' %}</strong><br />
                                             {% for delegate in delegate_of %}
                                                 {{ delegate.full_name }}{% if not forloop.last %}, {% endif %}
                                             {% endfor %}
@@ -45,11 +45,11 @@
                                     </tr>
                                 {% endif %}
                                     <td>
-                                        <strong>{% trans 'CC all my emails to' %}</strong><br />
+                                        <strong>{% translate 'CC all my emails to' %}</strong><br />
                                         {% for cc_user in cc_users %}
                                             {{ cc_user.full_name }}{% if not forloop.last %}, {% endif %}
                                         {% empty %}
-                                            <i>{% trans 'Nobody' %}</i>
+                                            <i>{% translate 'Nobody' %}</i>
                                         {% endfor %}
                                     </td>
                                 </tr>
@@ -59,7 +59,7 @@
                                         {% for ccing_user in ccing_users %}
                                             {{ ccing_user.full_name }}{% if not forloop.last %}, {% endif %}
                                         {% empty %}
-                                            <i>{% trans 'Nobody' %}</i>
+                                            <i>{% translate 'Nobody' %}</i>
                                         {% endfor %}
                                     </td>
                                 </tr>
@@ -75,10 +75,10 @@
                 <div class="card card-submit-area card-submit-area-2 text-center">
                     <div class="card-body tab-row">
                         <button type="submit" class="btn btn-primary">
-                            {% trans 'Save' %}
+                            {% translate 'Save' %}
                         </button>
                         <button type="button" class="btn btn-light" id="changeRequestModalShowButton">
-                            {% trans 'Request changes' %}
+                            {% translate 'Request changes' %}
                         </button>
                     </div>
                 </div>
@@ -89,7 +89,7 @@
 
 {% block modals %}
     {{ block.super }}
-    {% trans 'Request user setting changes' as title %}
-    {% trans 'Please tell us which of your settings we should change.' as teaser %}
+    {% translate 'Request user setting changes' as title %}
+    {% translate 'Please tell us which of your settings we should change.' as teaser %}
     {% include 'contact_modal.html' with modal_id='changeRequestModal' user=request.user title=title teaser=teaser %}
 {% endblock %}

--- a/evap/evaluation/templates/profile.html
+++ b/evap/evaluation/templates/profile.html
@@ -55,7 +55,7 @@
                                 </tr>
                                 <tr>
                                     <td>
-                                        <strong>{% blocktrans %}You receive CC'ed emails for{% endblocktrans %}</strong><br />
+                                        <strong>{% blocktranslate %}You receive CC'ed emails for{% endblocktrans %}</strong><br />
                                         {% for ccing_user in ccing_users %}
                                             {{ ccing_user.full_name }}{% if not forloop.last %}, {% endif %}
                                         {% empty %}

--- a/evap/evaluation/templates/profile.html
+++ b/evap/evaluation/templates/profile.html
@@ -55,7 +55,7 @@
                                 </tr>
                                 <tr>
                                     <td>
-                                        <strong>{% blocktranslate %}You receive CC'ed emails for{% endblocktrans %}</strong><br />
+                                        <strong>{% blocktranslate %}You receive CC'ed emails for{% endblocktranslate %}</strong><br />
                                         {% for ccing_user in ccing_users %}
                                             {{ ccing_user.full_name }}{% if not forloop.last %}, {% endif %}
                                         {% empty %}

--- a/evap/evaluation/templates/questionnaires_widget.html
+++ b/evap/evaluation/templates/questionnaires_widget.html
@@ -9,7 +9,7 @@
         {% endifchanged %}
         <li class="form-check" data-bs-toggle="tooltip" data-bs-placement="left" title="{% spaceless %}
             {% if questionnaire.is_locked and not manager %}
-                {% trans 'This questionnaire is locked, its selection cannot be changed.' %}<br /><br />
+                {% translate 'This questionnaire is locked, its selection cannot be changed.' %}<br /><br />
             {% endif %}
             {% if questionnaire.description %}
                 {{ questionnaire.description }}<br />

--- a/evap/evaluation/templates/role_buttons.html
+++ b/evap/evaluation/templates/role_buttons.html
@@ -3,9 +3,9 @@
 <div class="btn-group">
     {% for choice in form.role %}
         {% if choice.data.value == form.instance.Role.EDITOR %}
-            {% trans 'Able to edit the evaluation for preparation.' as tooltip %}
+            {% translate 'Able to edit the evaluation for preparation.' as tooltip %}
         {% elif choice.data.value == form.instance.Role.CONTRIBUTOR %}
-            {% trans 'Default value. No special rights.' as tooltip %}
+            {% translate 'Default value. No special rights.' as tooltip %}
         {% endif %}
         {% include 'choice_button.html' with formelement=form.role choice=choice tooltip=tooltip %}
     {% endfor %}

--- a/evap/evaluation/templates/startpage_button.html
+++ b/evap/evaluation/templates/startpage_button.html
@@ -1,12 +1,12 @@
 {% if user.startpage == page %}
-    <div data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'This is your startpage' %}">
+    <div data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'This is your startpage' %}">
         <button type="button" class="btn {{ btnClass }} btn-light" disabled><span class="fas fa-house"></span></button>
     </div>
 {% else %}
     <form id="startpage-form" class="d-flex" method="post" action="{% url 'evaluation:set_startpage' %}">
         {% csrf_token %}
         <input name="page" type="hidden" value="{{ page }}">
-        <button type="submit" class="btn {{ btnClass }} btn-light" onclick="setSpinnerIcon('span-set-startpage')" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Make this my startpage' %}">
+        <button type="submit" class="btn {{ btnClass }} btn-light" onclick="setSpinnerIcon('span-set-startpage')" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Make this my startpage' %}">
             <span id="span-set-startpage" class="fas fa-house"></span>
         </button>
     </form>

--- a/evap/evaluation/templates/textanswer_visibility_buttons.html
+++ b/evap/evaluation/templates/textanswer_visibility_buttons.html
@@ -1,9 +1,9 @@
 <div class="btn-group">
     {% for choice in form.textanswer_visibility %}
         {% if choice.data.value == 'GENERAL' %}
-            {% trans 'Will see own and general text answers.' as tooltip %}
+            {% translate 'Will see own and general text answers.' as tooltip %}
         {% elif choice.data.value == 'OWN' %}
-            {% trans 'Default value. Will only see own text answers.' as tooltip %}
+            {% translate 'Default value. Will only see own text answers.' as tooltip %}
         {% endif %}
         {% include 'choice_button.html' with formelement=form.textanswer_visibility choice=choice tooltip=tooltip %}
     {% endfor %}

--- a/evap/evaluation/templates/textanswer_visibility_info.html
+++ b/evap/evaluation/templates/textanswer_visibility_info.html
@@ -1,10 +1,10 @@
 <span class="far fa-eye ms-1 icon-gray" data-bs-toggle="tooltip" data-bs-placement="left" title="
     {{ intro_text }}<br />
     {% for contributor in visible_by_contribution %}
-        {{ contributor.full_name }}{% if contributor.is_proxy_user %} ({% blocktrans count delegate_count=contributor.delegates.count %}{{ delegate_count }} person{% plural %}{{ delegate_count }} people{% endblocktrans %}){% endif %}{% if not forloop.last or visible_by_delegation_count > 0 %}, {% endif %}
+        {{ contributor.full_name }}{% if contributor.is_proxy_user %} ({% blocktranslate count delegate_count=contributor.delegates.count %}{{ delegate_count }} person{% plural %}{{ delegate_count }} people{% endblocktrans %}){% endif %}{% if not forloop.last or visible_by_delegation_count > 0 %}, {% endif %}
     {% endfor %}
     {% if visible_by_delegation_count > 0 %}
-        {% blocktrans count delegate_count=visible_by_delegation_count %}{{ delegate_count }} delegate{% plural %}{{ delegate_count }} delegates{% endblocktrans %}
+        {% blocktranslate count delegate_count=visible_by_delegation_count %}{{ delegate_count }} delegate{% plural %}{{ delegate_count }} delegates{% endblocktrans %}
     {% endif %}
     {% translate 'and the evaluation team.' %}
 "></span>

--- a/evap/evaluation/templates/textanswer_visibility_info.html
+++ b/evap/evaluation/templates/textanswer_visibility_info.html
@@ -1,10 +1,10 @@
 <span class="far fa-eye ms-1 icon-gray" data-bs-toggle="tooltip" data-bs-placement="left" title="
     {{ intro_text }}<br />
     {% for contributor in visible_by_contribution %}
-        {{ contributor.full_name }}{% if contributor.is_proxy_user %} ({% blocktranslate count delegate_count=contributor.delegates.count %}{{ delegate_count }} person{% plural %}{{ delegate_count }} people{% endblocktrans %}){% endif %}{% if not forloop.last or visible_by_delegation_count > 0 %}, {% endif %}
+        {{ contributor.full_name }}{% if contributor.is_proxy_user %} ({% blocktranslate count delegate_count=contributor.delegates.count %}{{ delegate_count }} person{% plural %}{{ delegate_count }} people{% endblocktranslate %}){% endif %}{% if not forloop.last or visible_by_delegation_count > 0 %}, {% endif %}
     {% endfor %}
     {% if visible_by_delegation_count > 0 %}
-        {% blocktranslate count delegate_count=visible_by_delegation_count %}{{ delegate_count }} delegate{% plural %}{{ delegate_count }} delegates{% endblocktrans %}
+        {% blocktranslate count delegate_count=visible_by_delegation_count %}{{ delegate_count }} delegate{% plural %}{{ delegate_count }} delegates{% endblocktranslate %}
     {% endif %}
     {% translate 'and the evaluation team.' %}
 "></span>

--- a/evap/evaluation/templates/textanswer_visibility_info.html
+++ b/evap/evaluation/templates/textanswer_visibility_info.html
@@ -6,5 +6,5 @@
     {% if visible_by_delegation_count > 0 %}
         {% blocktrans count delegate_count=visible_by_delegation_count %}{{ delegate_count }} delegate{% plural %}{{ delegate_count }} delegates{% endblocktrans %}
     {% endif %}
-    {% trans 'and the evaluation team.' %}
+    {% translate 'and the evaluation team.' %}
 "></span>

--- a/evap/evaluation/templates/user_list_with_links.html
+++ b/evap/evaluation/templates/user_list_with_links.html
@@ -6,6 +6,6 @@
     </ul>
 {% else %}
     <p class="fst-italic">
-        {% trans 'Nobody' %}
+        {% translate 'Nobody' %}
     </p>
 {% endif %}

--- a/evap/grades/templates/grades_base.html
+++ b/evap/grades/templates/grades_base.html
@@ -1,15 +1,15 @@
 {% extends 'base.html' %}
 
-{% block title %}{% trans 'Grade publishing' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'Grade publishing' %} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb_bar %}
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
             {% block breadcrumb %}
                 {% if disable_breadcrumb_grades or not user.is_grade_publisher %}
-                    <li class="breadcrumb-item">{% trans 'Grade publishing' %}</li>
+                    <li class="breadcrumb-item">{% translate 'Grade publishing' %}</li>
                 {% else %}
-                    <li class="breadcrumb-item"><a href="{% url 'grades:index' %}">{% trans 'Grade publishing' %}</a></li>
+                    <li class="breadcrumb-item"><a href="{% url 'grades:index' %}">{% translate 'Grade publishing' %}</a></li>
                 {% endif %}
             {% endblock %}
         </ul>

--- a/evap/grades/templates/grades_course_view.html
+++ b/evap/grades/templates/grades_course_view.html
@@ -38,7 +38,7 @@
                                             <span slot="title">{% translate 'Delete grade document' %}</span>
                                             <span slot="action-text">{% translate 'Delete grade document' %}</span>
                                             <span slot="question">
-                                                {% blocktrans trimmed with description=grade_document.description %}
+                                                {% blocktranslate trimmed with description=grade_document.description %}
                                                     Do you really want to delete the grade document <strong>{{ description }}</strong>?
                                                 {% endblocktrans %}
                                             </span>

--- a/evap/grades/templates/grades_course_view.html
+++ b/evap/grades/templates/grades_course_view.html
@@ -7,7 +7,7 @@
 
     <div class="card mb-3">
         <div class="card-header">
-            {% trans 'Uploaded grade documents' %}
+            {% translate 'Uploaded grade documents' %}
         </div>
         <div class="card-body table-responsive">
             {% if grade_documents %}
@@ -18,10 +18,10 @@
                 <table class="table table-striped table-vertically-aligned">
                     <thead>
                         <tr>
-                            <th style="width: 40%">{% trans 'Description' %}</th>
-                            <th style="width: 20%">{% trans 'Type' %}</th>
-                            <th style="width: 25%">{% trans 'Last edited' %}</th>
-                            <th style="width: 15%">{% trans 'Actions' %}</th>
+                            <th style="width: 40%">{% translate 'Description' %}</th>
+                            <th style="width: 20%">{% translate 'Type' %}</th>
+                            <th style="width: 25%">{% translate 'Last edited' %}</th>
+                            <th style="width: 15%">{% translate 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -29,21 +29,21 @@
                             <tr id="grade-document-row-{{ grade_document.id }}">
                                 <td>{{ grade_document.description }}</td>
                                 <td>{{ grade_document.get_type_display }}</td>
-                                <td>{{ grade_document.last_modified_time }}, {% trans 'by' %} {{ grade_document.last_modified_user }}</td>
+                                <td>{{ grade_document.last_modified_time }}, {% translate 'by' %} {{ grade_document.last_modified_user }}</td>
                                 <td>
-                                    <a href="{% url 'grades:download_grades' grade_document.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Download' %}"><span class="fas fa-download"></span></a>
+                                    <a href="{% url 'grades:download_grades' grade_document.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Download' %}"><span class="fas fa-download"></span></a>
                                     {% if user.is_grade_publisher %}
-                                        <a href="{% url 'grades:edit_grades' grade_document.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Edit' %}"><span class="fas fa-pencil"></span></a>
+                                        <a href="{% url 'grades:edit_grades' grade_document.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Edit' %}"><span class="fas fa-pencil"></span></a>
                                         <confirmation-modal type="submit" form="grade-document-deletion-form" name="grade_document_id" value="{{ grade_document.id }}" confirm-button-class="btn-danger">
-                                            <span slot="title">{% trans 'Delete grade document' %}</span>
-                                            <span slot="action-text">{% trans 'Delete grade document' %}</span>
+                                            <span slot="title">{% translate 'Delete grade document' %}</span>
+                                            <span slot="action-text">{% translate 'Delete grade document' %}</span>
                                             <span slot="question">
                                                 {% blocktrans trimmed with description=grade_document.description %}
                                                     Do you really want to delete the grade document <strong>{{ description }}</strong>?
                                                 {% endblocktrans %}
                                             </span>
 
-                                            <button slot="show-button" type="button" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
+                                            <button slot="show-button" type="button" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Delete' %}">
                                                 <span class="fas fa-trash"></span>
                                             </button>
                                         </confirmation-modal>
@@ -60,12 +60,12 @@
                     });
                 </script>
             {% else %}
-                <span class="fst-italic">{% trans 'No grade documents have been uploaded yet' %}</span>
+                <span class="fst-italic">{% translate 'No grade documents have been uploaded yet' %}</span>
             {% endif %}
         </div>
     </div>
     {% if user.is_grade_publisher %}
-        <a href="{% url 'grades:upload_grades' course.id %}" class="btn btn-dark">{% trans 'Upload new midterm grades' %}</a>
-        <a href="{% url 'grades:upload_grades' course.id %}?final=true" class="btn btn-dark">{% trans 'Upload new final grades' %}</a>
+        <a href="{% url 'grades:upload_grades' course.id %}" class="btn btn-dark">{% translate 'Upload new midterm grades' %}</a>
+        <a href="{% url 'grades:upload_grades' course.id %}?final=true" class="btn btn-dark">{% translate 'Upload new final grades' %}</a>
     {% endif %}
 {% endblock %}

--- a/evap/grades/templates/grades_course_view.html
+++ b/evap/grades/templates/grades_course_view.html
@@ -40,7 +40,7 @@
                                             <span slot="question">
                                                 {% blocktranslate trimmed with description=grade_document.description %}
                                                     Do you really want to delete the grade document <strong>{{ description }}</strong>?
-                                                {% endblocktrans %}
+                                                {% endblocktranslate %}
                                             </span>
 
                                             <button slot="show-button" type="button" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Delete' %}">

--- a/evap/grades/templates/grades_index.html
+++ b/evap/grades/templates/grades_index.html
@@ -5,7 +5,7 @@
 {% block content %}
     {% show_infotext "grades_pages" %}
 
-    <h3>{% trans 'Semesters' %}</h3>
+    <h3>{% translate 'Semesters' %}</h3>
     <div class="card mb-3">
         <div class="card-body">
             {% if semesters %}
@@ -15,7 +15,7 @@
                 {% endfor %}
                 </ul>
             {% else %}
-                {% trans 'There are no semesters yet.' %}
+                {% translate 'There are no semesters yet.' %}
             {% endif %}
         </div>
     </div>

--- a/evap/grades/templates/grades_semester_view.html
+++ b/evap/grades/templates/grades_semester_view.html
@@ -18,8 +18,8 @@
                 </div>
             {% endif %}
             <div class="input-group">
-                <input type="search" name="search" class="form-control" placeholder="{% trans 'Search...' %}" />
-                <button class="btn btn-light text-secondary" type="button" data-reset="search" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Clear search filter' %}">
+                <input type="search" name="search" class="form-control" placeholder="{% translate 'Search...' %}" />
+                <button class="btn btn-light text-secondary" type="button" data-reset="search" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Clear search filter' %}">
                     <span class="fas fa-delete-left"></span>
                 </button>
             </div>
@@ -28,19 +28,19 @@
 
     <div class="card">
         <div class="card-header">
-            {% trans 'Courses' %}
+            {% translate 'Courses' %}
         </div>
         <div class="card-body table-responsive">
             {% if courses %}
                 <table class="table table-striped grade-course-table table-vertically-aligned">
                     <thead>
                         <tr>
-                            <th style="width: 35%" class="col-order" data-col="name">{% trans 'Name' %}</th>
-                            <th style="width: 20%" class="col-order" data-col="responsible">{% trans 'Responsible' %}</th>
-                            <th style="width: 10%" class="col-order" data-col="complete">{% trans 'Evaluation completed' %}</th>
-                            <th style="width: 10%" class="col-order" data-col="midterm-grades">{% trans 'Midterm grade documents' %}</th>
-                            <th style="width: 10%" class="col-order" data-col="final-grades">{% trans 'Final grade documents' %}</th>
-                            <th style="width: 15%" class="text-end">{% trans 'Actions' %}</th>
+                            <th style="width: 35%" class="col-order" data-col="name">{% translate 'Name' %}</th>
+                            <th style="width: 20%" class="col-order" data-col="responsible">{% translate 'Responsible' %}</th>
+                            <th style="width: 10%" class="col-order" data-col="complete">{% translate 'Evaluation completed' %}</th>
+                            <th style="width: 10%" class="col-order" data-col="midterm-grades">{% translate 'Midterm grade documents' %}</th>
+                            <th style="width: 10%" class="col-order" data-col="final-grades">{% translate 'Final grade documents' %}</th>
+                            <th style="width: 15%" class="text-end">{% translate 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -69,8 +69,8 @@
                                             <input type="hidden" name="course_id" value="{{ course.id }}">
 
                                             <confirmation-modal type="submit" name="status" value="0" confirm-button-class="btn-primary">
-                                                <span slot="title">{% trans 'Will final grades be uploaded?' %}</span>
-                                                <span slot="action-text">{% trans 'Confirm' %}</span>
+                                                <span slot="title">{% translate 'Will final grades be uploaded?' %}</span>
+                                                <span slot="action-text">{% translate 'Confirm' %}</span>
                                                 <span slot="question">
                                                     {% blocktrans trimmed with course_name=course.name %}
                                                         Please confirm that a grade document for the course <strong>{{ course_name }}</strong> will be uploaded later on.
@@ -78,7 +78,7 @@
                                                 </span>
 
                                                 <a slot="show-button" href="#">
-                                                    <span class="fas fa-xmark light-link" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Grade documents for this course will not be uploaded. Click to change.' %}"></span>
+                                                    <span class="fas fa-xmark light-link" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Grade documents for this course will not be uploaded. Click to change.' %}"></span>
                                                 </a>
                                             </confirmation-modal>
                                         </form>
@@ -92,31 +92,31 @@
                                                 <input type="hidden" name="course_id" value="{{ course.id }}">
 
                                                 <confirmation-modal type="submit" name="status" value="1" confirm-button-class="btn-primary">
-                                                    <span slot="title">{% trans 'Have final grades been submitted?' %}</span>
-                                                    <span slot="action-text">{% trans 'Confirm' %}</span>
+                                                    <span slot="title">{% translate 'Have final grades been submitted?' %}</span>
+                                                    <span slot="action-text">{% translate 'Confirm' %}</span>
                                                     <span slot="question">
                                                         {% blocktrans trimmed with course_name=course.name %}
                                                             Please confirm that the final grades for the course <strong>{{ course_name }}</strong> have been submitted but will not be uploaded.
                                                         {% endblocktrans %}
                                                     </span>
 
-                                                    <button slot="show-button" type="button" {{ disable_if_archived }} class="btn btn-sm btn-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Confirm that final grades have been submitted but will not be uploaded.' %}">
+                                                    <button slot="show-button" type="button" {{ disable_if_archived }} class="btn btn-sm btn-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Confirm that final grades have been submitted but will not be uploaded.' %}">
                                                         <span class="fas fa-xmark"></span>
                                                     </button>
                                                 </confirmation-modal>
                                             </form>
 
-                                            <div class="btn-group" role="group" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Upload grade document' %}">
+                                            <div class="btn-group" role="group" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Upload grade document' %}">
                                                 <button type="button" id="btnUpload{{ course.id }}" class="btn btn-sm btn-dark dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                                     <span class="fas fa-upload"></span>
                                                 </button>
                                                 <div class="dropdown-menu" aria-labelledby="btnUpload{{ course.id }}">
-                                                    <a class="dropdown-item" href="{% url 'grades:upload_grades' course.id %}">{% trans 'Midterm grades' %}</a>
-                                                    <a class="dropdown-item" href="{% url 'grades:upload_grades' course.id %}?final=true">{% trans 'Final grades' %}</a>
+                                                    <a class="dropdown-item" href="{% url 'grades:upload_grades' course.id %}">{% translate 'Midterm grades' %}</a>
+                                                    <a class="dropdown-item" href="{% url 'grades:upload_grades' course.id %}?final=true">{% translate 'Final grades' %}</a>
                                                 </div>
                                             </div>
                                         {% else %}
-                                            <a href="{% url 'grades:course_view' course.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Change grade document' %}"><span class="fas fa-pencil"></span></a>
+                                            <a href="{% url 'grades:course_view' course.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Change grade document' %}"><span class="fas fa-pencil"></span></a>
                                         {% endif %}
                                     {% endif %}
                                 </td>
@@ -125,7 +125,7 @@
                     </tbody>
                 </table>
             {% else %}
-                <span class="fst-italic">{% trans 'No courses have been created yet' %}</span>
+                <span class="fst-italic">{% translate 'No courses have been created yet' %}</span>
             {% endif %}
         </div>
     </div>

--- a/evap/grades/templates/grades_semester_view.html
+++ b/evap/grades/templates/grades_semester_view.html
@@ -72,7 +72,7 @@
                                                 <span slot="title">{% translate 'Will final grades be uploaded?' %}</span>
                                                 <span slot="action-text">{% translate 'Confirm' %}</span>
                                                 <span slot="question">
-                                                    {% blocktrans trimmed with course_name=course.name %}
+                                                    {% blocktranslate trimmed with course_name=course.name %}
                                                         Please confirm that a grade document for the course <strong>{{ course_name }}</strong> will be uploaded later on.
                                                     {% endblocktrans %}
                                                 </span>
@@ -95,7 +95,7 @@
                                                     <span slot="title">{% translate 'Have final grades been submitted?' %}</span>
                                                     <span slot="action-text">{% translate 'Confirm' %}</span>
                                                     <span slot="question">
-                                                        {% blocktrans trimmed with course_name=course.name %}
+                                                        {% blocktranslate trimmed with course_name=course.name %}
                                                             Please confirm that the final grades for the course <strong>{{ course_name }}</strong> have been submitted but will not be uploaded.
                                                         {% endblocktrans %}
                                                     </span>

--- a/evap/grades/templates/grades_semester_view.html
+++ b/evap/grades/templates/grades_semester_view.html
@@ -74,7 +74,7 @@
                                                 <span slot="question">
                                                     {% blocktranslate trimmed with course_name=course.name %}
                                                         Please confirm that a grade document for the course <strong>{{ course_name }}</strong> will be uploaded later on.
-                                                    {% endblocktrans %}
+                                                    {% endblocktranslate %}
                                                 </span>
 
                                                 <a slot="show-button" href="#">
@@ -97,7 +97,7 @@
                                                     <span slot="question">
                                                         {% blocktranslate trimmed with course_name=course.name %}
                                                             Please confirm that the final grades for the course <strong>{{ course_name }}</strong> have been submitted but will not be uploaded.
-                                                        {% endblocktrans %}
+                                                        {% endblocktranslate %}
                                                     </span>
 
                                                     <button slot="show-button" type="button" {{ disable_if_archived }} class="btn btn-sm btn-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Confirm that final grades have been submitted but will not be uploaded.' %}">

--- a/evap/grades/templates/grades_upload_form.html
+++ b/evap/grades/templates/grades_upload_form.html
@@ -11,15 +11,15 @@
     {% if show_automated_publishing_info %}
         <div class="callout callout-info">
             <b>{% translate 'Automated publishing' %}</b><br />
-            {% blocktrans %}After this file with final grades was uploaded, the evaluation results will be published automatically once the evaluation ends. If the evaluation has already ended, it will be published immediately. All contributors and participants will receive an email informing them about the published evaluation results and the available grade file document.{% endblocktrans %}
+            {% blocktranslate %}After this file with final grades was uploaded, the evaluation results will be published automatically once the evaluation ends. If the evaluation has already ended, it will be published immediately. All contributors and participants will receive an email informing them about the published evaluation results and the available grade file document.{% endblocktrans %}
         </div>
     {% endif %}
 
     <h3 class="mb-3">
         {% if final_grades %}
-            {% blocktrans with course=course.name semester=semester.name %}Upload final grades for {{ course }} ({{ semester }}){% endblocktrans %}
+            {% blocktranslate with course=course.name semester=semester.name %}Upload final grades for {{ course }} ({{ semester }}){% endblocktrans %}
         {% else %}
-            {% blocktrans with course=course.name semester=semester.name %}Upload midterm grades for {{ course }} ({{ semester }}){% endblocktrans %}
+            {% blocktranslate with course=course.name semester=semester.name %}Upload midterm grades for {{ course }} ({{ semester }}){% endblocktrans %}
         {% endif %}
     </h3>
     <form method="POST" class="form-horizontal" id="grades-upload-form" enctype="multipart/form-data">

--- a/evap/grades/templates/grades_upload_form.html
+++ b/evap/grades/templates/grades_upload_form.html
@@ -11,15 +11,15 @@
     {% if show_automated_publishing_info %}
         <div class="callout callout-info">
             <b>{% translate 'Automated publishing' %}</b><br />
-            {% blocktranslate %}After this file with final grades was uploaded, the evaluation results will be published automatically once the evaluation ends. If the evaluation has already ended, it will be published immediately. All contributors and participants will receive an email informing them about the published evaluation results and the available grade file document.{% endblocktrans %}
+            {% blocktranslate %}After this file with final grades was uploaded, the evaluation results will be published automatically once the evaluation ends. If the evaluation has already ended, it will be published immediately. All contributors and participants will receive an email informing them about the published evaluation results and the available grade file document.{% endblocktranslate %}
         </div>
     {% endif %}
 
     <h3 class="mb-3">
         {% if final_grades %}
-            {% blocktranslate with course=course.name semester=semester.name %}Upload final grades for {{ course }} ({{ semester }}){% endblocktrans %}
+            {% blocktranslate with course=course.name semester=semester.name %}Upload final grades for {{ course }} ({{ semester }}){% endblocktranslate %}
         {% else %}
-            {% blocktranslate with course=course.name semester=semester.name %}Upload midterm grades for {{ course }} ({{ semester }}){% endblocktrans %}
+            {% blocktranslate with course=course.name semester=semester.name %}Upload midterm grades for {{ course }} ({{ semester }}){% endblocktranslate %}
         {% endif %}
     </h3>
     <form method="POST" class="form-horizontal" id="grades-upload-form" enctype="multipart/form-data">

--- a/evap/grades/templates/grades_upload_form.html
+++ b/evap/grades/templates/grades_upload_form.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans "Upload document" %}</li>
+    <li class="breadcrumb-item">{% translate "Upload document" %}</li>
 {% endblock %}
 
 {% block content %}
@@ -10,7 +10,7 @@
 
     {% if show_automated_publishing_info %}
         <div class="callout callout-info">
-            <b>{% trans 'Automated publishing' %}</b><br />
+            <b>{% translate 'Automated publishing' %}</b><br />
             {% blocktrans %}After this file with final grades was uploaded, the evaluation results will be published automatically once the evaluation ends. If the evaluation has already ended, it will be published immediately. All contributors and participants will receive an email informing them about the published evaluation results and the available grade file document.{% endblocktrans %}
         </div>
     {% endif %}
@@ -31,7 +31,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Upload grades' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Upload grades' %}</button>
             </div>
         </div>
     </form>

--- a/evap/results/templates/distribution_widget.html
+++ b/evap/results/templates/distribution_widget.html
@@ -12,7 +12,7 @@
             </div>
         </div>
     {% else %}
-        <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" data-fallback-placement='["left", "bottom"]' title="{% trans 'Not enough answers were given.' %}">
+        <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" data-fallback-placement='["left", "bottom"]' title="{% translate 'Not enough answers were given.' %}">
             {% include "distribution_with_grade_disabled.html" with icon="far fa-eye-slash" %}
             <div class="badge-participants badge-disabled ms-2 ms-lg-3">
                 {% if question_result|is_published %}

--- a/evap/results/templates/distribution_with_grade.html
+++ b/evap/results/templates/distribution_with_grade.html
@@ -25,17 +25,17 @@
         </div>
     {% elif question_result.question.is_positive_yes_no_question %}
         <div class="left">
-            <span class="adjective">{% trans 'Yes' %}</span>
+            <span class="adjective">{% translate 'Yes' %}</span>
         </div>
         <div class="right">
-            <span class="adjective">{% trans 'No' %}</span>
+            <span class="adjective">{% translate 'No' %}</span>
         </div>
     {% elif question_result.question.is_negative_yes_no_question %}
         <div class="left">
-            <span class="adjective">{% trans 'No' %}</span>
+            <span class="adjective">{% translate 'No' %}</span>
         </div>
         <div class="right">
-            <span class="adjective">{% trans 'Yes' %}</span>
+            <span class="adjective">{% translate 'Yes' %}</span>
         </div>
     {% endif %}
     {% if weight_info %}

--- a/evap/results/templates/evaluation_result_widget.html
+++ b/evap/results/templates/evaluation_result_widget.html
@@ -10,7 +10,7 @@
         {% include "distribution_with_grade.html" with distribution=course_or_evaluation.distribution average=course_or_evaluation.avg_grade weight_info=course_or_evaluation|weight_info question_result=None %}
     </div>
 {% else %}
-    <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Not enough answers were given.' %}">
+    <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Not enough answers were given.' %}">
         {% include "distribution_with_grade_disabled.html" with icon="far fa-eye-slash" %}
     </div>
 {% endif %}

--- a/evap/results/templates/result_widget_tooltip.html
+++ b/evap/results/templates/result_widget_tooltip.html
@@ -2,7 +2,7 @@
 
 {% if weight_info %}
     <p>
-        {% blocktranslate with percentage=weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktrans %}
+        {% blocktranslate with percentage=weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktranslate %}
     </p>
 {% endif %}
 {% if question_result %}

--- a/evap/results/templates/result_widget_tooltip.html
+++ b/evap/results/templates/result_widget_tooltip.html
@@ -2,7 +2,7 @@
 
 {% if weight_info %}
     <p>
-        {% blocktrans with percentage=weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktrans %}
+        {% blocktranslate with percentage=weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktrans %}
     </p>
 {% endif %}
 {% if question_result %}

--- a/evap/results/templates/result_widget_tooltip.html
+++ b/evap/results/templates/result_widget_tooltip.html
@@ -8,7 +8,7 @@
 {% if question_result %}
     {% if question_result.warning %}
         <p>
-            {% trans 'Only a few participants answered this question.' %}
+            {% translate 'Only a few participants answered this question.' %}
         </p>
     {% endif %}
     {% with question_result.question.is_bipolar_likert_question as is_bipolar %}

--- a/evap/results/templates/results_evaluation_detail.html
+++ b/evap/results/templates/results_evaluation_detail.html
@@ -44,7 +44,7 @@
                                 class="btn btn-sm btn-light{% if view == 'export' %} active{% endif %}"
                                 data-bs-toggle="tooltip"
                                 data-bs-placement="bottom"
-                                title="{% blocktranslate %}Shows filtered view meant for personal export. Other contributors' results and private answers are hidden.{% endblocktrans %}"
+                                title="{% blocktranslate %}Shows filtered view meant for personal export. Other contributors' results and private answers are hidden.{% endblocktranslate %}"
                             >
                                 {% translate 'Export' context 'view mode' %}
                             </a>
@@ -67,7 +67,7 @@
                                 class="btn btn-sm btn-light"
                                 data-bs-toggle="tooltip"
                                 data-bs-placement="bottom"
-                                title="{% blocktranslate %}The results of this evaluation have not been published because it didn't get enough votes.{% endblocktrans %}"
+                                title="{% blocktranslate %}The results of this evaluation have not been published because it didn't get enough votes.{% endblocktranslate %}"
                             >
                                 {% if evaluation.course.is_private %}
                                     {% translate 'Participant' %}

--- a/evap/results/templates/results_evaluation_detail.html
+++ b/evap/results/templates/results_evaluation_detail.html
@@ -4,7 +4,7 @@
 {% load evaluation_filters %}
 {% load results_templatetags %}
 
-{% block title %}{{ evaluation.full_name }} - {{ evaluation.course.semester.name }} - {% trans 'Results' %} - {{ block.super }}{% endblock %}
+{% block title %}{{ evaluation.full_name }} - {{ evaluation.course.semester.name }} - {% translate 'Results' %} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb_bar %}
     <div class="breadcrumb-bar">
@@ -19,13 +19,13 @@
     {{ block.super }}
 
     {% if evaluation.state != evaluation.State.PUBLISHED %}
-        <div class="alert alert-warning">{% trans 'This is a preview. The results have not been published yet.' %}</div>
+        <div class="alert alert-warning">{% translate 'This is a preview. The results have not been published yet.' %}</div>
     {% endif %}
 
     {% if is_reviewer or is_responsible_or_contributor_or_delegate %}
         {% if evaluation.course.is_private %}
             <div class="alert alert-info d-print-none">
-                <span class="fas fa-lock"></span> {% trans 'This evaluation is private. Only contributors and participants can see the results.' %}
+                <span class="fas fa-lock"></span> {% translate 'This evaluation is private. Only contributors and participants can see the results.' %}
             </div>
         {% endif %}
         <div class="row align-items-end mb-3">
@@ -35,7 +35,7 @@
 
             <div class="col-auto">
                 <div class="btn-switch btn-switch-light my-auto d-print-none">
-                    <div class="btn-switch-label">{% trans 'View' %}</div>
+                    <div class="btn-switch-label">{% translate 'View' %}</div>
                     <div class="btn-switch btn-group">
                         {% if user.is_staff and view == 'export' or is_contributor %}
                             <a
@@ -46,7 +46,7 @@
                                 data-bs-placement="bottom"
                                 title="{% blocktrans %}Shows filtered view meant for personal export. Other contributors' results and private answers are hidden.{% endblocktrans %}"
                             >
-                                {% trans 'Export' context 'view mode' %}
+                                {% translate 'Export' context 'view mode' %}
                             </a>
 
                         {% endif %}
@@ -56,9 +56,9 @@
                             class="btn btn-sm btn-light{% if view == 'full' %} active{% endif %}"
                             data-bs-toggle="tooltip"
                             data-bs-placement="bottom"
-                            title="{% trans 'Shows all results available for you.' %}"
+                            title="{% translate 'Shows all results available for you.' %}"
                         >
-                            {% trans 'Full' %}
+                            {% translate 'Full' %}
                         </a>
                         {% if not evaluation.can_publish_rating_results %}
                             <button
@@ -70,9 +70,9 @@
                                 title="{% blocktrans %}The results of this evaluation have not been published because it didn't get enough votes.{% endblocktrans %}"
                             >
                                 {% if evaluation.course.is_private %}
-                                    {% trans 'Participant' %}
+                                    {% translate 'Participant' %}
                                 {% else %}
-                                    {% trans 'Public' %}
+                                    {% translate 'Public' %}
                                 {% endif %}
                             </button>
                         {% else %}
@@ -84,13 +84,13 @@
                                 data-bs-placement="bottom"
                                 title="
                                     {% if evaluation.course.is_private %}
-                                        {% trans 'Shows results available for the participants.' %}"
+                                        {% translate 'Shows results available for the participants.' %}"
                                         >
-                                        {% trans 'Participant' %}
+                                        {% translate 'Participant' %}
                                     {% else %}
-                                        {% trans 'Shows results available for everyone logged in.' %}"
+                                        {% translate 'Shows results available for everyone logged in.' %}"
                                         >
-                                        {% trans 'Public' %}
+                                        {% translate 'Public' %}
                                     {% endif %}
                             </a>
                         {% endif %}
@@ -104,17 +104,17 @@
 
     <div class="card card-outline-primary mb-3">
         <div class="card-header d-flex">
-            <div class="me-auto">{% trans 'Overview' %}</div>
+            <div class="me-auto">{% translate 'Overview' %}</div>
             {% if can_export_text_answers %}
                 <a class="btn btn-sm btn-light d-print-none" href="{% url 'results:evaluation_text_answers_export' evaluation.id %}?view={{ view }}{% if contributor_id is not None %}&contributor_id={{ contributor_id }}{% endif %}" type="button">
-                    {% trans 'Export text answers' %}
+                    {% translate 'Export text answers' %}
                 </a>
             {% endif %}
             {% if evaluation.course.grade_documents.count == 1 and can_download_grades %}
                 <a class="btn btn-sm btn-light d-print-none ms-2" href="{% url 'grades:download_grades' evaluation.course.grade_documents.first.id %}">{{ evaluation.course.grade_documents.first.description }}</a>
             {% elif evaluation.course.grade_documents.count > 1 and can_download_grades %}
                 <div class="btn-group d-print-none ms-2" role="group">
-                    <button type="button" id="btnDownload" class="btn btn-sm btn-light dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Grades' %}</button>
+                    <button type="button" id="btnDownload" class="btn btn-sm btn-light dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% translate 'Grades' %}</button>
                     <div class="dropdown-menu" aria-labelledby="btnDownload">
                         {% for grade_document in evaluation.course.grade_documents.all %}
                             <a class="dropdown-item" href="{% url 'grades:download_grades' grade_document.id %}">{{ grade_document.description }}</a>
@@ -126,11 +126,11 @@
         <div class="card-body pt-2">
             <div class="result-grid">
                 <div class="grid-header results-grid-row border-bottom d-none d-lg-grid">
-                        <div data-col="name">{% trans 'Evaluation' %}</div>
-                        <div data-col="semester">{% trans 'Semester' %}</div>
-                        <div data-col="responsible">{% trans 'Responsible' %}</div>
-                        <div data-col="voters">{% trans 'Voters' %}</div>
-                        <div data-col="result">{% trans 'Distribution and average grade' %}</div>
+                        <div data-col="name">{% translate 'Evaluation' %}</div>
+                        <div data-col="semester">{% translate 'Semester' %}</div>
+                        <div data-col="responsible">{% translate 'Responsible' %}</div>
+                        <div data-col="voters">{% translate 'Voters' %}</div>
+                        <div data-col="result">{% translate 'Distribution and average grade' %}</div>
                 </div>
                 {% if course_evaluations %}
                     {% include 'results_index_course.html' with evaluations=course_evaluations %}
@@ -151,7 +151,7 @@
     {% if general_questionnaire_results_top %}
         <div class="card card-outline-primary mb-3">
             <div class="card-header">
-                {% trans 'General' %}
+                {% translate 'General' %}
             </div>
             <div class="card-body">
                 {% for questionnaire_result in general_questionnaire_results_top %}
@@ -164,7 +164,7 @@
     {% if contributor_contribution_results or contributors_with_omitted_results %}
         <div class="card card-outline-primary mb-3">
             <div class="card-header">
-                {% trans 'Contributors' %}
+                {% translate 'Contributors' %}
             </div>
             <div class="card-body">
                 {% for contribution_result in contributor_contribution_results %}
@@ -183,7 +183,7 @@
                             {% if not contribution_result.has_answers %}
                                 <div class="participants-warning">
                                     <span class="fas fa-circle-info"></span>
-                                    {% trans 'There are no results for this person.' %}
+                                    {% translate 'There are no results for this person.' %}
                                 </div>
                             {% endif %}
                         </div>
@@ -199,7 +199,7 @@
                 {% if contributors_with_omitted_results %}
                     <div class="card mt-3">
                         <div class="card-header">
-                            {% trans 'Other contributors' %}
+                            {% translate 'Other contributors' %}
                         </div>
                         <div class="card-body">
                             <ul>
@@ -217,7 +217,7 @@
     {% if general_questionnaire_results_bottom %}
         <div class="card card-outline-primary">
             <div class="card-header">
-                {% trans 'General' %}
+                {% translate 'General' %}
             </div>
             <div class="card-body">
                 {% for questionnaire_result in general_questionnaire_results_bottom %}

--- a/evap/results/templates/results_evaluation_detail.html
+++ b/evap/results/templates/results_evaluation_detail.html
@@ -44,7 +44,7 @@
                                 class="btn btn-sm btn-light{% if view == 'export' %} active{% endif %}"
                                 data-bs-toggle="tooltip"
                                 data-bs-placement="bottom"
-                                title="{% blocktrans %}Shows filtered view meant for personal export. Other contributors' results and private answers are hidden.{% endblocktrans %}"
+                                title="{% blocktranslate %}Shows filtered view meant for personal export. Other contributors' results and private answers are hidden.{% endblocktrans %}"
                             >
                                 {% translate 'Export' context 'view mode' %}
                             </a>
@@ -67,7 +67,7 @@
                                 class="btn btn-sm btn-light"
                                 data-bs-toggle="tooltip"
                                 data-bs-placement="bottom"
-                                title="{% blocktrans %}The results of this evaluation have not been published because it didn't get enough votes.{% endblocktrans %}"
+                                title="{% blocktranslate %}The results of this evaluation have not been published because it didn't get enough votes.{% endblocktrans %}"
                             >
                                 {% if evaluation.course.is_private %}
                                     {% translate 'Participant' %}

--- a/evap/results/templates/results_evaluation_detail_questionnaires.html
+++ b/evap/results/templates/results_evaluation_detail_questionnaires.html
@@ -3,7 +3,7 @@
     {% if questionnaire_result.warning %}
         <p class="ms-auto mt-auto participants-warning">
             <span class="fas fa-triangle-exclamation"></span>
-            {% trans 'Only a few participants answered these questions.' %}
+            {% translate 'Only a few participants answered these questions.' %}
         </p>
     {% endif %}
 </div>

--- a/evap/results/templates/results_index.html
+++ b/evap/results/templates/results_index.html
@@ -4,26 +4,26 @@
 {% load results_templatetags %}
 {% load evaluation_filters %}
 
-{% block title %}{% trans 'Results' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'Results' %} - {{ block.super }}{% endblock %}
 
 {% block content %}
     {{ block.super }}
-    <h3>{% trans 'Evaluation results' %}</h3>
+    <h3>{% translate 'Evaluation results' %}</h3>
     <div class="card mb-1">
         <div class="card-body">
             <h5 class="card-title">
-                {% trans 'Filter' %}
+                {% translate 'Filter' %}
                 <span class="reset-button float-end" data-reset="filter">
                     <span class="fas fa-eraser"></span>
-                    {% trans 'Clear all filters' %}
+                    {% translate 'Clear all filters' %}
                 </span>
             </h5>
             <div class="row">
                 <div class="col-12 col-lg">
-                    <input type="search" name="search" class="form-control mb-3" placeholder="{% trans 'Search...' %}" />
+                    <input type="search" name="search" class="form-control mb-3" placeholder="{% translate 'Search...' %}" />
                 </div>
                 <div class="col-6 col-sm-4 col-md">
-                    <h6 class="card-subtitle mb-1">{% trans 'Degrees' %}</h6>
+                    <h6 class="card-subtitle mb-1">{% translate 'Degrees' %}</h6>
                     <div id="degree-select" class="result-filter-list">
                         {% for degree in degrees %}
                             <div class="form-check">
@@ -36,7 +36,7 @@
                     </div>
                 </div>
                 <div class="col-6 col-sm-4 col-md">
-                    <h6 class="card-subtitle mb-1">{% trans 'Course types' %}</h6>
+                    <h6 class="card-subtitle mb-1">{% translate 'Course types' %}</h6>
                     <div id="course-type-select" class="result-filter-list">
                         {% for course_type in course_types %}
                             <div class="form-check">
@@ -49,7 +49,7 @@
                     </div>
                 </div>
                 <div class="col-sm-4 col-md">
-                    <h6 class="card-subtitle mb-1">{% trans 'Semester' %}</h6>
+                    <h6 class="card-subtitle mb-1">{% translate 'Semester' %}</h6>
                     <div id="semester-select" class="result-filter-list">
                         {% for semester in semesters %}
                             <div class="form-check">
@@ -67,18 +67,18 @@
     <div class="card mb-1">
         <div class="card-body pb-lg-0">
             <h5 class="card-title mb-lg-0">
-                {% trans 'Order' %}
+                {% translate 'Order' %}
                 <span class="reset-button float-end d-none d-lg-block" data-reset="order">
                     <span class="fas fa-arrow-down-wide-short"></span>
-                    {% trans 'Order by evaluation and semester' %}
+                    {% translate 'Order by evaluation and semester' %}
                 </span>
             </h5>
             <div class="grid-header results-grid-row d-none d-lg-grid">
-                <div data-col="name" class="col-order">{% trans 'Evaluation' %}</div>
-                <div data-col="semester" class="col-order">{% trans 'Semester' %}</div>
-                <div data-col="responsible" class="col-order">{% trans 'Responsible' %}</div>
-                <div data-col="voters" class="col-order">{% trans 'Voters' %}</div>
-                <div data-col="result" class="col-order">{% trans 'Distribution and average grade' %}</div>
+                <div data-col="name" class="col-order">{% translate 'Evaluation' %}</div>
+                <div data-col="semester" class="col-order">{% translate 'Semester' %}</div>
+                <div data-col="responsible" class="col-order">{% translate 'Responsible' %}</div>
+                <div data-col="voters" class="col-order">{% translate 'Voters' %}</div>
+                <div data-col="result" class="col-order">{% translate 'Distribution and average grade' %}</div>
             </div>
             <div class="d-flex d-lg-none">
                 <div class="me-2 btn-group icon-buttons" data-bs-toggle="buttons">
@@ -92,12 +92,12 @@
                     </label>
                 </div>
                 <select name="result-sort-column" class="form-select no-tomselect">
-                    <option value="name-semester">{% trans 'Evaluation and semester' %}</option>
-                    <option value="name">{% trans 'Evaluation' %}</option>
-                    <option value="semester">{% trans 'Semester' %}</option>
-                    <option value="responsible">{% trans 'Responsible' %}</option>
-                    <option value="voters">{% trans 'Voters' %}</option>
-                    <option value="result">{% trans 'Distribution and average grade' %}</option>
+                    <option value="name-semester">{% translate 'Evaluation and semester' %}</option>
+                    <option value="name">{% translate 'Evaluation' %}</option>
+                    <option value="semester">{% translate 'Semester' %}</option>
+                    <option value="responsible">{% translate 'Responsible' %}</option>
+                    <option value="voters">{% translate 'Voters' %}</option>
+                    <option value="result">{% translate 'Distribution and average grade' %}</option>
                 </select>
             </div>
         </div>

--- a/evap/results/templates/results_index_course_impl.html
+++ b/evap/results/templates/results_index_course_impl.html
@@ -20,7 +20,7 @@
     <div data-col="voters" data-order="{{ evaluations|aggregated_voters_order }}"></div>
     <div data-col="result" data-order="{{ course.avg_grade|default:7 }}">
         {% if course.not_all_evaluations_are_published %}
-            <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Course result is not yet available.' %}">
+            <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Course result is not yet available.' %}">
                 {% include 'distribution_with_grade_disabled.html' with icon="fas fa-hourglass" %}
             </div>
         {% else %}

--- a/evap/results/templates/results_index_evaluation_impl.html
+++ b/evap/results/templates/results_index_evaluation_impl.html
@@ -28,14 +28,14 @@
             {% endif %}
             {% if evaluation.is_single_result %} ({{ evaluation.vote_start_datetime|date }}){% endif %}
             {% if evaluation.state == evaluation.State.IN_EVALUATION %}
-                <span data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-play icon-gray" title="{% trans 'This evaluation is still running' %}"></span>
+                <span data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-play icon-gray" title="{% translate 'This evaluation is still running' %}"></span>
             {% elif evaluation.state == evaluation.State.EVALUATED %}
-                <span data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-chart-simple icon-yellow" title="{% trans 'Results not yet published' %}"></span>
+                <span data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-chart-simple icon-yellow" title="{% translate 'Results not yet published' %}"></span>
             {% elif evaluation.state == evaluation.State.REVIEWED %}
                 {% if evaluation.is_single_result or evaluation.grading_process_is_finished %}
-                    <span data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-chart-simple icon-red" title="{% trans 'Results not yet published although grading process is finished' %}"></span>
+                    <span data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-chart-simple icon-red" title="{% translate 'Results not yet published although grading process is finished' %}"></span>
                 {% else %}
-                    <span data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-chart-simple icon-yellow" title="{% trans 'Results not yet published' %}"></span>
+                    <span data-bs-toggle="tooltip" data-bs-placement="top" class="fas fa-chart-simple icon-yellow" title="{% translate 'Results not yet published' %}"></span>
                 {% endif %}
             {% endif %}
         </span>
@@ -59,7 +59,7 @@
     </div>
     <div data-col="result"{% if not is_subentry %} data-order="{% if evaluation.is_single_result %}{{ evaluation.single_result_rating_result.average }}{% else %}{{ evaluation.avg_grade|default:7 }}{% endif %}"{% endif %}>
         {% if not evaluation.can_staff_see_average_grade %}
-            <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Evaluation result is not yet available.' %}">
+            <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Evaluation result is not yet available.' %}">
                 {% include "distribution_with_grade_disabled.html" with icon="fas fa-hourglass" %}
             </div>
         {% else %}

--- a/evap/results/templates/textanswer_list.html
+++ b/evap/results/templates/textanswer_list.html
@@ -3,7 +3,7 @@
 <div class="w-100">
     <div class="float-end text-end">
         <span class="d-print-none">
-            {% blocktrans asvar intro_text %}These text answers can be seen by:{% endblocktrans %}
+            {% blocktranslate asvar intro_text %}These text answers can be seen by:{% endblocktrans %}
             {% include 'textanswer_visibility_info.html' with intro_text=intro_text visible_by_contribution=question_result.answers_visible_to.visible_by_contribution visible_by_delegation_count=question_result.answers_visible_to.visible_by_delegation_count %}
         </span>
         <div class="d-inline-block badge-participants badge-participants-{{ num_answers|participationclass:num_voters }} ms-2">

--- a/evap/results/templates/textanswer_list.html
+++ b/evap/results/templates/textanswer_list.html
@@ -3,7 +3,7 @@
 <div class="w-100">
     <div class="float-end text-end">
         <span class="d-print-none">
-            {% blocktranslate asvar intro_text %}These text answers can be seen by:{% endblocktrans %}
+            {% blocktranslate asvar intro_text %}These text answers can be seen by:{% endblocktranslate %}
             {% include 'textanswer_visibility_info.html' with intro_text=intro_text visible_by_contribution=question_result.answers_visible_to.visible_by_contribution visible_by_delegation_count=question_result.answers_visible_to.visible_by_delegation_count %}
         </span>
         <div class="d-inline-block badge-participants badge-participants-{{ num_answers|participationclass:num_voters }} ms-2">

--- a/evap/results/templates/textanswer_list.html
+++ b/evap/results/templates/textanswer_list.html
@@ -14,7 +14,7 @@
         {% for answer in question_result.answers %}
             <li>
                 {% if answer.is_private %}
-                    <span data-bs-toggle="tooltip" data-bs-placement="left" class="fas fa-circle-info" title="{% trans 'This answer is only visible to you. Other contributors and your delegates can not see it.' %}"></span>
+                    <span data-bs-toggle="tooltip" data-bs-placement="left" class="fas fa-circle-info" title="{% translate 'This answer is only visible to you. Other contributors and your delegates can not see it.' %}"></span>
                 {% endif %}
                 {{ answer.answer|linebreaksbr }}
             </li>

--- a/evap/rewards/templates/rewards_index.html
+++ b/evap/rewards/templates/rewards_index.html
@@ -8,7 +8,7 @@
     {{ block.super }}
 
     <div class="callout callout-info small">
-        {% blocktrans %}You will get reward points by taking part in evaluations. These points can be redeemed for different events. You will receive vouchers for food and drinks at the event you selected below. We'll inform you about any upcoming event where you can redeem your reward points.{% endblocktrans %}
+        {% blocktranslate %}You will get reward points by taking part in evaluations. These points can be redeemed for different events. You will receive vouchers for food and drinks at the event you selected below. We'll inform you about any upcoming event where you can redeem your reward points.{% endblocktrans %}
     </div>
 
     <div class="card card-outline-primary mb-3">
@@ -50,10 +50,10 @@
                         </span>
                     </form>
                 {% else %}
-                    <p class="fst-italic">{% blocktrans %}Currently there are no events available for which you can redeem points. We'll send you a message when this changes.{% endblocktrans %}</p>
+                    <p class="fst-italic">{% blocktranslate %}Currently there are no events available for which you can redeem points. We'll send you a message when this changes.{% endblocktrans %}</p>
                 {% endif %}
             {% else %}
-                <p class="fst-italic">{% blocktrans %}You don't have any reward points that you could redeem.{% endblocktrans %}</p>
+                <p class="fst-italic">{% blocktranslate %}You don't have any reward points that you could redeem.{% endblocktrans %}</p>
             {% endif %}
         </div>
     </div>

--- a/evap/rewards/templates/rewards_index.html
+++ b/evap/rewards/templates/rewards_index.html
@@ -8,7 +8,7 @@
     {{ block.super }}
 
     <div class="callout callout-info small">
-        {% blocktranslate %}You will get reward points by taking part in evaluations. These points can be redeemed for different events. You will receive vouchers for food and drinks at the event you selected below. We'll inform you about any upcoming event where you can redeem your reward points.{% endblocktrans %}
+        {% blocktranslate %}You will get reward points by taking part in evaluations. These points can be redeemed for different events. You will receive vouchers for food and drinks at the event you selected below. We'll inform you about any upcoming event where you can redeem your reward points.{% endblocktranslate %}
     </div>
 
     <div class="card card-outline-primary mb-3">
@@ -50,10 +50,10 @@
                         </span>
                     </form>
                 {% else %}
-                    <p class="fst-italic">{% blocktranslate %}Currently there are no events available for which you can redeem points. We'll send you a message when this changes.{% endblocktrans %}</p>
+                    <p class="fst-italic">{% blocktranslate %}Currently there are no events available for which you can redeem points. We'll send you a message when this changes.{% endblocktranslate %}</p>
                 {% endif %}
             {% else %}
-                <p class="fst-italic">{% blocktranslate %}You don't have any reward points that you could redeem.{% endblocktrans %}</p>
+                <p class="fst-italic">{% blocktranslate %}You don't have any reward points that you could redeem.{% endblocktranslate %}</p>
             {% endif %}
         </div>
     </div>

--- a/evap/rewards/templates/rewards_index.html
+++ b/evap/rewards/templates/rewards_index.html
@@ -2,7 +2,7 @@
 
 {% load evaluation_filters %}
 
-{% block title %}{% trans 'Rewards' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'Rewards' %} - {{ block.super }}{% endblock %}
 
 {% block content %}
     {{ block.super }}
@@ -13,10 +13,10 @@
 
     <div class="card card-outline-primary mb-3">
         <div class="card-header">
-            {% trans 'Redeem points' %}
+            {% translate 'Redeem points' %}
         </div>
         <div class="card-body table-responsive">
-            <p><b>{% trans 'Total points available' %}: {{ total_points_available }}</b></p>
+            <p><b>{% translate 'Total points available' %}: {{ total_points_available }}</b></p>
             {% if total_points_available > 0 %}
                 {% if events %}
                     <form id="reward-redemption-form" action="#" method="POST" class="form-horizontal multiselect-form">
@@ -26,10 +26,10 @@
                         <table class="table table-striped table-vertically-aligned mb-3">
                             <thead>
                                 <tr>
-                                    <th style="width: 20%">{% trans 'Date' %}</th>
-                                    <th style="width: 40%">{% trans 'Event' %}</th>
-                                    <th style="width: 20%">{% trans 'Available until' %}</th>
-                                    <th style="width: 20%">{% trans 'Redeem points' %}</th>
+                                    <th style="width: 20%">{% translate 'Date' %}</th>
+                                    <th style="width: 40%">{% translate 'Event' %}</th>
+                                    <th style="width: 20%">{% translate 'Available until' %}</th>
+                                    <th style="width: 20%">{% translate 'Redeem points' %}</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -46,7 +46,7 @@
                             </tbody>
                         </table>
                         <span class="d-flex">
-                            <button type="submit" class="btn btn-primary ms-auto">{% trans 'Redeem' %}</button>
+                            <button type="submit" class="btn btn-primary ms-auto">{% translate 'Redeem' %}</button>
                         </span>
                     </form>
                 {% else %}
@@ -60,17 +60,17 @@
 
     <div class="card">
         <div class="card-header">
-            {% trans 'Reward points history' %}
+            {% translate 'Reward points history' %}
         </div>
         <div class="card-body table-responsive">
             {% if reward_point_actions %}
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <th style="width: 20%">{% trans 'Date' %}</th>
-                            <th style="width: 40%">{% trans 'Action' %}</th>
-                            <th style="width: 20%" class="text-end">{% trans 'Granted points' %}</th>
-                            <th style="width: 20%" class="text-end">{% trans 'Redeemed points' %}</th>
+                            <th style="width: 20%">{% translate 'Date' %}</th>
+                            <th style="width: 40%">{% translate 'Action' %}</th>
+                            <th style="width: 20%" class="text-end">{% translate 'Granted points' %}</th>
+                            <th style="width: 20%" class="text-end">{% translate 'Redeemed points' %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -85,7 +85,7 @@
                     </tbody>
                 </table>
             {% else %}
-                <p class="fst-italic">{% trans 'No reward points earned yet.' %}</p>
+                <p class="fst-italic">{% translate 'No reward points earned yet.' %}</p>
             {% endif %}
         </div>
     </div>

--- a/evap/rewards/templates/rewards_reward_point_redemption_event_form.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_event_form.html
@@ -2,8 +2,8 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'rewards:reward_point_redemption_events' %}">{% trans 'Reward Point Redemption Events' %}</a></li>
-    <li class="breadcrumb-item">{% trans 'Edit event' %}</li>
+    <li class="breadcrumb-item"><a href="{% url 'rewards:reward_point_redemption_events' %}">{% translate 'Reward Point Redemption Events' %}</a></li>
+    <li class="breadcrumb-item">{% translate 'Edit event' %}</li>
 {% endblock %}
 
 {% block content %}
@@ -17,7 +17,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save event' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save event' %}</button>
             </div>
         </div>
     </form>

--- a/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
@@ -1,16 +1,16 @@
 <div class="card-header">
-    {% trans title %}
+    {% translate title %}
 </div>
 <div class="card-body table-responsive">
     {% if events %}
         <table class="table table-striped">
             <thead>
                 <tr>
-                    <th style="width: 20%">{% trans 'Event date' %}</th>
-                    <th style="width: 20%">{% trans 'Redemption end date' %}</th>
-                    <th style="width: 30%">{% trans 'Event name' %}</th>
-                    <th style="width: 15%">{% trans 'Redemptions' %}</th>
-                    <th class="text-end" style="width: 15%">{% trans 'Actions' %}</th>
+                    <th style="width: 20%">{% translate 'Event date' %}</th>
+                    <th style="width: 20%">{% translate 'Redemption end date' %}</th>
+                    <th style="width: 30%">{% translate 'Event name' %}</th>
+                    <th style="width: 15%">{% translate 'Redemptions' %}</th>
+                    <th class="text-end" style="width: 15%">{% translate 'Actions' %}</th>
                 </tr>
             </thead>
             <tbody>
@@ -21,25 +21,25 @@
                         <td>{{ event.name }}</td>
                         <td><span class="fas fa-user"></span> {{ event.redemptions_by_user|length }}</td>
                         <td class="d-flex justify-content-end gap-1">
-                            <a href="{% url 'rewards:reward_point_redemption_event_export' event.id %}" class="btn btn-sm btn-primary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Export Redemptions' %}"><span class="fas fa-download"></span></a>
-                            <a href="{% url 'rewards:reward_point_redemption_event_edit' event.id %}" class="btn btn-sm btn-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Edit' %}"><span class="fas fa-pencil"></span></a>
+                            <a href="{% url 'rewards:reward_point_redemption_event_export' event.id %}" class="btn btn-sm btn-primary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Export Redemptions' %}"><span class="fas fa-download"></span></a>
+                            <a href="{% url 'rewards:reward_point_redemption_event_edit' event.id %}" class="btn btn-sm btn-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Edit' %}"><span class="fas fa-pencil"></span></a>
                             {% if event.can_delete %}
                                 <confirmation-modal type="submit" form="event-deletion-form" name="event_id" value="{{ event.id }}" confirm-button-class="btn-danger">
-                                    <span slot="title">{% trans 'Delete event' %}</span>
-                                    <span slot="action-text">{% trans 'Delete event' %}</span>
+                                    <span slot="title">{% translate 'Delete event' %}</span>
+                                    <span slot="action-text">{% translate 'Delete event' %}</span>
                                     <span slot="question">
                                         {% blocktrans trimmed with event_name=event.name %}
                                             Do you really want to delete the event <strong>{{ event_name }}</strong>?
                                         {% endblocktrans %}
                                     </span>
 
-                                    <button slot="show-button" type="button" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
+                                    <button slot="show-button" type="button" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Delete' %}">
                                         <span class="fas fa-trash"></span>
                                     </button>
                                 </confirmation-modal>
                             {% else %}
                                 <button disabled type="button" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top"
-                                    title="{% trans 'This event cannot be deleted because some users already redeemed points for it.' %}">
+                                    title="{% translate 'This event cannot be deleted because some users already redeemed points for it.' %}">
                                     <span class="fas fa-trash"></span>
                                 </button>
                             {% endif %}
@@ -49,6 +49,6 @@
             </tbody>
         </table>
     {% else %}
-        <span class="fst-italic">{% trans 'No events exist.' %}</span>
+        <span class="fst-italic">{% translate 'No events exist.' %}</span>
     {% endif %}
 </div>

--- a/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
@@ -28,7 +28,7 @@
                                     <span slot="title">{% translate 'Delete event' %}</span>
                                     <span slot="action-text">{% translate 'Delete event' %}</span>
                                     <span slot="question">
-                                        {% blocktrans trimmed with event_name=event.name %}
+                                        {% blocktranslate trimmed with event_name=event.name %}
                                             Do you really want to delete the event <strong>{{ event_name }}</strong>?
                                         {% endblocktrans %}
                                     </span>

--- a/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
@@ -30,7 +30,7 @@
                                     <span slot="question">
                                         {% blocktranslate trimmed with event_name=event.name %}
                                             Do you really want to delete the event <strong>{{ event_name }}</strong>?
-                                        {% endblocktrans %}
+                                        {% endblocktranslate %}
                                     </span>
 
                                     <button slot="show-button" type="button" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Delete' %}">

--- a/evap/rewards/templates/rewards_reward_point_redemption_events.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_events.html
@@ -2,17 +2,17 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Reward Point Redemption Events' %}</li>
+    <li class="breadcrumb-item">{% translate 'Reward Point Redemption Events' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
     <div class="row mb-2">
         <div class="col">
-            <a href="{% url 'rewards:reward_point_redemption_event_create' %}" class="btn btn-dark btn-sm">{% trans 'Create new event' %}</a>
+            <a href="{% url 'rewards:reward_point_redemption_event_create' %}" class="btn btn-dark btn-sm">{% translate 'Create new event' %}</a>
         </div>
         <div class="col text-end">
-            {% trans 'Available reward points' %}: {{ total_points_available }}
+            {% translate 'Available reward points' %}: {{ total_points_available }}
         </div>
     </div>
 
@@ -33,18 +33,18 @@
                 assert(response.ok);
                 fadeOutThenRemove(document.querySelector(`#event-row-${body.get("event_id")}`));
             }).catch(error => {
-                window.alert("{% trans 'The server is not responding.' %}");
+                window.alert("{% translate 'The server is not responding.' %}");
             });
         });
     </script>
 
     <div class="card card-outline-primary mb-3">
-        {% trans 'Upcoming events' as title %}
+        {% translate 'Upcoming events' as title %}
         {% include 'rewards_reward_point_redemption_event_list.html' with title=title events=upcoming_events %}
     </div>
 
     <div class="card">
-        {% trans 'Past events' as title %}
+        {% translate 'Past events' as title %}
         {% include 'rewards_reward_point_redemption_event_list.html' with title=title events=past_events %}
     </div>
 {% endblock %}

--- a/evap/staff/templates/staff_base.html
+++ b/evap/staff/templates/staff_base.html
@@ -1,15 +1,15 @@
 {% extends 'base.html' %}
 
-{% block title %}{% trans 'Manage' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'Manage' %} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb_bar %}
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
             {% block breadcrumb %}
                 {% if disable_breadcrumb_manager or not user.is_manager %}
-                    <li class="breadcrumb-item">{% trans 'Manage' %}</li>
+                    <li class="breadcrumb-item">{% translate 'Manage' %}</li>
                 {% else %}
-                    <li class="breadcrumb-item"><a href="{% url 'staff:index' %}">{% trans 'Manage' %}</a></li>
+                    <li class="breadcrumb-item"><a href="{% url 'staff:index' %}">{% translate 'Manage' %}</a></li>
                 {% endif %}
             {% endblock %}
         </ul>

--- a/evap/staff/templates/staff_course_copyform.html
+++ b/evap/staff/templates/staff_course_copyform.html
@@ -3,7 +3,7 @@
 {% block content %}
     {{ block.super }}
     <h3>
-        {% trans 'Create copy of course' %}
+        {% translate 'Create copy of course' %}
     </h3>
     <form id="course-form" method="POST" class="form-horizontal multiselect-form tomselectform">
         {% csrf_token %}
@@ -16,7 +16,7 @@
 
         <div class="card mb-3">
             <div class="card-body">
-                <h5 class="card-title">{% trans 'Evaluations that will be copied' %}</h5>
+                <h5 class="card-title">{% translate 'Evaluations that will be copied' %}</h5>
                 {% if course.evaluations.count > 0 %}
                     <ul>
                         {% for evaluation in evaluations %}
@@ -26,14 +26,14 @@
                         {% endfor %}
                     </ul>
                 {% else %}
-                    <span class="fst-italic">{% trans 'There are no evaluations for this course.' %}</span>
+                    <span class="fst-italic">{% translate 'There are no evaluations for this course.' %}</span>
                 {% endif %}
             </div>
         </div>
 
         <div class="card card-submit-area card-submit-area-3 text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_course_form.html
+++ b/evap/staff/templates/staff_course_form.html
@@ -6,7 +6,7 @@
         {% if course_form.instance.id %}
             {{ course.name }} ({{ course.semester.name }})
         {% else %}
-            {% trans 'Create course' %}
+            {% translate 'Create course' %}
         {% endif %}
     </h3>
     <form id="course-form" method="POST" class="form-horizontal multiselect-form tomselectform">
@@ -21,7 +21,7 @@
         {% if course_form.instance.id %}
             <div class="card mb-3">
                 <div class="card-body">
-                    <h5 class="card-title">{% trans 'Evaluations' %}</h5>
+                    <h5 class="card-title">{% translate 'Evaluations' %}</h5>
                     {% if course.evaluations.count > 0 %}
                         <ul>
                             {% for evaluation in course.evaluations.all %}
@@ -33,7 +33,7 @@
                             {% endfor %}
                         </ul>
                     {% else %}
-                        <span class="fst-italic">{% trans 'There are no evaluations for this course.' %}</span>
+                        <span class="fst-italic">{% translate 'There are no evaluations for this course.' %}</span>
                     {% endif %}
                 </div>
             </div>
@@ -42,9 +42,9 @@
         {% if editable %}
             <div class="card card-submit-area card-submit-area-3 text-center mb-3">
                 <div class="card-body">
-                    <button name="operation" value="save" type="submit" class="btn btn-primary">{% trans 'Save' %}</button>
-                    <button name="operation" value="save_create_evaluation" type="submit" class="btn btn-dark">{% trans 'Save and create evaluation' %}</button>
-                    <button name="operation" value="save_create_single_result" type="submit" class="btn btn-dark">{% trans 'Save and create single result' %}</button>
+                    <button name="operation" value="save" type="submit" class="btn btn-primary">{% translate 'Save' %}</button>
+                    <button name="operation" value="save_create_evaluation" type="submit" class="btn btn-dark">{% translate 'Save and create evaluation' %}</button>
+                    <button name="operation" value="save_create_single_result" type="submit" class="btn btn-dark">{% translate 'Save and create single result' %}</button>
                 </div>
             </div>
         {% endif %}

--- a/evap/staff/templates/staff_course_type_index.html
+++ b/evap/staff/templates/staff_course_type_index.html
@@ -4,14 +4,14 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Course types' %}</li>
+    <li class="breadcrumb-item">{% translate 'Course types' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
 
     <div class="mb-3">
-        <a href="{% url 'staff:course_type_merge_selection' %}" class="btn btn-sm btn-secondary">{% trans 'Merge course types' %}</a>
+        <a href="{% url 'staff:course_type_merge_selection' %}" class="btn btn-sm btn-secondary">{% translate 'Merge course types' %}</a>
     </div>
 
     <form id="course-type-form" method="POST" class="form-horizontal tomselectform">
@@ -24,10 +24,10 @@
                     <thead>
                         <tr>
                             <th class="movable"></th>
-                            <th style="width: 30%">{% trans 'Name (German)' %}</th>
-                            <th style="width: 30%">{% trans 'Name (English)' %}</th>
-                            <th style="width: 30%">{% trans 'Import names' %}</th>
-                            <th class="text-end" style="width: 10%">{% trans 'Actions' %}</th>
+                            <th style="width: 30%">{% translate 'Name (German)' %}</th>
+                            <th style="width: 30%">{% translate 'Name (English)' %}</th>
+                            <th style="width: 30%">{% translate 'Import names' %}</th>
+                            <th class="text-end" style="width: 10%">{% translate 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -53,7 +53,7 @@
                                         {% include 'bootstrap_form_field_widget.html' with field=form.DELETE class="d-none" %}
                                     {% else %}
                                         <button type="button" disabled class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="left"
-                                            title="{% trans 'This course type cannot be deleted because it is used for at least one course.' %}">
+                                            title="{% translate 'This course type cannot be deleted because it is used for at least one course.' %}">
                                             <span class="fas fa-trash"></span>
                                         </button>
                                     {% endif %}
@@ -66,7 +66,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save course types' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save course types' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_course_type_merge.html
+++ b/evap/staff/templates/staff_course_type_merge.html
@@ -4,13 +4,13 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:course_type_index' %}">{% trans 'Course types' %}</a></li>
-    <li class="breadcrumb-item">{% trans 'Merge course types' %}</li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:course_type_index' %}">{% translate 'Course types' %}</a></li>
+    <li class="breadcrumb-item">{% translate 'Merge course types' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
-    <h3>{% trans 'Merge course types' %}</h3>
+    <h3>{% translate 'Merge course types' %}</h3>
 
     <div class="card mb-3">
         <div class="card-body">
@@ -32,7 +32,7 @@
         {% csrf_token %}
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Merge course types' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Merge course types' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_course_type_merge.html
+++ b/evap/staff/templates/staff_course_type_merge.html
@@ -15,7 +15,7 @@
     <div class="card mb-3">
         <div class="card-body">
             <p>
-                {% blocktrans %}The following courses currently have the course type <strong>{{ other_type }}</strong> and will
+                {% blocktranslate %}The following courses currently have the course type <strong>{{ other_type }}</strong> and will
                 get the type <strong>{{ main_type }}</strong> once you merge the course types. The course type <strong>
                 {{ other_type }}</strong> will be deleted after that.{% endblocktrans %}
             </p>

--- a/evap/staff/templates/staff_course_type_merge.html
+++ b/evap/staff/templates/staff_course_type_merge.html
@@ -17,7 +17,7 @@
             <p>
                 {% blocktranslate %}The following courses currently have the course type <strong>{{ other_type }}</strong> and will
                 get the type <strong>{{ main_type }}</strong> once you merge the course types. The course type <strong>
-                {{ other_type }}</strong> will be deleted after that.{% endblocktrans %}
+                {{ other_type }}</strong> will be deleted after that.{% endblocktranslate %}
             </p>
 
             <ul>

--- a/evap/staff/templates/staff_course_type_merge_selection.html
+++ b/evap/staff/templates/staff_course_type_merge_selection.html
@@ -2,25 +2,25 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:course_type_index' %}">{% trans 'Course types' %}</a></li>
-    <li class="breadcrumb-item">{% trans 'Merge course types' %}</li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:course_type_index' %}">{% translate 'Course types' %}</a></li>
+    <li class="breadcrumb-item">{% translate 'Merge course types' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
-    <h3>{% trans 'Merge course types' %}</h3>
+    <h3>{% translate 'Merge course types' %}</h3>
 
     <form id="course-type-merge-selection-form" method="POST" class="form-horizontal">
         {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
-                <p>{% trans 'Select the course types you want to merge.' %}</p>
+                <p>{% translate 'Select the course types you want to merge.' %}</p>
                 {% include 'bootstrap_form.html' with form=form %}
             </div>
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Show merge info' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Show merge info' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_degree_index.html
+++ b/evap/staff/templates/staff_degree_index.html
@@ -4,7 +4,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Degrees' %}</li>
+    <li class="breadcrumb-item">{% translate 'Degrees' %}</li>
 {% endblock %}
 
 {% block content %}
@@ -20,10 +20,10 @@
                     <thead>
                         <tr>
                             <th class="movable"></th>
-                            <th style="width: 25%">{% trans 'Name (German)' %}</th>
-                            <th style="width: 25%">{% trans 'Name (English)' %}</th>
-                            <th style="width: 40%">{% trans 'Import names' %}</th>
-                            <th class="text-end" style="width: 10%">{% trans 'Actions' %}</th>
+                            <th style="width: 25%">{% translate 'Name (German)' %}</th>
+                            <th style="width: 25%">{% translate 'Name (English)' %}</th>
+                            <th style="width: 40%">{% translate 'Import names' %}</th>
+                            <th class="text-end" style="width: 10%">{% translate 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -49,7 +49,7 @@
                                         {% include 'bootstrap_form_field_widget.html' with field=form.DELETE class="d-none" %}
                                     {% else %}
                                         <button type="button" disabled class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="left"
-                                            title="{% trans 'This degree cannot be deleted because it is used for at least one course.' %}">
+                                            title="{% translate 'This degree cannot be deleted because it is used for at least one course.' %}">
                                             <span class="fas fa-trash"></span>
                                         </button>
                                     {% endif %}
@@ -62,7 +62,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save degrees' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save degrees' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_email_preview_form.html
+++ b/evap/staff/templates/staff_email_preview_form.html
@@ -4,21 +4,21 @@
         <div class="form-check mb-2">
             <input class="form-check-input" id="send_email{{ id_suffix }}" type="checkbox" name="send_email{{ id_suffix }}"
                 checked onclick="document.getElementById('email_form').classList.toggle('d-none');" />
-            <label class="form-check-label" for="send_email{{ id_suffix }}">{% trans 'Send email notifications' %}</label>
+            <label class="form-check-label" for="send_email{{ id_suffix }}">{% translate 'Send email notifications' %}</label>
         </div>
         <div class="email-form" id="email_form{{ id_suffix}}">
             <div class="mb-3 d-flex">
-                <div class="form-label pe-4">{% trans 'Email subject' %}</div>
+                <div class="form-label pe-4">{% translate 'Email subject' %}</div>
                 <div class="form-field"><input class="form-control" name="email_subject{{ id_suffix }}" type="text" value="{{ email_template.subject }}" /></div>
             </div>
             <div class="mb-3 d-flex">
                 <div class="form-label pe-4">
                     <div class="nav nav-pills btn-switch btn-group-vertical float-end" role="tablist">
                         <a class="p-1 space-normal fw-bold btn btn-light text-center nav-link show active" href="#tab-plain{{ id_suffix }}" data-bs-toggle="pill" role="tab" aria-controls="pills-plain{{ id_suffix }}" aria-selected="true">
-                            {% trans 'Plain Text' %}
+                            {% translate 'Plain Text' %}
                         </a>
                         <a class="p-1 space-normal fw-bold btn btn-light text-center nav-link" href="#tab-html{{ id_suffix }}" data-bs-toggle="pill" role="tab" aria-controls="pills-html{{ id_suffix }}" aria-selected="false">
-                            {% trans 'HTML' %}
+                            {% translate 'HTML' %}
                         </a>
                     </div>
                 </div>

--- a/evap/staff/templates/staff_evaluation_email.html
+++ b/evap/staff/templates/staff_evaluation_email.html
@@ -28,7 +28,7 @@
                                                         </label>
                                                     {% endfor %}
                                                 </div>
-                                                <button name="export" type="submit" formnovalidate class="btn btn-sm btn-secondary">{% trans 'Show Recipients' %}</button>
+                                                <button name="export" type="submit" formnovalidate class="btn btn-sm btn-secondary">{% translate 'Show Recipients' %}</button>
                                             </div>
                                         </div>
                                     {% else %}
@@ -44,7 +44,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button name="send" type="submit" class="btn btn-primary">{% trans 'Send email' %}</button>
+                <button name="send" type="submit" class="btn btn-primary">{% translate 'Send email' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_evaluation_email.html
+++ b/evap/staff/templates/staff_evaluation_email.html
@@ -5,7 +5,7 @@
 {% block content %}
     {{ block.super }}
     {% if form.errors %}
-        <div class="alert alert-danger" role="alert">{% blocktranslate %}Please fill out all required fields and select at least one recipient group.{% endblocktrans %}</div>
+        <div class="alert alert-danger" role="alert">{% blocktranslate %}Please fill out all required fields and select at least one recipient group.{% endblocktranslate %}</div>
     {% endif %}
     <form id="evaluation-email-form" method="POST" class="form-horizontal">
         {% csrf_token %}

--- a/evap/staff/templates/staff_evaluation_email.html
+++ b/evap/staff/templates/staff_evaluation_email.html
@@ -5,7 +5,7 @@
 {% block content %}
     {{ block.super }}
     {% if form.errors %}
-        <div class="alert alert-danger" role="alert">{% blocktrans %}Please fill out all required fields and select at least one recipient group.{% endblocktrans %}</div>
+        <div class="alert alert-danger" role="alert">{% blocktranslate %}Please fill out all required fields and select at least one recipient group.{% endblocktrans %}</div>
     {% endif %}
     <form id="evaluation-email-form" method="POST" class="form-horizontal">
         {% csrf_token %}

--- a/evap/staff/templates/staff_evaluation_evaluation_period.html
+++ b/evap/staff/templates/staff_evaluation_evaluation_period.html
@@ -11,16 +11,16 @@
         {% if state < evaluation.State.IN_EVALUATION  %}
             {% if evaluation.days_until_evaluation < 0 %}
                 <div class="badge bg-danger">
-                    {% trans 'Overdue' %}
+                    {% translate 'Overdue' %}
                 </div>
             {% else %}
                 <div class="badge {% if evaluation.days_until_evaluation <= 7 %}bg-warning{% else %}bg-light{% endif %}">
-                    {% trans 'Begins in' %} {{ evaluation.vote_start_datetime|timeuntil }}
+                    {% translate 'Begins in' %} {{ evaluation.vote_start_datetime|timeuntil }}
                 </div>
             {% endif %}
         {% elif state == evaluation.State.IN_EVALUATION %}
             <div class="badge {% if evaluation.days_left_for_evaluation <= 3 %}bg-dark{% else %}bg-light{% endif %}">
-                {% trans 'Ends in' %} {{ evaluation.vote_end_datetime|timeuntil }}
+                {% translate 'Ends in' %} {{ evaluation.vote_end_datetime|timeuntil }}
             </div>
         {% endif %}
     {% endif %}

--- a/evap/staff/templates/staff_evaluation_evaluation_period.html
+++ b/evap/staff/templates/staff_evaluation_evaluation_period.html
@@ -5,7 +5,7 @@
 {% else %}
     <span class="small">
         {{ evaluation.vote_start_datetime }}{% if not start_only %} &ndash;<br />
-        {{ evaluation.vote_end_date }} ({% blocktranslate count runtime=evaluation.runtime %}{{ runtime }} day{% plural %}{{ runtime }} days{% endblocktrans %}){% endif %}
+        {{ evaluation.vote_end_date }} ({% blocktranslate count runtime=evaluation.runtime %}{{ runtime }} day{% plural %}{{ runtime }} days{% endblocktranslate %}){% endif %}
     </span><br />
     {% if not start_only %}
         {% if state < evaluation.State.IN_EVALUATION  %}

--- a/evap/staff/templates/staff_evaluation_evaluation_period.html
+++ b/evap/staff/templates/staff_evaluation_evaluation_period.html
@@ -5,7 +5,7 @@
 {% else %}
     <span class="small">
         {{ evaluation.vote_start_datetime }}{% if not start_only %} &ndash;<br />
-        {{ evaluation.vote_end_date }} ({% blocktrans count runtime=evaluation.runtime %}{{ runtime }} day{% plural %}{{ runtime }} days{% endblocktrans %}){% endif %}
+        {{ evaluation.vote_end_date }} ({% blocktranslate count runtime=evaluation.runtime %}{{ runtime }} day{% plural %}{{ runtime }} days{% endblocktrans %}){% endif %}
     </span><br />
     {% if not start_only %}
         {% if state < evaluation.State.IN_EVALUATION  %}

--- a/evap/staff/templates/staff_evaluation_form.html
+++ b/evap/staff/templates/staff_evaluation_form.html
@@ -8,7 +8,7 @@
         {% if evaluation_form.instance.id %}
             {{ evaluation.full_name }} ({{ evaluation.course.semester.name }})
         {% else %}
-            {% trans 'Create evaluation' %}
+            {% translate 'Create evaluation' %}
         {% endif %}
     </h3>
     {% if evaluation_form.instance.id %}
@@ -37,20 +37,20 @@
         <div class="card card-submit-area{% if state <= evaluation.State.EDITOR_APPROVED %} card-submit-area-2{% endif %} text-center mb-3">
             <div class="card-body">
                 {% if questionnaires_with_answers_per_contributor %}
-                    <div class="alert alert-danger">{% trans 'You are editing an evaluation, for which answers have already been received. If you remove any of the questionnaires highlighted in red above, all related answers will be permanently deleted.' %}</div>
+                    <div class="alert alert-danger">{% translate 'You are editing an evaluation, for which answers have already been received. If you remove any of the questionnaires highlighted in red above, all related answers will be permanently deleted.' %}</div>
                 {% endif %}
                 {% if state == evaluation.State.IN_EVALUATION %}
-                    <div class="alert alert-warning">{% trans 'You are editing an evaluation, which is already running. Please note that only the participants who did not evaluate yet will see your changes.' %}</div>
+                    <div class="alert alert-warning">{% translate 'You are editing an evaluation, which is already running. Please note that only the participants who did not evaluate yet will see your changes.' %}</div>
                 {% endif %}
                 {% if state == evaluation.State.EVALUATED or state == evaluation.State.REVIEWED %}
-                    <div class="alert alert-warning">{% trans 'You are editing an evaluation, for which the evaluation already finished. Please be careful to not destroy any results.' %}</div>
+                    <div class="alert alert-warning">{% translate 'You are editing an evaluation, for which the evaluation already finished. Please be careful to not destroy any results.' %}</div>
                 {% endif %}
                 {% if state == evaluation.State.NEW or state == evaluation.State.PREPARED %}
-                    <div class="alert alert-warning">{% trans 'You are editing an evaluation which has not been approved by the editor yet.' %}</div>
+                    <div class="alert alert-warning">{% translate 'You are editing an evaluation which has not been approved by the editor yet.' %}</div>
                 {% endif %}
-                <button name="operation" value="save" type="submit" class="btn btn-primary">{% trans 'Save' %}</button>
+                <button name="operation" value="save" type="submit" class="btn btn-primary">{% translate 'Save' %}</button>
                 {% if state == evaluation.State.NEW or state == evaluation.State.PREPARED or state == evaluation.State.EDITOR_APPROVED %}
-                    <button name="operation" value="approve" type="submit" class="btn btn-success">{% trans 'Save and approve' %}</button>
+                    <button name="operation" value="approve" type="submit" class="btn btn-success">{% translate 'Save and approve' %}</button>
                 {% endif %}
             </div>
         </div>

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -43,11 +43,11 @@
                     </div>
                 {% else %}
                     <div class="col">
-                        {% trans 'Notify Contributors' as heading %}
+                        {% translate 'Notify Contributors' as heading %}
                         {% include "staff_email_preview_form.html" with email_template=email_template_contributor id_suffix="_contributor" heading=heading %}
                     </div>
                     <div class="col">
-                        {% trans 'Notify Participants' as heading %}
+                        {% translate 'Notify Participants' as heading %}
                         {% include "staff_email_preview_form.html" with email_template=email_template_participant id_suffix="_participant" heading=heading %}
                     </div>
                 {% endif %}
@@ -57,8 +57,8 @@
 
         <div class="card card-submit-area card-submit-area-2 text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Confirm' %}</button>
-                <a href="{% url 'staff:semester_view' semester.id %}" class="btn btn-light">{% trans 'Cancel' %}</a>
+                <button type="submit" class="btn btn-primary">{% translate 'Confirm' %}</button>
+                <a href="{% url 'staff:semester_view' semester.id %}" class="btn btn-light">{% translate 'Cancel' %}</a>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_evaluation_person_management.html
+++ b/evap/staff/templates/staff_evaluation_person_management.html
@@ -32,7 +32,7 @@
                                     <span slot="title">{% translate 'Import participants' %}</span>
                                     <span slot="action-text">{% translate 'Import participants' %}</span>
                                     <span slot="question">
-                                        {% blocktrans trimmed %}
+                                        {% blocktranslate trimmed %}
                                             Do you really want to import the Excel file with participant data?
                                         {% endblocktrans %}
                                     </span>
@@ -44,7 +44,7 @@
                                     <span slot="title">{% translate 'Replace participants' %}</span>
                                     <span slot="action-text">{% translate 'Replace participants' %}</span>
                                     <span slot="question">
-                                        {% blocktrans trimmed %}
+                                        {% blocktranslate trimmed %}
                                             Do you really want to delete all existing participants and replace them with participant data from the Excel file?
                                         {% endblocktrans %}
                                     </span>
@@ -72,7 +72,7 @@
                             <span slot="title">{% translate 'Copy participants' %}</span>
                             <span slot="action-text">{% translate 'Copy participants' %}</span>
                             <span slot="question">
-                                {% blocktrans trimmed %}
+                                {% blocktranslate trimmed %}
                                     Do you really want to copy the participants?
                                 {% endblocktrans %}
                             </span>
@@ -83,7 +83,7 @@
                             <span slot="title">{% translate 'Replace participants' %}</span>
                             <span slot="action-text">{% translate 'Replace participants' %}</span>
                             <span slot="question">
-                                {% blocktrans trimmed %}
+                                {% blocktranslate trimmed %}
                                     Do you really want to delete all existing participants and copy the participants into the evaluation?
                                 {% endblocktrans %}
                             </span>
@@ -122,7 +122,7 @@
                                     <span slot="title">{% translate 'Import contributors' %}</span>
                                     <span slot="action-text">{% translate 'Import contributors' %}</span>
                                     <span slot="question">
-                                        {% blocktrans trimmed %}
+                                        {% blocktranslate trimmed %}
                                             Do you really want to import the Excel file with contributor data?
                                         {% endblocktrans %}
                                     </span>
@@ -133,7 +133,7 @@
                                     <span slot="title">{% translate 'Replace contributors' %}</span>
                                     <span slot="action-text">{% translate 'Replace contributors' %}</span>
                                     <span slot="question">
-                                        {% blocktrans trimmed %}
+                                        {% blocktranslate trimmed %}
                                             Do you really want to delete all existing contributors and replace them with contributor data from the Excel file?
                                         {% endblocktrans %}
                                     </span>
@@ -161,7 +161,7 @@
                             <span slot="title">{% translate 'Copy contributors' %}</span>
                             <span slot="action-text">{% translate 'Copy contributors' %}</span>
                             <span slot="question">
-                                {% blocktrans trimmed %}
+                                {% blocktranslate trimmed %}
                                     Do you really want to copy the contributors?
                                 {% endblocktrans %}
                             </span>
@@ -172,7 +172,7 @@
                             <span slot="title">{% translate 'Replace contributors' %}</span>
                             <span slot="action-text">{% translate 'Replace contributors' %}</span>
                             <span slot="question">
-                                {% blocktrans trimmed %}
+                                {% blocktranslate trimmed %}
                                     Do you really want to delete all existing contributors and copy the contributors into the evaluation?
                                 {% endblocktrans %}
                             </span>

--- a/evap/staff/templates/staff_evaluation_person_management.html
+++ b/evap/staff/templates/staff_evaluation_person_management.html
@@ -13,43 +13,43 @@
                 {% csrf_token %}
                 <div class="card">
                     <div class="card-body h-100">
-                        <h4 class="card-title">{% trans 'Import participants' %}</h4>
-                        <h6 class="card-subtitle mb-2 text-muted">{% trans 'From Excel file' %}</h6>
+                        <h4 class="card-title">{% translate 'Import participants' %}</h4>
+                        <h6 class="card-subtitle mb-2 text-muted">{% translate 'From Excel file' %}</h6>
                         <p class="card-text">
-                            {% trans 'Upload Excel file with participant data' %} (<a href="{% url 'staff:download_sample_file' 'sample_user.xlsx' %}">{% trans 'Download sample file' %}</a>,
-                            <button type="button" class="btn btn-link" onclick="copyHeaders(['Title', 'First name', 'Last name', 'Email'])">{% trans 'Copy headers to clipboard' %}</button>).
-                            {% trans 'This will create all containing users.' %}
+                            {% translate 'Upload Excel file with participant data' %} (<a href="{% url 'staff:download_sample_file' 'sample_user.xlsx' %}">{% translate 'Download sample file' %}</a>,
+                            <button type="button" class="btn btn-link" onclick="copyHeaders(['Title', 'First name', 'Last name', 'Email'])">{% translate 'Copy headers to clipboard' %}</button>).
+                            {% translate 'This will create all containing users.' %}
                         </p>
                         {% include 'bootstrap_form.html' with form=participant_excel_form wide=True %}
                     </div>
                     <div class="card-footer text-center">
                         {% if not participant_test_passed %}
-                            <button name="operation" value="test-participants" type="submit" class="btn btn-sm btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
+                            <button name="operation" value="test-participants" type="submit" class="btn btn-sm btn-light form-submit-btn">{% translate 'Upload and test' %}</button>
                         {% else %}
-                            <button name="operation" value="test-participants" type="submit" class="btn btn-sm btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
+                            <button name="operation" value="test-participants" type="submit" class="btn btn-sm btn-light form-submit-btn">{% translate 'Upload and test' %}</button>
                             <div class="mt-2">
                                 <confirmation-modal type="submit" name="operation" value="import-participants">
-                                    <span slot="title">{% trans 'Import participants' %}</span>
-                                    <span slot="action-text">{% trans 'Import participants' %}</span>
+                                    <span slot="title">{% translate 'Import participants' %}</span>
+                                    <span slot="action-text">{% translate 'Import participants' %}</span>
                                     <span slot="question">
                                         {% blocktrans trimmed %}
                                             Do you really want to import the Excel file with participant data?
                                         {% endblocktrans %}
                                     </span>
 
-                                    <button slot="show-button" type="button" class="btn btn-sm btn-primary me-1 form-submit-btn">{% trans 'Import previously uploaded file' %}</button>
+                                    <button slot="show-button" type="button" class="btn btn-sm btn-primary me-1 form-submit-btn">{% translate 'Import previously uploaded file' %}</button>
                                 </confirmation-modal>
 
                                 <confirmation-modal type="submit" name="operation" value="import-replace-participants" confirm-button-class="btn-danger">
-                                    <span slot="title">{% trans 'Replace participants' %}</span>
-                                    <span slot="action-text">{% trans 'Replace participants' %}</span>
+                                    <span slot="title">{% translate 'Replace participants' %}</span>
+                                    <span slot="action-text">{% translate 'Replace participants' %}</span>
                                     <span slot="question">
                                         {% blocktrans trimmed %}
                                             Do you really want to delete all existing participants and replace them with participant data from the Excel file?
                                         {% endblocktrans %}
                                     </span>
 
-                                    <button slot="show-button" type="button" class="btn btn-sm btn-danger form-submit-btn">{% trans 'Replace participants' %}</button>
+                                    <button slot="show-button" type="button" class="btn btn-sm btn-danger form-submit-btn">{% translate 'Replace participants' %}</button>
                                 </confirmation-modal>
                             </div>
                         {% endif %}
@@ -62,33 +62,33 @@
                 {% csrf_token %}
                 <div class="card h-100">
                     <div class="card-body">
-                        <h4 class="card-title">{% trans 'Copy participants' %}</h4>
-                    <h6 class="card-subtitle mb-2 text-muted">{% trans 'From other evaluation' %}</h6>
-                        <p class="card-text">{% trans 'Copy participants from another evaluation.' %}</p>
+                        <h4 class="card-title">{% translate 'Copy participants' %}</h4>
+                    <h6 class="card-subtitle mb-2 text-muted">{% translate 'From other evaluation' %}</h6>
+                        <p class="card-text">{% translate 'Copy participants from another evaluation.' %}</p>
                         {% include 'bootstrap_form.html' with form=participant_copy_form wide=True %}
                     </div>
                     <div class="card-footer text-center">
                         <confirmation-modal type="submit" name="operation" value="copy-participants">
-                            <span slot="title">{% trans 'Copy participants' %}</span>
-                            <span slot="action-text">{% trans 'Copy participants' %}</span>
+                            <span slot="title">{% translate 'Copy participants' %}</span>
+                            <span slot="action-text">{% translate 'Copy participants' %}</span>
                             <span slot="question">
                                 {% blocktrans trimmed %}
                                     Do you really want to copy the participants?
                                 {% endblocktrans %}
                             </span>
 
-                            <button slot="show-button" type="button" class="btn btn-sm btn-primary form-submit-btn">{% trans 'Copy participants' %}</button>
+                            <button slot="show-button" type="button" class="btn btn-sm btn-primary form-submit-btn">{% translate 'Copy participants' %}</button>
                         </confirmation-modal>
                         <confirmation-modal type="submit" name="operation" value="copy-replace-participants" confirm-button-class="btn-danger">
-                            <span slot="title">{% trans 'Replace participants' %}</span>
-                            <span slot="action-text">{% trans 'Replace participants' %}</span>
+                            <span slot="title">{% translate 'Replace participants' %}</span>
+                            <span slot="action-text">{% translate 'Replace participants' %}</span>
                             <span slot="question">
                                 {% blocktrans trimmed %}
                                     Do you really want to delete all existing participants and copy the participants into the evaluation?
                                 {% endblocktrans %}
                             </span>
 
-                            <button slot="show-button" type="button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% trans 'Replace participants' %}</button>
+                            <button slot="show-button" type="button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% translate 'Replace participants' %}</button>
                         </confirmation-modal>
                     </div>
                 </div>
@@ -102,43 +102,43 @@
                 {% csrf_token %}
                 <div class="card h-100">
                     <div class="card-body">
-                        <h4 class="card-title">{% trans 'Import contributors' %}</h4>
-                        <h6 class="card-subtitle mb-2 text-muted">{% trans 'From Excel file' %}</h6>
+                        <h4 class="card-title">{% translate 'Import contributors' %}</h4>
+                        <h6 class="card-subtitle mb-2 text-muted">{% translate 'From Excel file' %}</h6>
                         <p class="card-text">
-                            {% trans 'Upload Excel file with contributor data' %}
-                            (<a href="{% url 'staff:download_sample_file' 'sample_user.xlsx' %}">{% trans 'Download sample file' %}</a>,
-                            <button type="button" class="btn btn-link" onclick="copyHeaders(['Title', 'First name', 'Last name', 'Email'])">{% trans 'Copy headers to clipboard' %}</button>).
-                            {% trans 'This will create all containing users.' %}
+                            {% translate 'Upload Excel file with contributor data' %}
+                            (<a href="{% url 'staff:download_sample_file' 'sample_user.xlsx' %}">{% translate 'Download sample file' %}</a>,
+                            <button type="button" class="btn btn-link" onclick="copyHeaders(['Title', 'First name', 'Last name', 'Email'])">{% translate 'Copy headers to clipboard' %}</button>).
+                            {% translate 'This will create all containing users.' %}
                         </p>
                         {% include 'bootstrap_form.html' with form=contributor_excel_form wide=True %}
                     </div>
                     <div class="card-footer text-center">
                         {% if not contributor_test_passed %}
-                            <button name="operation" value="test-contributors" type="submit" class="btn btn-sm btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
+                            <button name="operation" value="test-contributors" type="submit" class="btn btn-sm btn-light form-submit-btn">{% translate 'Upload and test' %}</button>
                         {% else %}
-                            <button name="operation" value="test-contributors" type="submit" class="btn btn-sm btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
+                            <button name="operation" value="test-contributors" type="submit" class="btn btn-sm btn-light form-submit-btn">{% translate 'Upload and test' %}</button>
                             <div class="mt-2">
                                 <confirmation-modal type="submit" name="operation" value="import-contributors">
-                                    <span slot="title">{% trans 'Import contributors' %}</span>
-                                    <span slot="action-text">{% trans 'Import contributors' %}</span>
+                                    <span slot="title">{% translate 'Import contributors' %}</span>
+                                    <span slot="action-text">{% translate 'Import contributors' %}</span>
                                     <span slot="question">
                                         {% blocktrans trimmed %}
                                             Do you really want to import the Excel file with contributor data?
                                         {% endblocktrans %}
                                     </span>
 
-                                    <button slot="show-button" type="button" class="btn btn-sm btn-primary form-submit-btn">{% trans 'Import previously uploaded file' %}</button>
+                                    <button slot="show-button" type="button" class="btn btn-sm btn-primary form-submit-btn">{% translate 'Import previously uploaded file' %}</button>
                                 </confirmation-modal>
                                 <confirmation-modal type="submit" name="operation" value="import-replace-contributors" confirm-button-class="btn-danger">
-                                    <span slot="title">{% trans 'Replace contributors' %}</span>
-                                    <span slot="action-text">{% trans 'Replace contributors' %}</span>
+                                    <span slot="title">{% translate 'Replace contributors' %}</span>
+                                    <span slot="action-text">{% translate 'Replace contributors' %}</span>
                                     <span slot="question">
                                         {% blocktrans trimmed %}
                                             Do you really want to delete all existing contributors and replace them with contributor data from the Excel file?
                                         {% endblocktrans %}
                                     </span>
 
-                                    <button slot="show-button" type="button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% trans 'Replace contributors' %}</button>
+                                    <button slot="show-button" type="button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% translate 'Replace contributors' %}</button>
                                 </confirmation-modal>
                             </div>
                         {% endif %}
@@ -151,33 +151,33 @@
                 {% csrf_token %}
                 <div class="card h-100">
                     <div class="card-body">
-                        <h4 class="card-title">{% trans 'Copy contributors' %}</h4>
-                    <h6 class="card-subtitle mb-2 text-muted">{% trans 'From other evaluation' %}</h6>
-                        <p class="card-text">{% trans 'Copy contributors from another evaluation.' %}</p>
+                        <h4 class="card-title">{% translate 'Copy contributors' %}</h4>
+                    <h6 class="card-subtitle mb-2 text-muted">{% translate 'From other evaluation' %}</h6>
+                        <p class="card-text">{% translate 'Copy contributors from another evaluation.' %}</p>
                         {% include 'bootstrap_form.html' with form=contributor_copy_form wide=True %}
                     </div>
                     <div class="card-footer text-center">
                         <confirmation-modal type="submit" name="operation" value="copy-contributors">
-                            <span slot="title">{% trans 'Copy contributors' %}</span>
-                            <span slot="action-text">{% trans 'Copy contributors' %}</span>
+                            <span slot="title">{% translate 'Copy contributors' %}</span>
+                            <span slot="action-text">{% translate 'Copy contributors' %}</span>
                             <span slot="question">
                                 {% blocktrans trimmed %}
                                     Do you really want to copy the contributors?
                                 {% endblocktrans %}
                             </span>
 
-                            <button slot="show-button" type="button" class="btn btn-sm btn-primary form-submit-btn">{% trans 'Copy contributors' %}</button>
+                            <button slot="show-button" type="button" class="btn btn-sm btn-primary form-submit-btn">{% translate 'Copy contributors' %}</button>
                         </confirmation-modal>
                         <confirmation-modal type="submit" name="operation" value="copy-replace-contributors" confirm-button-class="btn-danger">
-                            <span slot="title">{% trans 'Replace contributors' %}</span>
-                            <span slot="action-text">{% trans 'Replace contributors' %}</span>
+                            <span slot="title">{% translate 'Replace contributors' %}</span>
+                            <span slot="action-text">{% translate 'Replace contributors' %}</span>
                             <span slot="question">
                                 {% blocktrans trimmed %}
                                     Do you really want to delete all existing contributors and copy the contributors into the evaluation?
                                 {% endblocktrans %}
                             </span>
 
-                            <button slot="show-button" type="button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% trans 'Replace contributors' %}</button>
+                            <button slot="show-button" type="button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% translate 'Replace contributors' %}</button>
                         </confirmation-modal>
                     </div>
                 </div>
@@ -191,15 +191,15 @@
                 {% csrf_token %}
                 <div class="card">
                     <div class="card-body">
-                        <h4 class="card-title">{% trans 'Export login keys' %}</h4>
-                        <h6 class="card-subtitle mb-2 text-muted">{% trans 'To CSV file' %}</h6>
-                        <p class="card-text">{% trans 'This will create a CSV file containing login keys for all external participants.' %}</p>
+                        <h4 class="card-title">{% translate 'Export login keys' %}</h4>
+                        <h6 class="card-subtitle mb-2 text-muted">{% translate 'To CSV file' %}</h6>
+                        <p class="card-text">{% translate 'This will create a CSV file containing login keys for all external participants.' %}</p>
                     </div>
                     <div class="card-footer text-center">
-                        <div{% if not evaluation.has_external_participant %} data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans "This evaluation has no external participants." %}"{% endif %}>
+                        <div{% if not evaluation.has_external_participant %} data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate "This evaluation has no external participants." %}"{% endif %}>
                             <button name="operation" value="export-login-keys" type="submit" class="btn btn-sm btn-primary form-submit-btn"
                             {% if not evaluation.has_external_participant %} disabled{% endif %}>
-                                {% trans 'Export login keys' %}
+                                {% translate 'Export login keys' %}
                             </button>
                         </div>
                     </div>

--- a/evap/staff/templates/staff_evaluation_person_management.html
+++ b/evap/staff/templates/staff_evaluation_person_management.html
@@ -34,7 +34,7 @@
                                     <span slot="question">
                                         {% blocktranslate trimmed %}
                                             Do you really want to import the Excel file with participant data?
-                                        {% endblocktrans %}
+                                        {% endblocktranslate %}
                                     </span>
 
                                     <button slot="show-button" type="button" class="btn btn-sm btn-primary me-1 form-submit-btn">{% translate 'Import previously uploaded file' %}</button>
@@ -46,7 +46,7 @@
                                     <span slot="question">
                                         {% blocktranslate trimmed %}
                                             Do you really want to delete all existing participants and replace them with participant data from the Excel file?
-                                        {% endblocktrans %}
+                                        {% endblocktranslate %}
                                     </span>
 
                                     <button slot="show-button" type="button" class="btn btn-sm btn-danger form-submit-btn">{% translate 'Replace participants' %}</button>
@@ -74,7 +74,7 @@
                             <span slot="question">
                                 {% blocktranslate trimmed %}
                                     Do you really want to copy the participants?
-                                {% endblocktrans %}
+                                {% endblocktranslate %}
                             </span>
 
                             <button slot="show-button" type="button" class="btn btn-sm btn-primary form-submit-btn">{% translate 'Copy participants' %}</button>
@@ -85,7 +85,7 @@
                             <span slot="question">
                                 {% blocktranslate trimmed %}
                                     Do you really want to delete all existing participants and copy the participants into the evaluation?
-                                {% endblocktrans %}
+                                {% endblocktranslate %}
                             </span>
 
                             <button slot="show-button" type="button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% translate 'Replace participants' %}</button>
@@ -124,7 +124,7 @@
                                     <span slot="question">
                                         {% blocktranslate trimmed %}
                                             Do you really want to import the Excel file with contributor data?
-                                        {% endblocktrans %}
+                                        {% endblocktranslate %}
                                     </span>
 
                                     <button slot="show-button" type="button" class="btn btn-sm btn-primary form-submit-btn">{% translate 'Import previously uploaded file' %}</button>
@@ -135,7 +135,7 @@
                                     <span slot="question">
                                         {% blocktranslate trimmed %}
                                             Do you really want to delete all existing contributors and replace them with contributor data from the Excel file?
-                                        {% endblocktrans %}
+                                        {% endblocktranslate %}
                                     </span>
 
                                     <button slot="show-button" type="button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% translate 'Replace contributors' %}</button>
@@ -163,7 +163,7 @@
                             <span slot="question">
                                 {% blocktranslate trimmed %}
                                     Do you really want to copy the contributors?
-                                {% endblocktrans %}
+                                {% endblocktranslate %}
                             </span>
 
                             <button slot="show-button" type="button" class="btn btn-sm btn-primary form-submit-btn">{% translate 'Copy contributors' %}</button>
@@ -174,7 +174,7 @@
                             <span slot="question">
                                 {% blocktranslate trimmed %}
                                     Do you really want to delete all existing contributors and copy the contributors into the evaluation?
-                                {% endblocktrans %}
+                                {% endblocktranslate %}
                             </span>
 
                             <button slot="show-button" type="button" class="btn btn-sm btn-danger ms-1 form-submit-btn">{% translate 'Replace contributors' %}</button>

--- a/evap/staff/templates/staff_evaluation_textanswer_edit.html
+++ b/evap/staff/templates/staff_evaluation_textanswer_edit.html
@@ -2,13 +2,13 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:evaluation_textanswers' evaluation.id %}#{{ textanswer.id }}">{% trans 'Text answers' %}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:evaluation_textanswers' evaluation.id %}#{{ textanswer.id }}">{% translate 'Text answers' %}</a></li>
     <li class="breadcrumb-item">{{ textanswer.id }}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
-    <h3>{% trans 'Text answer' %}</h3>
+    <h3>{% translate 'Text answer' %}</h3>
     <form id="textanswer-edit-form" method="POST" class="form-horizontal">
         {% csrf_token %}
         <div class="card mb-3">
@@ -18,7 +18,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save text answer' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save text answer' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_evaluation_textanswers.html
+++ b/evap/staff/templates/staff_evaluation_textanswers.html
@@ -4,7 +4,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Text answers' %}</li>
+    <li class="breadcrumb-item">{% translate 'Text answers' %}</li>
 {% endblock %}
 
 {% block content %}
@@ -16,35 +16,35 @@
         </div>
         <div class="col-auto">
             <div class="btn-switch btn-switch-light my-auto d-print-none">
-                <div class="btn-switch-label">{% trans 'View' %}</div>
+                <div class="btn-switch-label">{% translate 'View' %}</div>
                 <div class="btn-switch btn-group">
                     <a
                         href="{% url 'staff:evaluation_textanswers' evaluation.id %}"
                         role="button"
                         class="btn btn-sm btn-light{% if view == 'quick' %} active{% endif %}"
                     >
-                        {% trans 'Quick' %}
+                        {% translate 'Quick' %}
                     </a>
                     <a
                         href="{% url 'staff:evaluation_textanswers' evaluation.id %}?view=full"
                         role="button"
                         class="btn btn-sm btn-light{% if view == 'full' %} active{% endif %}"
                     >
-                        {% trans 'Full' %}
+                        {% translate 'Full' %}
                     </a>
                     <a
                         href="{% url 'staff:evaluation_textanswers' evaluation.id %}?view=undecided"
                         role="button"
                         class="btn btn-sm btn-light{% if view == 'undecided' %} active{% endif %}"
                     >
-                        {% trans 'Undecided' %}
+                        {% translate 'Undecided' %}
                     </a>
                     <a
                         href="{% url 'staff:evaluation_textanswers' evaluation.id %}?view=flagged"
                         role="button"
                         class="btn btn-sm btn-light{% if view == 'flagged' %} active{% endif %}"
                     >
-                        {% trans 'Flagged' %}
+                        {% translate 'Flagged' %}
                     </a>
                 </div>
             </div>
@@ -52,9 +52,9 @@
     </div>
     <div class="mb-2">
         {% if evaluation.state == evaluation.State.IN_EVALUATION %}
-            <span class="badge bg-warning"><span class="fas fa-play icon-gray"></span> {% trans 'Still in evaluation' %}</span>
+            <span class="badge bg-warning"><span class="fas fa-play icon-gray"></span> {% translate 'Still in evaluation' %}</span>
         {% else %}
-            <span class="badge bg-light"><span class="fas fa-stop icon-green"></span> {% trans 'Evaluation finished' %}</span>
+            <span class="badge bg-light"><span class="fas fa-stop icon-green"></span> {% translate 'Evaluation finished' %}</span>
         {% endif %}
         {% include 'evaluation_badges.html' with mode='manager' %}
     </div>

--- a/evap/staff/templates/staff_evaluation_textanswers.html
+++ b/evap/staff/templates/staff_evaluation_textanswers.html
@@ -59,6 +59,6 @@
         {% include 'evaluation_badges.html' with mode='manager' %}
     </div>
     <div class="callout callout-warning">
-        {% blocktrans %}If you select "delete" for a text answer on this page, the respective answer will be deleted irrevocably when publishing the evaluation's results. If you edit an answer, the original answer will also be deleted when publishing the evaluation's results.{% endblocktrans %}
+        {% blocktranslate %}If you select "delete" for a text answer on this page, the respective answer will be deleted irrevocably when publishing the evaluation's results. If you edit an answer, the original answer will also be deleted when publishing the evaluation's results.{% endblocktrans %}
     </div>
 {% endblock %}

--- a/evap/staff/templates/staff_evaluation_textanswers.html
+++ b/evap/staff/templates/staff_evaluation_textanswers.html
@@ -59,6 +59,6 @@
         {% include 'evaluation_badges.html' with mode='manager' %}
     </div>
     <div class="callout callout-warning">
-        {% blocktranslate %}If you select "delete" for a text answer on this page, the respective answer will be deleted irrevocably when publishing the evaluation's results. If you edit an answer, the original answer will also be deleted when publishing the evaluation's results.{% endblocktrans %}
+        {% blocktranslate %}If you select "delete" for a text answer on this page, the respective answer will be deleted irrevocably when publishing the evaluation's results. If you edit an answer, the original answer will also be deleted when publishing the evaluation's results.{% endblocktranslate %}
     </div>
 {% endblock %}

--- a/evap/staff/templates/staff_evaluation_textanswers_full.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_full.html
@@ -5,7 +5,7 @@
 
     <div class="card card-outline-primary mb-3">
         <div class="card-header">
-            {% trans 'General text answers' %}
+            {% translate 'General text answers' %}
         </div>
         <div class="card-body">
             {% if evaluation_sections %}
@@ -13,14 +13,14 @@
                     {% include 'staff_evaluation_textanswers_section.html' with evaluation_id=evaluation.id %}
                 {% endwith %}
             {% else %}
-                <span class="fst-italic">{% trans 'No text answers' %}</span>
+                <span class="fst-italic">{% translate 'No text answers' %}</span>
             {% endif %}
         </div>
     </div>
 
     <div class="card card-outline-primary">
         <div class="card-header">
-            {% trans 'Text answers about the contributors' %}
+            {% translate 'Text answers about the contributors' %}
         </div>
         <div class="card-body">
             {% if contributor_sections %}
@@ -28,7 +28,7 @@
                     {% include 'staff_evaluation_textanswers_section.html' with evaluation_id=evaluation.id %}
                 {% endwith %}
             {% else %}
-                <span class="fst-italic">{% trans 'No text answers' %}</span>
+                <span class="fst-italic">{% translate 'No text answers' %}</span>
             {% endif %}
         </div>
     </div>

--- a/evap/staff/templates/staff_evaluation_textanswers_quick.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_quick.html
@@ -124,7 +124,7 @@
                         {% endif %}
                         {% for next_evaluation in next_evaluations %}
                             <span data-next-evaluation-index="{{ forloop.counter0 }}" data-evaluation="{{ next_evaluation.pk }}">
-                                {% blocktrans with name=next_evaluation.full_name count answers=next_evaluation.num_unreviewed_textanswers %}The next evaluation "{{ name }}" has got {{ answers }} unreviewed text answer.{% plural %}The next evaluation "{{ name }}" has got {{ answers }} unreviewed text answers.{% endblocktrans %}
+                                {% blocktranslate with name=next_evaluation.full_name count answers=next_evaluation.num_unreviewed_textanswers %}The next evaluation "{{ name }}" has got {{ answers }} unreviewed text answer.{% plural %}The next evaluation "{{ name }}" has got {{ answers }} unreviewed text answers.{% endblocktrans %}
                             </span>
                         {% endfor %}
                     </div>
@@ -150,7 +150,7 @@
                         {% translate 'Publish' %}
                     </button>
                     <button type="submit" name="action" value="make_private" class="btn btn-sm btn-outline-secondary" disabled
-                        title="{% blocktrans %}This answer is for a general question and can't be made private.{% endblocktrans %}" data-bs-toggle="tooltip">
+                        title="{% blocktranslate %}This answer is for a general question and can't be made private.{% endblocktrans %}" data-bs-toggle="tooltip">
                         {% translate 'Private' %}
                     </button>
                     <button type="submit" name="action" value="delete" class="btn btn-sm btn-outline-secondary">

--- a/evap/staff/templates/staff_evaluation_textanswers_quick.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_quick.html
@@ -124,7 +124,7 @@
                         {% endif %}
                         {% for next_evaluation in next_evaluations %}
                             <span data-next-evaluation-index="{{ forloop.counter0 }}" data-evaluation="{{ next_evaluation.pk }}">
-                                {% blocktranslate with name=next_evaluation.full_name count answers=next_evaluation.num_unreviewed_textanswers %}The next evaluation "{{ name }}" has got {{ answers }} unreviewed text answer.{% plural %}The next evaluation "{{ name }}" has got {{ answers }} unreviewed text answers.{% endblocktrans %}
+                                {% blocktranslate with name=next_evaluation.full_name count answers=next_evaluation.num_unreviewed_textanswers %}The next evaluation "{{ name }}" has got {{ answers }} unreviewed text answer.{% plural %}The next evaluation "{{ name }}" has got {{ answers }} unreviewed text answers.{% endblocktranslate %}
                             </span>
                         {% endfor %}
                     </div>
@@ -150,7 +150,7 @@
                         {% translate 'Publish' %}
                     </button>
                     <button type="submit" name="action" value="make_private" class="btn btn-sm btn-outline-secondary" disabled
-                        title="{% blocktranslate %}This answer is for a general question and can't be made private.{% endblocktrans %}" data-bs-toggle="tooltip">
+                        title="{% blocktranslate %}This answer is for a general question and can't be made private.{% endblocktranslate %}" data-bs-toggle="tooltip">
                         {% translate 'Private' %}
                     </button>
                     <button type="submit" name="action" value="delete" class="btn btn-sm btn-outline-secondary">

--- a/evap/staff/templates/staff_evaluation_textanswers_quick.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_quick.html
@@ -13,18 +13,18 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <table class="modal-body table table-striped table-vertically-aligned">
-                    <tr><td><kbd>←</kbd> <kbd>→</kbd></td><td>{% trans 'Navigate through answers' %}</td></tr>
-                    <tr><td><kbd>J</kbd></td><td>{% trans 'Publish answer' %}</td></tr>
-                    <tr><td><kbd>K</kbd></td><td>{% trans 'Make answer private to the contributor' %}</td></tr>
-                    <tr><td><kbd>L</kbd></td><td>{% trans 'Delete answer' %}</td></tr>
-                    <tr><td><kbd>&#x232b;</kbd></td><td>{% trans 'Unreview answer' %}</td></tr>
-                    <tr><td><kbd>E</kbd></td><td>{% trans 'Edit answer' %}</td></tr>
-                    <tr><td><kbd>F</kbd></td><td>{% trans 'Set flag' %}</td></tr>
-                    <tr><td><kbd>D</kbd></td><td>{% trans 'Clear flag' %}</td></tr>
-                    <tr><td><kbd>&#x21b2;</kbd></td><td>{% trans 'Review next evaluation' %}</td></tr>
-                    <tr><td><kbd>S</kbd></td><td>{% trans 'Skip evaluation' %}</td></tr>
-                    <tr><td><kbd>N</kbd></td><td>{% trans 'Show all again' %}</td></tr>
-                    <tr><td><kbd>M</kbd></td><td>{% trans 'Show undecided' %}</td></tr>
+                    <tr><td><kbd>←</kbd> <kbd>→</kbd></td><td>{% translate 'Navigate through answers' %}</td></tr>
+                    <tr><td><kbd>J</kbd></td><td>{% translate 'Publish answer' %}</td></tr>
+                    <tr><td><kbd>K</kbd></td><td>{% translate 'Make answer private to the contributor' %}</td></tr>
+                    <tr><td><kbd>L</kbd></td><td>{% translate 'Delete answer' %}</td></tr>
+                    <tr><td><kbd>&#x232b;</kbd></td><td>{% translate 'Unreview answer' %}</td></tr>
+                    <tr><td><kbd>E</kbd></td><td>{% translate 'Edit answer' %}</td></tr>
+                    <tr><td><kbd>F</kbd></td><td>{% translate 'Set flag' %}</td></tr>
+                    <tr><td><kbd>D</kbd></td><td>{% translate 'Clear flag' %}</td></tr>
+                    <tr><td><kbd>&#x21b2;</kbd></td><td>{% translate 'Review next evaluation' %}</td></tr>
+                    <tr><td><kbd>S</kbd></td><td>{% translate 'Skip evaluation' %}</td></tr>
+                    <tr><td><kbd>N</kbd></td><td>{% translate 'Show all again' %}</td></tr>
+                    <tr><td><kbd>M</kbd></td><td>{% translate 'Show undecided' %}</td></tr>
                 </table>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-light" data-bs-dismiss="modal">Close</button>
@@ -50,21 +50,21 @@
 
         <div class="card card-outline-primary slider">
             <div class="card-header">
-                {% trans 'Text answers' %}
-                <span class="hotkey-btn" aria-hidden="true" data-bs-toggle="tooltip" data-bs-placement="right" title="{% trans 'Hotkeys' %}">
+                {% translate 'Text answers' %}
+                <span class="hotkey-btn" aria-hidden="true" data-bs-toggle="tooltip" data-bs-placement="right" title="{% translate 'Hotkeys' %}">
                     <span class="far fa-keyboard" data-bs-toggle="modal" data-bs-target="#hotkeys-modal"></span>
                 </span>
             </div>
             <div class="card-body slider-inner px-0">
                 <div class="slider-side slider-side-left">
-                    <span class="badge rounded-pill bg-primary" data-counter="reviewed-left" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Reviewed text answers' %}"></span>
+                    <span class="badge rounded-pill bg-primary" data-counter="reviewed-left" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Reviewed text answers' %}"></span>
                     <span class="py-2 fas fa-chevron-left" data-slide="left"></span>
-                    <span class="badge rounded-pill bg-secondary" data-counter="unreviewed-left" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Unreviewed text answers' %}"></span>
+                    <span class="badge rounded-pill bg-secondary" data-counter="unreviewed-left" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Unreviewed text answers' %}"></span>
                 </div>
                 <div class="slider-items">
                     {% for questionnaire, contributor, label, is_responsible, results in sections %}
                         <div class="slider-item card-header" data-layer="0">
-                            {{ questionnaire.public_name }}{% if contributor %}: {{ contributor.full_name }}{% if is_responsible %} ({% trans 'responsible' %}){% endif %}{% if label %} &ndash;&nbsp;<span class="fst-italic">{{ label }}</span>{% endif %}{% endif %}
+                            {{ questionnaire.public_name }}{% if contributor %}: {{ contributor.full_name }}{% if is_responsible %} ({% translate 'responsible' %}){% endif %}{% if label %} &ndash;&nbsp;<span class="fst-italic">{{ label }}</span>{% endif %}{% endif %}
                         </div>
                         {% for result in results %}
                             <div class="slider-item card-body" data-layer="1">
@@ -112,14 +112,14 @@
                     <div class="slider-item alert text-center">
                         {% if sections %}
                             <span data-content="unreviewed">
-                                {% trans 'Some text answers for this evaluation are still unreviewed.' %}
+                                {% translate 'Some text answers for this evaluation are still unreviewed.' %}
                             </span>
                             <span data-content="reviewed">
-                                {% trans 'You have reviewed all text answers for this evaluation.' %}
+                                {% translate 'You have reviewed all text answers for this evaluation.' %}
                             </span>
                         {% else %}
                             <span>
-                                {% trans 'There are no text answers for this evaluation.' %}
+                                {% translate 'There are no text answers for this evaluation.' %}
                             </span>
                         {% endif %}
                         {% for next_evaluation in next_evaluations %}
@@ -130,9 +130,9 @@
                     </div>
                 </div>
                 <div class="slider-side slider-side-right">
-                    <span class="badge rounded-pill bg-primary" data-counter="reviewed-right" data-bs-toggle="tooltip" data-bs-placement="right" title="{% trans 'Reviewed text answers' %}"></span>
+                    <span class="badge rounded-pill bg-primary" data-counter="reviewed-right" data-bs-toggle="tooltip" data-bs-placement="right" title="{% translate 'Reviewed text answers' %}"></span>
                     <span class="py-2 fas fa-chevron-right" data-slide="right" title=""></span>
-                    <span class="badge rounded-pill bg-secondary" data-counter="unreviewed-right" data-bs-toggle="tooltip" data-bs-placement="right" title="{% trans 'Unreviewed text answers' %}"></span>
+                    <span class="badge rounded-pill bg-secondary" data-counter="unreviewed-right" data-bs-toggle="tooltip" data-bs-placement="right" title="{% translate 'Unreviewed text answers' %}"></span>
                 </div>
             </div>
 
@@ -141,38 +141,38 @@
                 <div class="lcr-left">
                     <div data-action-set="reviewing">
                         <button type="submit" name="action" value="unreview" class="btn btn-sm btn-outline-secondary">
-                            {% trans 'Unreview' %}
+                            {% translate 'Unreview' %}
                         </button>
                     </div>
                 </div>
                 <div class="lcr-center" data-action-set="reviewing">
                     <button type="submit" name="action" value="publish" class="btn btn-sm btn-outline-secondary">
-                        {% trans 'Publish' %}
+                        {% translate 'Publish' %}
                     </button>
                     <button type="submit" name="action" value="make_private" class="btn btn-sm btn-outline-secondary" disabled
                         title="{% blocktrans %}This answer is for a general question and can't be made private.{% endblocktrans %}" data-bs-toggle="tooltip">
-                        {% trans 'Private' %}
+                        {% translate 'Private' %}
                     </button>
                     <button type="submit" name="action" value="delete" class="btn btn-sm btn-outline-secondary">
-                        {% trans 'Delete' %}
+                        {% translate 'Delete' %}
                     </button>
                 </div>
                 <div class="lcr-center d-none" data-action-set="summary">
                     {% if next_evaluations %}
                         {% for next_evaluation in next_evaluations %}
                             <a href="{% url 'staff:evaluation_textanswers' next_evaluation.id %}" data-next-evaluation-index="{{ forloop.counter0 }}" data-evaluation="{{ next_evaluation.pk }}" data-url="next-evaluation" class="btn btn-sm btn-primary">
-                                {% trans 'Review next evaluation' %}
+                                {% translate 'Review next evaluation' %}
                             </a>
                         {% endfor %}
                         <button type="button" data-skip-evaluation class="btn btn-sm btn-outline-primary">
-                            {% trans 'Skip evaluation' %}
+                            {% translate 'Skip evaluation' %}
                         </button>
                     {% endif %}
                     <button type="button" data-startover="all" class="btn btn-sm btn-outline-primary">
-                        {% trans 'Show all again' %}
+                        {% translate 'Show all again' %}
                     </button>
                     <button type="button" data-startover="undecided" class="btn btn-sm btn-outline-primary">
-                        {% trans 'Show undecided' %}
+                        {% translate 'Show undecided' %}
                     </button>
                 </div>
                 <div class="lcr-right">

--- a/evap/staff/templates/staff_evaluation_textanswers_section.html
+++ b/evap/staff/templates/staff_evaluation_textanswers_section.html
@@ -3,17 +3,17 @@
 {% for questionnaire, contributor, label, is_responsible, results in sections %}
     <div class="card{% if not forloop.last %} mb-3{% endif %}">
         <div class="card-header">
-            {{ questionnaire.public_name }}{% if contributor %}: {{ contributor.full_name }}{% if is_responsible %} ({% trans 'responsible' %}){% endif %}{% if label %} &ndash; <span class="fst-italic">{{ label }}</span>{% endif %}{% endif %}
+            {{ questionnaire.public_name }}{% if contributor %}: {{ contributor.full_name }}{% if is_responsible %} ({% translate 'responsible' %}){% endif %}{% if label %} &ndash; <span class="fst-italic">{{ label }}</span>{% endif %}{% endif %}
         </div>
         <div class="card-body">
             {% for result in results %}
                 <p>{{ result.question.text }}</p>
                 <div class="grid-striped textanswer-review-grid container{% if not forloop.last %} mb-4{% endif %}">
                     <div class="grid-row fw-bold">
-                        <div>{% trans 'Text answer' %}</div>
+                        <div>{% translate 'Text answer' %}</div>
                         <div></div>
-                        <div>{% trans 'Decision' %}</div>
-                        <div>{% trans 'Flag' %}</div>
+                        <div>{% translate 'Decision' %}</div>
+                        <div>{% translate 'Flag' %}</div>
                     </div>
                     {% for answer in result.answers %}
                         <div class="grid-row" id="{{ answer.id }}">
@@ -37,16 +37,16 @@
 
                                     <div class="btn-group btn-group-sm outline-fix" role="group">
                                         <input type="radio" class="btn-check" name="action" value="publish" id="{{ answer.id }}-radio-publish" autocomplete="off" {% if answer.will_be_public %}checked{% endif %}>
-                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-publish">{% trans 'Publish' %}</label>
+                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-publish">{% translate 'Publish' %}</label>
 
                                         <input type="radio" class="btn-check" name="action" value="make_private" id="{{ answer.id }}-radio-private" autocomplete="off" {% if answer.will_be_private %}checked{% endif %} {% if not contributor %}disabled{% endif %}>
-                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-private">{% trans 'Private' %}</label>
+                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-private">{% translate 'Private' %}</label>
 
                                         <input type="radio" class="btn-check" name="action" value="unreview" id="{{ answer.id }}-radio-undecided" autocomplete="off" {% if not answer.is_reviewed %}checked{% endif %}>
-                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-undecided">{% trans 'Undecided' %}</label>
+                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-undecided">{% translate 'Undecided' %}</label>
 
                                         <input type="radio" class="btn-check" name="action" value="delete" id="{{ answer.id }}-radio-delete" autocomplete="off" {% if answer.will_be_deleted %}checked{% endif %}>
-                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-delete">{% trans 'Delete' %}</label>
+                                        <label class="btn btn-outline-primary" for="{{ answer.id }}-radio-delete">{% translate 'Delete' %}</label>
                                     </div>
                                 </form>
                             </div>

--- a/evap/staff/templates/staff_faq_index.html
+++ b/evap/staff/templates/staff_faq_index.html
@@ -4,7 +4,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'FAQ Sections' %}</li>
+    <li class="breadcrumb-item">{% translate 'FAQ Sections' %}</li>
 {% endblock %}
 
 {% block content %}
@@ -20,9 +20,9 @@
                     <thead>
                         <tr>
                             <th class="movable"></th>
-                            <th style="width: 45%">{% trans 'Section title (German)' %}</th>
-                            <th style="width: 45%">{% trans 'Section title (English)' %}</th>
-                            <th class="text-end" style="width: 10%">{% trans 'Actions' %}</th>
+                            <th style="width: 45%">{% translate 'Section title (German)' %}</th>
+                            <th style="width: 45%">{% translate 'Section title (English)' %}</th>
+                            <th class="text-end" style="width: 10%">{% translate 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -52,7 +52,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save FAQ sections' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save FAQ sections' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_faq_section.html
+++ b/evap/staff/templates/staff_faq_section.html
@@ -4,7 +4,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:faq_index' %}">{% trans 'FAQ Sections' %}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:faq_index' %}">{% translate 'FAQ Sections' %}</a></li>
     <li class="breadcrumb-item">{{ section.title }}</li>
 {% endblock %}
 
@@ -21,9 +21,9 @@
                     <thead>
                         <tr>
                             <th class="movable"></th>
-                            <th style="width: 45%">{% trans 'Question/Answer (German)' %}</th>
-                            <th style="width: 45%">{% trans 'Question/Answer (English)' %}</th>
-                            <th class="text-end" style="width: 10%">{% trans 'Actions' %}</th>
+                            <th style="width: 45%">{% translate 'Question/Answer (German)' %}</th>
+                            <th style="width: 45%">{% translate 'Question/Answer (English)' %}</th>
+                            <th class="text-end" style="width: 10%">{% translate 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -52,7 +52,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save FAQ section' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save FAQ section' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_index.html
+++ b/evap/staff/templates/staff_index.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="card-columns staff-index-card-columns">
         <div class="card staff-index-card card-body">
-            <h4 class="card-title">{% trans 'Semesters' %}</h4>
+            <h4 class="card-title">{% translate 'Semesters' %}</h4>
             {% if semesters %}
                 <ul>
                 {% for semester in semesters %}
@@ -11,58 +11,58 @@
                 {% endfor %}
                 </ul>
             {% else %}
-                {% trans 'There are no semesters yet.' %}
+                {% translate 'There are no semesters yet.' %}
             {% endif %}
-            <a href="{% url 'staff:semester_create' %}" class="btn btn-sm btn-dark mt-2">{% trans 'Create new semester' %}</a>
+            <a href="{% url 'staff:semester_create' %}" class="btn btn-sm btn-dark mt-2">{% translate 'Create new semester' %}</a>
         </div>
         <div class="card staff-index-card card-body">
-            <h4 class="card-title">{% trans 'Questionnaires' %}</h4>
+            <h4 class="card-title">{% translate 'Questionnaires' %}</h4>
             <ul>
-                <li><a href="{% url 'staff:questionnaire_index' %}">{% trans 'All questionnaires' %}</a></li>
+                <li><a href="{% url 'staff:questionnaire_index' %}">{% translate 'All questionnaires' %}</a></li>
             </ul>
-            <a href="{% url 'staff:questionnaire_create' %}" class="btn btn-sm btn-dark mt-2">{% trans 'Create new questionnaire' %}</a>
+            <a href="{% url 'staff:questionnaire_create' %}" class="btn btn-sm btn-dark mt-2">{% translate 'Create new questionnaire' %}</a>
         </div>
         <div class="card staff-index-card card-body">
-            <h4 class="card-title">{% trans 'Users' %}</h4>
+            <h4 class="card-title">{% translate 'Users' %}</h4>
             <ul>
-                <li><a href="{% url 'staff:user_list' %}">{% trans 'All users' %}</a></li>
-                <li><a href="{% url 'staff:user_import' %}">{% trans 'Import users' %}</a></li>
-                <li><a href="{% url 'staff:user_merge_selection' %}">{% trans 'Merge users' %}</a></li>
-                <li><a href="{% url 'staff:user_bulk_update' %}">{% trans 'Update users' %}</a></li>
+                <li><a href="{% url 'staff:user_list' %}">{% translate 'All users' %}</a></li>
+                <li><a href="{% url 'staff:user_import' %}">{% translate 'Import users' %}</a></li>
+                <li><a href="{% url 'staff:user_merge_selection' %}">{% translate 'Merge users' %}</a></li>
+                <li><a href="{% url 'staff:user_bulk_update' %}">{% translate 'Update users' %}</a></li>
             </ul>
-            <a href="{% url 'staff:user_create' %}" class="btn btn-sm btn-dark mt-2">{% trans 'Create new user' %}</a>
+            <a href="{% url 'staff:user_create' %}" class="btn btn-sm btn-dark mt-2">{% translate 'Create new user' %}</a>
         </div>
         <div class="card staff-index-card card-body">
-            <h4 class="card-title">{% trans 'Degrees' %}</h4>
+            <h4 class="card-title">{% translate 'Degrees' %}</h4>
             <ul>
-                <li><a href="{% url 'staff:degree_index' %}">{% trans 'All degrees' %}</a></li>
-            </ul>
-        </div>
-        <div class="card staff-index-card card-body">
-            <h4 class="card-title">{% trans 'Course types' %}</h4>
-            <ul>
-                <li><a href="{% url 'staff:course_type_index' %}">{% trans 'All course types' %}</a></li>
-                <li><a href="{% url 'staff:course_type_merge_selection' %}">{% trans 'Merge course types' %}</a></li>
+                <li><a href="{% url 'staff:degree_index' %}">{% translate 'All degrees' %}</a></li>
             </ul>
         </div>
         <div class="card staff-index-card card-body">
-            <h4 class="card-title">{% trans 'Text answer warnings' %}</h4>
+            <h4 class="card-title">{% translate 'Course types' %}</h4>
+            <ul>
+                <li><a href="{% url 'staff:course_type_index' %}">{% translate 'All course types' %}</a></li>
+                <li><a href="{% url 'staff:course_type_merge_selection' %}">{% translate 'Merge course types' %}</a></li>
+            </ul>
+        </div>
+        <div class="card staff-index-card card-body">
+            <h4 class="card-title">{% translate 'Text answer warnings' %}</h4>
             <ul>
                 <li>
                     <a href="{% url 'staff:text_answer_warnings' %}">
-                        {% trans 'All text answer warnings' %}
+                        {% translate 'All text answer warnings' %}
                     </a>
                 </li>
             </ul>
         </div>
         <div class="card staff-index-card card-body">
-            <h4 class="card-title">{% trans 'Reward Points' %}</h4>
+            <h4 class="card-title">{% translate 'Reward Points' %}</h4>
             <ul>
-                <li><a href="{% url 'rewards:reward_point_redemption_events' %}">{% trans 'Reward point redemption events' %}</a></li>
+                <li><a href="{% url 'rewards:reward_point_redemption_events' %}">{% translate 'Reward point redemption events' %}</a></li>
             </ul>
         </div>
         <div class="card staff-index-card card-body">
-            <h4 class="card-title">{% trans 'Templates' %}</h4>
+            <h4 class="card-title">{% translate 'Templates' %}</h4>
             <ul>
                 {% for template in templates %}
                     <li><a href="{% url 'staff:template_edit' template.id %}">{{ template.name }}</a></li>
@@ -70,10 +70,10 @@
             </ul>
         </div>
         <div class="card staff-index-card card-body">
-            <h4 class="card-title">{% trans 'FAQ and Infotexts' %}</h4>
+            <h4 class="card-title">{% translate 'FAQ and Infotexts' %}</h4>
             <ul>
-                <li><a href="{% url 'staff:faq_index' %}">{% trans 'All FAQ Sections' %}</a></li>
-                <li><a href="{% url 'staff:infotexts' %}">{% trans 'All Infotexts' %}</a></li>
+                <li><a href="{% url 'staff:faq_index' %}">{% translate 'All FAQ Sections' %}</a></li>
+                <li><a href="{% url 'staff:infotexts' %}">{% translate 'All Infotexts' %}</a></li>
             </ul>
         </div>
     </div>

--- a/evap/staff/templates/staff_infotexts.html
+++ b/evap/staff/templates/staff_infotexts.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Infotexts' %}</li>
+    <li class="breadcrumb-item">{% translate 'Infotexts' %}</li>
 {% endblock %}
 
 {% block content %}
@@ -14,14 +14,14 @@
         {% for form in formset %}
             <div class="card mb-3">
                 <div class="card-header">
-                    {% trans form.instance.get_page_display %}
+                    {% translate form.instance.get_page_display %}
                 </div>
                 <div class="card-body infotext-edit-grid">
                     {% for hidden in form.hidden_fields %}
                         {{ hidden }}
                     {% endfor %}
-                    <label class="card-subtitle pb-2">{% trans 'Title/Content (German)' %}</label>
-                    <label class="card-subtitle pb-2">{% trans 'Title/Content (English)' %}</label>
+                    <label class="card-subtitle pb-2">{% translate 'Title/Content (German)' %}</label>
+                    <label class="card-subtitle pb-2">{% translate 'Title/Content (English)' %}</label>
 
                     {% include 'bootstrap_form_field_widget.html' with field=form.title_de %}
                     {% include 'bootstrap_form_field_widget.html' with field=form.title_en %}
@@ -33,7 +33,7 @@
         {% endfor %}
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save infotexts' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save infotexts' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_questionnaire_base.html
+++ b/evap/staff/templates/staff_questionnaire_base.html
@@ -3,10 +3,10 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% if questionnaire %}
-        <li class="breadcrumb-item"><a href="{% url 'staff:questionnaire_index' %}">{% trans 'Questionnaires' %}</a></li>
+        <li class="breadcrumb-item"><a href="{% url 'staff:questionnaire_index' %}">{% translate 'Questionnaires' %}</a></li>
         <li class="breadcrumb-item">{{ questionnaire.name }}</li>
     {% else %}
-        <li class="breadcrumb-item">{% trans 'Questionnaires' %}</li>
+        <li class="breadcrumb-item">{% translate 'Questionnaires' %}</li>
     {% endif %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_questionnaire_form.html
+++ b/evap/staff/templates/staff_questionnaire_form.html
@@ -6,7 +6,7 @@
     {{ block.super }}
     {% if not editable %}
         <div class="callout callout-info">
-            {% trans 'Some fields are disabled as this questionnaire is already in use.' %}
+            {% translate 'Some fields are disabled as this questionnaire is already in use.' %}
         </div>
     {% endif %}
     <form id="questionnaire-form" method="POST" class="form-horizontal tomselectform">
@@ -14,7 +14,7 @@
         <fieldset>
             <div class="card mb-3">
                 <div class="card-body">
-                    <h5 class="card-title">{% trans 'General Options' %}</h5>
+                    <h5 class="card-title">{% translate 'General Options' %}</h5>
                     {% include 'bootstrap_form.html' with form=form %}
                 </div>
             </div>
@@ -23,16 +23,16 @@
         <fieldset>
             <div class="card mb-3">
                 <div class="card-body table-responsive">
-                    <h5 class="card-title">{% trans 'Questions' %}</h5>
+                    <h5 class="card-title">{% translate 'Questions' %}</h5>
                     {{ formset.management_form }}
                     {% include 'bootstrap_form_errors.html' with errors=formset.non_form_errors %}
                     <table id="question_table" class="table table-vertically-aligned mb-3">
                         <thead>
                             <tr>
                                 <th></th>
-                                <th style="width: 37%">{% trans 'Question text (German)' %}</th>
-                                <th style="width: 37%">{% trans 'Question text (English)' %}</th>
-                                <th style="width: 20%">{% trans 'Question type' %}</th>
+                                <th style="width: 37%">{% translate 'Question text (German)' %}</th>
+                                <th style="width: 37%">{% translate 'Question text (English)' %}</th>
+                                <th style="width: 20%">{% translate 'Question type' %}</th>
                                 <th style="width: 6%"></th>
                             </tr>
                         </thead>
@@ -72,7 +72,7 @@
         </fieldset>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save questionnaire' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save questionnaire' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_questionnaire_index.html
+++ b/evap/staff/templates/staff_questionnaire_index.html
@@ -6,25 +6,25 @@
     {{ block.super }}
     <div class="row mb-3 align-items-center">
         <div class="col">
-            <a href="{% url 'staff:questionnaire_create' %}" class="btn btn-sm btn-dark">{% trans 'Create new questionnaire' %}</a>
+            <a href="{% url 'staff:questionnaire_create' %}" class="btn btn-sm btn-dark">{% translate 'Create new questionnaire' %}</a>
         </div>
         <div class="col-auto">
             <div class="btn-switch btn-switch-light">
-                <div class="btn-switch-label">{% trans 'Hidden questionnaires' %}</div>
+                <div class="btn-switch-label">{% translate 'Hidden questionnaires' %}</div>
                 <div class="btn-switch btn-group">
                     <a href="{% url 'staff:questionnaire_index' %}?filter_questionnaires=false" role="button" class="btn btn-sm btn-light{% if not filter_questionnaires %} active{% endif %}">
-                    {% trans 'Show' %}
+                    {% translate 'Show' %}
                     </a>
                     <a href="{% url 'staff:questionnaire_index' %}?filter_questionnaires=true" role="button" class="btn btn-sm btn-light{% if filter_questionnaires %} active{% endif %}">
-                        {% trans 'Hide' %}
+                        {% translate 'Hide' %}
                     </a>
                 </div>
             </div>
         </div>
         <div class="col-3">
             <div class="input-group">
-                <input type="search" name="search" class="form-control" placeholder="{% trans 'Search...' %}" />
-                <button class="btn btn-light text-secondary" type="button" data-reset="search" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Clear filter' %}">
+                <input type="search" name="search" class="form-control" placeholder="{% translate 'Search...' %}" />
+                <button class="btn btn-light text-secondary" type="button" data-reset="search" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Clear filter' %}">
                     <span class="fas fa-delete-left"></span>
                 </button>
             </div>
@@ -49,20 +49,20 @@
                     assert(response.ok);
                     fadeOutThenRemove(document.querySelector(`#questionnaire-row-${body.get("questionnaire_id")}`));
                 }).catch(error => {
-                    window.alert("{% trans 'The server is not responding.' %}");
+                    window.alert("{% translate 'The server is not responding.' %}");
                 });;
             });
         </script>
 
-        {% trans 'Top general questionnaires' as headline %}
+        {% translate 'Top general questionnaires' as headline %}
         {% include 'staff_questionnaire_index_list.html' with questionnaires=general_questionnaires_top headline=headline extra_classes='mb-3' type='top' %}
-        {% trans 'Contributor questionnaires' as headline %}
+        {% translate 'Contributor questionnaires' as headline %}
         {% include 'staff_questionnaire_index_list.html' with questionnaires=contributor_questionnaires headline=headline extra_classes='mb-3' type='contributor' %}
-        {% trans 'Bottom general questionnaires' as headline %}
+        {% translate 'Bottom general questionnaires' as headline %}
         {% include 'staff_questionnaire_index_list.html' with questionnaires=general_questionnaires_bottom headline=headline extra_classes='' type='bottom' %}
     {% else %}
         <p>
-            {% trans 'There are no questionnaires yet.' %}
+            {% translate 'There are no questionnaires yet.' %}
         </p>
     {% endif %}
 {% endblock %}
@@ -94,7 +94,7 @@
                 assert(response.ok);
                 questionnaire.querySelectorAll(`button[data-visibility]`).forEach(button => {button.classList.remove("active");});
                 questionnaire.querySelectorAll(`button[data-visibility="${visibility}"]`).forEach(button => {button.classList.add("active");});
-            }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
+            }).catch(error => {window.alert("{% translate 'The server is not responding.' %}");});
         }
 
         function changeLocked(element) {
@@ -109,7 +109,7 @@
                 assert(response.ok);
                 questionnaire.querySelectorAll(`button[data-is-locked]`).forEach(button => {button.classList.remove("active");});
                 questionnaire.querySelectorAll(`button[data-is-locked="${is_locked}"]`).forEach(button => {button.classList.add("active");});
-            }).catch(error => {window.alert("{% trans 'The server is not responding.' %}");});
+            }).catch(error => {window.alert("{% translate 'The server is not responding.' %}");});
         }
     </script>
 {% endblock %}

--- a/evap/staff/templates/staff_questionnaire_index_list.html
+++ b/evap/staff/templates/staff_questionnaire_index_list.html
@@ -28,8 +28,8 @@
                                 <td>
                                     <strong class="questionnaire-name">{{ questionnaire.name }}</strong>
                                     <br />
-                                    {% blocktrans count questionnaire.questions.count as count %}{{ count }} question{% plural %}{{ count }} questions{% endblocktrans %},
-                                    {% blocktrans count questionnaire.contributions.count as count %}used {{ count }} time{% plural %}used {{ count }} times{% endblocktrans %}
+                                    {% blocktranslate count questionnaire.questions.count as count %}{{ count }} question{% plural %}{{ count }} questions{% endblocktrans %},
+                                    {% blocktranslate count questionnaire.contributions.count as count %}used {{ count }} time{% plural %}used {{ count }} times{% endblocktrans %}
                                 </td>
                                 <td>
                                     {% if type != 'contributor' %}
@@ -41,7 +41,7 @@
                                 </td>
                                 <td>
                                     <div class="btn-group icon-buttons">
-                                        <button data-visibility="0" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 0 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% blocktrans %}Hide in lists{% endblocktrans %}"><span class="fas fa-fw fa-eye-slash" aria-hidden="true"></span></button>
+                                        <button data-visibility="0" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 0 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% blocktranslate %}Hide in lists{% endblocktrans %}"><span class="fas fa-fw fa-eye-slash" aria-hidden="true"></span></button>
                                         <button data-visibility="1" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 1 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Show only for managers' %}"><span class="fas fa-fw fa-briefcase" aria-hidden="true"></span></button>
                                         <button data-visibility="2" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 2 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Show for managers and editors' %}"><span class="fas fa-fw fa-person-chalkboard" aria-hidden="true"></span></button>
                                     </div>
@@ -56,7 +56,7 @@
                                             <span slot="title">{% translate 'Delete questionnaire' %}</span>
                                             <span slot="action-text">{% translate 'Delete questionnaire' %}</span>
                                             <span slot="question">
-                                                {% blocktrans trimmed with questionnaire_name=questionnaire.name %}
+                                                {% blocktranslate trimmed with questionnaire_name=questionnaire.name %}
                                                     Do you really want to delete the questionnaire <strong>{{questionnaire_name}}</strong>?
                                                 {% endblocktrans %}
                                             </span>

--- a/evap/staff/templates/staff_questionnaire_index_list.html
+++ b/evap/staff/templates/staff_questionnaire_index_list.html
@@ -28,8 +28,8 @@
                                 <td>
                                     <strong class="questionnaire-name">{{ questionnaire.name }}</strong>
                                     <br />
-                                    {% blocktranslate count questionnaire.questions.count as count %}{{ count }} question{% plural %}{{ count }} questions{% endblocktrans %},
-                                    {% blocktranslate count questionnaire.contributions.count as count %}used {{ count }} time{% plural %}used {{ count }} times{% endblocktrans %}
+                                    {% blocktranslate count questionnaire.questions.count as count %}{{ count }} question{% plural %}{{ count }} questions{% endblocktranslate %},
+                                    {% blocktranslate count questionnaire.contributions.count as count %}used {{ count }} time{% plural %}used {{ count }} times{% endblocktranslate %}
                                 </td>
                                 <td>
                                     {% if type != 'contributor' %}
@@ -41,7 +41,7 @@
                                 </td>
                                 <td>
                                     <div class="btn-group icon-buttons">
-                                        <button data-visibility="0" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 0 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% blocktranslate %}Hide in lists{% endblocktrans %}"><span class="fas fa-fw fa-eye-slash" aria-hidden="true"></span></button>
+                                        <button data-visibility="0" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 0 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% blocktranslate %}Hide in lists{% endblocktranslate %}"><span class="fas fa-fw fa-eye-slash" aria-hidden="true"></span></button>
                                         <button data-visibility="1" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 1 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Show only for managers' %}"><span class="fas fa-fw fa-briefcase" aria-hidden="true"></span></button>
                                         <button data-visibility="2" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 2 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Show for managers and editors' %}"><span class="fas fa-fw fa-person-chalkboard" aria-hidden="true"></span></button>
                                     </div>
@@ -58,7 +58,7 @@
                                             <span slot="question">
                                                 {% blocktranslate trimmed with questionnaire_name=questionnaire.name %}
                                                     Do you really want to delete the questionnaire <strong>{{questionnaire_name}}</strong>?
-                                                {% endblocktrans %}
+                                                {% endblocktranslate %}
                                             </span>
 
                                             <button slot="show-button" type="button" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Delete' %}">

--- a/evap/staff/templates/staff_questionnaire_index_list.html
+++ b/evap/staff/templates/staff_questionnaire_index_list.html
@@ -2,7 +2,7 @@
     <div class="card collapsible {{ extra_classes }}">
         <div class="card-header">
             <a class="collapse-toggle" data-bs-toggle="collapse" href="#questionnaires-{{ type }}" aria-expanded="false" aria-controls="questionnaires-{{ type }}">
-                {% trans headline %}
+                {% translate headline %}
             </a>
         </div>
         <div class="collapse show" id="questionnaires-{{ type }}">
@@ -11,14 +11,14 @@
                     <thead>
                         <tr class="table-header">
                             <th class="movable" style="width: 3%"></th>
-                            <th style="width: 52%">{% trans 'Questionnaire' %}</th>
+                            <th style="width: 52%">{% translate 'Questionnaire' %}</th>
                             <th style="width: 10%">
                                 {% if type != 'contributor' %}
-                                    {% trans 'Locked' %}
+                                    {% translate 'Locked' %}
                                 {% endif %}
                             </th>
-                            <th style="width: 15%">{% trans 'Visibility' %}</th>
-                            <th class="text-end" style="width: 20%">{% trans 'Actions' %}</th>
+                            <th style="width: 15%">{% translate 'Visibility' %}</th>
+                            <th class="text-end" style="width: 20%">{% translate 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -34,40 +34,40 @@
                                 <td>
                                     {% if type != 'contributor' %}
                                         <div class="btn-switch btn-group icon-buttons">
-                                            <button data-is-locked="0" type="button" onclick="changeLocked(this);" class="btn btn-sm btn-light{% if questionnaire.is_locked == False %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Allow editors to change the selection of this questionnaire' %}"><span class="fas fa-fw fa-lock-open" aria-hidden="true"></span></button>
-                                            <button data-is-locked="1" type="button" onclick="changeLocked(this);" class="btn btn-sm btn-light{% if questionnaire.is_locked == True %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Prevent editors from changing the selection of this questionnaire' %}"><span class="fas fa-fw fa-lock" aria-hidden="true"></span></button>
+                                            <button data-is-locked="0" type="button" onclick="changeLocked(this);" class="btn btn-sm btn-light{% if questionnaire.is_locked == False %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Allow editors to change the selection of this questionnaire' %}"><span class="fas fa-fw fa-lock-open" aria-hidden="true"></span></button>
+                                            <button data-is-locked="1" type="button" onclick="changeLocked(this);" class="btn btn-sm btn-light{% if questionnaire.is_locked == True %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Prevent editors from changing the selection of this questionnaire' %}"><span class="fas fa-fw fa-lock" aria-hidden="true"></span></button>
                                         </div>
                                     {% endif %}
                                 </td>
                                 <td>
                                     <div class="btn-group icon-buttons">
                                         <button data-visibility="0" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 0 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% blocktrans %}Hide in lists{% endblocktrans %}"><span class="fas fa-fw fa-eye-slash" aria-hidden="true"></span></button>
-                                        <button data-visibility="1" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 1 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Show only for managers' %}"><span class="fas fa-fw fa-briefcase" aria-hidden="true"></span></button>
-                                        <button data-visibility="2" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 2 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Show for managers and editors' %}"><span class="fas fa-fw fa-person-chalkboard" aria-hidden="true"></span></button>
+                                        <button data-visibility="1" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 1 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Show only for managers' %}"><span class="fas fa-fw fa-briefcase" aria-hidden="true"></span></button>
+                                        <button data-visibility="2" type="button" onclick="changeVisibility(this);" class="btn btn-sm btn-light{% if questionnaire.visibility == 2 %} active{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Show for managers and editors' %}"><span class="fas fa-fw fa-person-chalkboard" aria-hidden="true"></span></button>
                                     </div>
                                 </td>
                                 <td class="text-end">
-                                    <a href="{% url 'staff:questionnaire_edit' questionnaire.id %}" class="btn btn-sm {%if questionnaire.can_be_edited_by_manager %}btn-primary{% else %}btn-light{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{%if questionnaire.can_be_edited_by_manager %}{% trans 'Edit' %}{% else %}{% trans 'Edit (questionnaire is already in use)' %}{% endif %}"><span class="fas fa-pencil fa-fw"></span></a>
-                                    <a href="{% url 'staff:questionnaire_new_version' questionnaire.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Hide and create new version' %}"><span class="fas fa-turn-up fa-fw fa-rotate-90"></span></a>
-                                    <a href="{% url 'staff:questionnaire_copy' questionnaire.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Copy' %}"><span class="fas fa-copy fa-fw"></span></a>
-                                    <a href="{% url 'staff:questionnaire_view' questionnaire.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Preview' %}"><span class="fas fa-eye fa-fw"></span></a>
+                                    <a href="{% url 'staff:questionnaire_edit' questionnaire.id %}" class="btn btn-sm {%if questionnaire.can_be_edited_by_manager %}btn-primary{% else %}btn-light{% endif %}" data-bs-toggle="tooltip" data-bs-placement="top" title="{%if questionnaire.can_be_edited_by_manager %}{% translate 'Edit' %}{% else %}{% translate 'Edit (questionnaire is already in use)' %}{% endif %}"><span class="fas fa-pencil fa-fw"></span></a>
+                                    <a href="{% url 'staff:questionnaire_new_version' questionnaire.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Hide and create new version' %}"><span class="fas fa-turn-up fa-fw fa-rotate-90"></span></a>
+                                    <a href="{% url 'staff:questionnaire_copy' questionnaire.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Copy' %}"><span class="fas fa-copy fa-fw"></span></a>
+                                    <a href="{% url 'staff:questionnaire_view' questionnaire.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Preview' %}"><span class="fas fa-eye fa-fw"></span></a>
                                     {% if questionnaire.can_be_deleted_by_manager %}
                                         <confirmation-modal type="submit" form="questionnaire-deletion-form" name="questionnaire_id" value="{{ questionnaire.id }}" confirm-button-class="btn-danger">
-                                            <span slot="title">{% trans 'Delete questionnaire' %}</span>
-                                            <span slot="action-text">{% trans 'Delete questionnaire' %}</span>
+                                            <span slot="title">{% translate 'Delete questionnaire' %}</span>
+                                            <span slot="action-text">{% translate 'Delete questionnaire' %}</span>
                                             <span slot="question">
                                                 {% blocktrans trimmed with questionnaire_name=questionnaire.name %}
                                                     Do you really want to delete the questionnaire <strong>{{questionnaire_name}}</strong>?
                                                 {% endblocktrans %}
                                             </span>
 
-                                            <button slot="show-button" type="button" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
+                                            <button slot="show-button" type="button" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Delete' %}">
                                                 <span class="fas fa-trash"></span>
                                             </button>
                                         </confirmation-modal>
                                     {% else %}
                                         <button type="button" disabled class="btn btn-sm btn-danger" data-bs-toggle="tooltip" data-bs-placement="top"
-                                            title="{% trans 'This questionnaire cannot be deleted because it is already in use.' %}">
+                                            title="{% translate 'This questionnaire cannot be deleted because it is already in use.' %}">
                                             <span class="fas fa-trash"></span>
                                         </button>
                                     {% endif %}

--- a/evap/staff/templates/staff_questionnaire_view.html
+++ b/evap/staff/templates/staff_questionnaire_view.html
@@ -2,7 +2,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Preview' %}</li>
+    <li class="breadcrumb-item">{% translate 'Preview' %}</li>
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_base.html
+++ b/evap/staff/templates/staff_semester_base.html
@@ -9,7 +9,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Semesters' %}</li>
+    <li class="breadcrumb-item">{% translate 'Semesters' %}</li>
     {% if semester %}
         {% if disable_breadcrumb_semester %}
             <li class="breadcrumb-item">{{ semester.name }}</li>

--- a/evap/staff/templates/staff_semester_export.html
+++ b/evap/staff/templates/staff_semester_export.html
@@ -4,12 +4,12 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Export' %}</li>
+    <li class="breadcrumb-item">{% translate 'Export' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
-    <h3>{% trans 'Export' %} {{ semester.name }}</h3>
+    <h3>{% translate 'Export' %} {{ semester.name }}</h3>
 
     <form id="semester-export-form" method="POST" class="form-horizontal multiselect-form">
         {% csrf_token %}
@@ -18,12 +18,12 @@
 
         <div class="card mb-3">
             <div class="card-body">
-                <p>{% trans 'Select the degrees and course types you want to export. An export will include all evaluations of courses that have at least one of the selected degrees and one of the selected course types. Add multiple lines to create an export file with multiple sheets.' %}</p>
+                <p>{% translate 'Select the degrees and course types you want to export. An export will include all evaluations of courses that have at least one of the selected degrees and one of the selected course types. Add multiple lines to create an export file with multiple sheets.' %}</p>
                 <table id="exportsheets-table" class="table">
                     <thead>
                         <tr>
-                            <th style="width: 25%">{% trans 'Degrees' %}</th>
-                            <th style="width: 65%">{% trans 'Course types' %}</th>
+                            <th style="width: 25%">{% translate 'Degrees' %}</th>
+                            <th style="width: 65%">{% translate 'Course types' %}</th>
                             <th style="width: 10%"></th>
                         </tr>
                     </thead>
@@ -52,20 +52,20 @@
                 <div class="form-check">
                     <input class="form-check-input" id="include_unpublished" type="checkbox" name="include_unpublished" />
                     <label class="form-check-label" for="include_unpublished">
-                        {% trans 'Include unpublished evaluations where the evaluation period ended in the export' %}
+                        {% translate 'Include unpublished evaluations where the evaluation period ended in the export' %}
                     </label>
                 </div>
                 <div class="form-check">
                     <input class="form-check-input" id="include_not_enough_voters" type="checkbox" name="include_not_enough_voters" />
                     <label class="form-check-label" for="include_not_enough_voters">
-                        {% trans 'Include evaluations where not enough votes were given in the export' %}
+                        {% translate 'Include evaluations where not enough votes were given in the export' %}
                     </label>
                 </div>
             </div>
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary form-submit-btn">{% trans 'Export' %}</button>
+                <button type="submit" class="btn btn-primary form-submit-btn">{% translate 'Export' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_semester_flagged_textanswers.html
+++ b/evap/staff/templates/staff_semester_flagged_textanswers.html
@@ -2,13 +2,13 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Flagged textanswers' %}</li>
+    <li class="breadcrumb-item">{% translate 'Flagged textanswers' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
     <h3>
-        {% trans 'Flagged textanswers' %} ({{ semester.name }})
+        {% translate 'Flagged textanswers' %} ({{ semester.name }})
     </h3>
     <div class="card">
         <div class="card-body">
@@ -28,7 +28,7 @@
                     </ul>
                 {% endfor %}
             {% else %}
-                <i>{% trans 'There are no flagged textanswers in this semester.' %}</i>
+                <i>{% translate 'There are no flagged textanswers in this semester.' %}</i>
             {% endif %}
         </div>
     </div>

--- a/evap/staff/templates/staff_semester_form.html
+++ b/evap/staff/templates/staff_semester_form.html
@@ -11,7 +11,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save semester' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save semester' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_semester_grade_reminder.html
+++ b/evap/staff/templates/staff_semester_grade_reminder.html
@@ -2,13 +2,13 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Grade publish reminder' %}</li>
+    <li class="breadcrumb-item">{% translate 'Grade publish reminder' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
     <h3>
-        {% trans 'Grade publish reminder' %} ({{ semester.name }})
+        {% translate 'Grade publish reminder' %} ({{ semester.name }})
     </h3>
     <div class="card">
         <div class="card-body">

--- a/evap/staff/templates/staff_semester_import.html
+++ b/evap/staff/templates/staff_semester_import.html
@@ -4,12 +4,12 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Import semester data' %}</li>
+    <li class="breadcrumb-item">{% translate 'Import semester data' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
-    <h3>{% trans 'Import semester data' %}</h3>
+    <h3>{% translate 'Import semester data' %}</h3>
 
     {% include 'staff_message_rendering_template.html' with importer_log=importer_log %}
 
@@ -17,11 +17,11 @@
         <div class="card mb-3">
             <div class="card-body">
                 <p>
-                    {% trans 'Upload Excel file' %}
-                    (<a href="{% url 'staff:download_sample_file' 'sample.xlsx' %}">{% trans 'Download sample file' %}</a>,
+                    {% translate 'Upload Excel file' %}
+                    (<a href="{% url 'staff:download_sample_file' 'sample.xlsx' %}">{% translate 'Download sample file' %}</a>,
                     <button type="button" class="btn btn-link" onClick="copyHeaders(['Degree', 'Participant last name', 'Participant first name', 'Participant email address', 'Course kind', 'Course is graded', 'Course name (de)', 'Course name (en)', 'Responsible title', 'Responsible last name', 'Responsible first name', 'Responsible email address'])">
-                        {% trans 'Copy headers to clipboard' %}</button>).
-                    {% trans 'This will create all containing participants, contributors and courses and connect them. It will also set the entered values as default for all evaluations.' %}
+                        {% translate 'Copy headers to clipboard' %}</button>).
+                    {% translate 'This will create all containing participants, contributors and courses and connect them. It will also set the entered values as default for all evaluations.' %}
                 </p>
                 {% csrf_token %}
                 {% include 'bootstrap_form.html' with form=excel_form %}
@@ -31,15 +31,15 @@
         <div class="card card-submit-area{% if test_passed %} card-submit-area-2{% endif %} text-center mb-3">
             <div class="card-body">
                 {% if not test_passed %}
-                    <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
+                    <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% translate 'Upload and test' %}</button>
                 {% else %}
-                    <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
+                    <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% translate 'Upload and test' %}</button>
                     <confirmation-modal type="submit" name="operation" value="import">
-                        <span slot="title">{% trans 'Import semester data' %}</span>
-                        <span slot="action-text">{% trans 'Import semester data' %}</span>
-                        <span slot="question">{% trans 'Do you really want to import semester data from the Excel file?' %}</span>
+                        <span slot="title">{% translate 'Import semester data' %}</span>
+                        <span slot="action-text">{% translate 'Import semester data' %}</span>
+                        <span slot="question">{% translate 'Do you really want to import semester data from the Excel file?' %}</span>
 
-                        <button slot="show-button" type="button" class="btn btn-primary form-submit-btn">{% trans 'Import previously uploaded file' %}</button>
+                        <button slot="show-button" type="button" class="btn btn-primary form-submit-btn">{% translate 'Import previously uploaded file' %}</button>
                     </confirmation-modal>
                 {% endif %}
             </div>

--- a/evap/staff/templates/staff_semester_preparation_reminder.html
+++ b/evap/staff/templates/staff_semester_preparation_reminder.html
@@ -4,7 +4,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Preparation reminder' %}</li>
+    <li class="breadcrumb-item">{% translate 'Preparation reminder' %}</li>
 {% endblock %}
 
 {% block content %}
@@ -20,11 +20,11 @@
                     <input type="hidden" name="semester_id" value="{{ semester.id }}" />
 
                     <confirmation-modal type="submit">
-                        <span slot="title">{% trans 'Remind all' %}</span>
-                        <span slot="action-text">{% trans 'Remind all' %}</span>
-                        <span slot="question">{% trans 'Do you really want to remind everyone?' %}</span>
+                        <span slot="title">{% translate 'Remind all' %}</span>
+                        <span slot="action-text">{% translate 'Remind all' %}</span>
+                        <span slot="question">{% translate 'Do you really want to remind everyone?' %}</span>
 
-                        <button slot="show-button" type="button" id="remindAllButton" class="btn btn-sm btn-light">{% trans 'Remind all' %}</button>
+                        <button slot="show-button" type="button" id="remindAllButton" class="btn btn-sm btn-light">{% translate 'Remind all' %}</button>
                     </confirmation-modal>
                 </form>
             </div>
@@ -35,7 +35,7 @@
         <div class="card{% if not forloop.last %} mb-3{% endif %}">
             <div class="card-header d-flex">
                 <span class="ps-1 me-auto">
-                    <a href="{% url 'staff:user_edit' responsible.id %}">{{ responsible.full_name }}</a>, {% trans 'Delegates' %}:
+                    <a href="{% url 'staff:user_edit' responsible.id %}">{{ responsible.full_name }}</a>, {% translate 'Delegates' %}:
                     {% for delegate in delegates %}
                         <a href="{% url 'staff:user_edit' delegate.id %}">{{ delegate.full_name }}</a>{% if not forloop.last %},{% endif %}
                     {% empty %}
@@ -43,16 +43,16 @@
                     {% endfor %}
                 </span>
                 <div>
-                    <a href="{% url 'staff:send_reminder' semester.id responsible.id %}" class="btn btn-sm btn-light">{% trans 'Send reminder' %}</a>
+                    <a href="{% url 'staff:send_reminder' semester.id responsible.id %}" class="btn btn-sm btn-light">{% translate 'Send reminder' %}</a>
                 </div>
             </div>
             <div class="card-body">
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <th style="width: 57%">{% trans 'Name' %}</th>
-                            <th style="width: 18%">{% trans 'Start of evaluation' %}</th>
-                            <th style="width: 25%">{% trans 'Last modified by' %}</th>
+                            <th style="width: 57%">{% translate 'Name' %}</th>
+                            <th style="width: 18%">{% translate 'Start of evaluation' %}</th>
+                            <th style="width: 25%">{% translate 'Last modified by' %}</th>
                        </tr>
                     </thead>
                     <tbody>

--- a/evap/staff/templates/staff_semester_questionnaire_assign_form.html
+++ b/evap/staff/templates/staff_semester_questionnaire_assign_form.html
@@ -2,18 +2,18 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Assign questionnaires' %}</li>
+    <li class="breadcrumb-item">{% translate 'Assign questionnaires' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
-    <h3>{% trans 'Assign questionnaires' %}</h3>
+    <h3>{% translate 'Assign questionnaires' %}</h3>
 
     <form id="questionnaire-assign-form" method="POST" class="form-horizontal multiselect-form">
         {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
-                <p>{% trans 'Select the questionnaires which shall be assigned each of these course types and the contributors. This will only change evaluations in preparation. If you do select nothing, the currently applied questionnaires for the corresponding course type or contributor will not be changed.' %}</p>
+                <p>{% translate 'Select the questionnaires which shall be assigned each of these course types and the contributors. This will only change evaluations in preparation. If you do select nothing, the currently applied questionnaires for the corresponding course type or contributor will not be changed.' %}</p>
                 <fieldset>
                     {% include 'bootstrap_form.html' with form=form %}
                 </fieldset>
@@ -21,7 +21,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Assign questionnaires' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Assign questionnaires' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_semester_send_reminder.html
+++ b/evap/staff/templates/staff_semester_send_reminder.html
@@ -4,7 +4,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:semester_preparation_reminder' semester.id %}">{% trans 'Preparation reminder' %}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:semester_preparation_reminder' semester.id %}">{% translate 'Preparation reminder' %}</a></li>
     <li class="breadcrumb-item">{{ responsible }}</li>
 {% endblock %}
 
@@ -25,7 +25,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Send email' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Send email' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -20,7 +20,7 @@
                         <span slot="question">
                             {% blocktranslate trimmed %}
                                 Do you want to make this the active semester?
-                            {% endblocktrans %}
+                            {% endblocktranslate %}
                         </span>
 
                         <button
@@ -45,7 +45,7 @@
                                 Do you really want to delete the semester <strong>{{ semester_name }}</strong>?
                                 All courses and evaluations will be deleted as well as all results.
                                 If you are sure, enter the name of the semester below.
-                            {% endblocktrans %}
+                            {% endblocktranslate %}
                         </span>
 
                         <div slot="extra-inputs">
@@ -103,7 +103,7 @@
                                     {% blocktranslate trimmed with semester_name=semester.name %}
                                         Do you really want to archive all participations in the semester <strong>{{ semester_name }}</strong>?
                                         Further changes to the evaluations won't be possible and you can't undo this action.
-                                    {% endblocktrans %}
+                                    {% endblocktranslate %}
                                 </span>
 
                                 <button slot="show-button" type="button" class="btn btn-sm btn-warning">{% translate 'Archive participations' %}</button>
@@ -127,7 +127,7 @@
                                         Do you really want to delete the grade documents in the semester <strong>{{ semester_name }}</strong>?
                                         This will delete all existing grade documents for this semester's courses and will disable new uploads.
                                         You can't undo this action.
-                                    {% endblocktrans %}
+                                    {% endblocktranslate %}
                                 </span>
 
                                 <button slot="show-button" type="button" class="btn btn-sm btn-warning">{% translate 'Delete grade documents' %}</button>
@@ -147,7 +147,7 @@
                                         Do you really want to archive the results in the semester <strong>{{ semester_name }}</strong>?
                                         This will make the results of all evaluations inaccessible for all users except their contributors and managers.
                                         You can't undo this action.
-                                    {% endblocktrans %}
+                                    {% endblocktranslate %}
                                 </span>
 
                                 <button slot="show-button" type="button" class="btn btn-sm btn-warning">{% translate 'Archive results' %}</button>
@@ -183,7 +183,7 @@
                                             Do you want to activate the reward points for the semester <strong>{{ semester_name }}</strong>?
                                             The activation will allow participants to receive reward points when voting and will also grant all eligible points for participants who have already voted so far.
                                             The process will take a while.
-                                        {% endblocktrans %}
+                                        {% endblocktranslate %}
                                     </span>
 
                                     <button slot="show-button" type="button" class="btn btn-sm btn-light{% if rewards_active %} active{% endif %}"><span class="fas fa-check" aria-hidden="true"></span></button>
@@ -564,7 +564,7 @@
                                                 <span slot="question">
                                                     {% blocktranslate trimmed with course_name=course.name %}
                                                         Do you really want to delete the course <strong>{{ course_name }}</strong>?
-                                                    {% endblocktrans %}
+                                                    {% endblocktranslate %}
                                                 </span>
 
                                                 <button slot="show-button" type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Delete' %}">

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -11,12 +11,12 @@
 
         <div class="d-inline-flex flex-wrap gap-2 align-items-start justify-content-start">
             {% if request.user.is_manager %}
-                <a href="{% url 'staff:semester_edit' semester.id %}" class="btn btn-sm btn-secondary">{% trans 'Edit' %}</a>
+                <a href="{% url 'staff:semester_edit' semester.id %}" class="btn btn-sm btn-secondary">{% translate 'Edit' %}</a>
                 <form reload-on-success method="POST" action="{% url 'staff:semester_make_active' %}" class="d-inline">
                     {% csrf_token %}
-                    <confirmation-modal type="submit" name="semester_id" value="{{ semester.id }}" {% if semester.is_active %}data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'This is the active semester' %}" {% endif %}>
-                        <span slot="title">{% trans 'Make this the active semester' %}</span>
-                        <span slot="action-text">{% trans 'Make active' %}</span>
+                    <confirmation-modal type="submit" name="semester_id" value="{{ semester.id }}" {% if semester.is_active %}data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'This is the active semester' %}" {% endif %}>
+                        <span slot="title">{% translate 'Make this the active semester' %}</span>
+                        <span slot="action-text">{% translate 'Make active' %}</span>
                         <span slot="question">
                             {% blocktrans trimmed %}
                                 Do you want to make this the active semester?
@@ -29,7 +29,7 @@
                             class="btn btn-sm btn-light"
                             {% if semester.is_active %}disabled{% endif %}
                         >
-                            {% trans 'Make active' %}
+                            {% translate 'Make active' %}
                         </button>
                     </confirmation-modal>
                 </form>
@@ -39,7 +39,7 @@
                     <input type="hidden" name="semester_id" value="{{ semester.pk }}" />
 
                     <confirmation-modal type="submit" confirm-button-class="btn-danger">
-                        <span slot="title">{% trans 'Delete semester' %}</span>
+                        <span slot="title">{% translate 'Delete semester' %}</span>
                         <span slot="question">
                             {% blocktrans trimmed with semester_name=semester.name %}
                                 Do you really want to delete the semester <strong>{{ semester_name }}</strong>?
@@ -53,7 +53,7 @@
                         </div>
 
                         <span slot="submit-group">
-                            <button class="btn btn-danger ms-2">{% trans 'Delete semester' %}</button>
+                            <button class="btn btn-danger ms-2">{% translate 'Delete semester' %}</button>
                         </span>
 
                         <button
@@ -62,7 +62,7 @@
                             {% if not semester.can_be_deleted_by_manager %}disabled{% endif %}
                             class="btn btn-sm btn-danger"
                         >
-                            {% trans 'Delete' %}
+                            {% translate 'Delete' %}
                         </button>
 
                         <script type="text/javascript">
@@ -73,7 +73,7 @@
                                     if (element.value === element.dataset.mustEqual) {
                                         element.setCustomValidity("");
                                     } else {
-                                        element.setCustomValidity("{% trans 'Please enter the required text.' %}");
+                                        element.setCustomValidity("{% translate 'Please enter the required text.' %}");
                                     }
 
                                     element.reportValidity();
@@ -89,7 +89,7 @@
     {% if request.user.is_manager %}
         <div class="card collapsible mb-3">
             <div class="card-header d-flex">
-                <a class="collapse-toggle{% if not semester.participations_are_archived and not semester.grade_documents_are_deleted and not semester.results_are_archived %} collapsed{% endif %}" data-bs-toggle="collapse" href="#archivingCard">{% trans 'Archiving' %}</a>
+                <a class="collapse-toggle{% if not semester.participations_are_archived and not semester.grade_documents_are_deleted and not semester.results_are_archived %} collapsed{% endif %}" data-bs-toggle="collapse" href="#archivingCard">{% translate 'Archiving' %}</a>
             </div>
             <div class="collapse{% if semester.participations_are_archived or semester.grade_documents_are_deleted or semester.results_are_archived %} show{% endif %}" id="archivingCard">
                 <div class="card-body d-flex flex-wrap gap-2">
@@ -97,8 +97,8 @@
                         <form reload-on-success method="POST" action="{% url 'staff:semester_archive_participations' %}">
                             {% csrf_token %}
                             <confirmation-modal type="submit" name="semester_id" value="{{ semester.id }}" confirm-button-class="btn-danger">
-                                <span slot="title">{% trans 'Archive participations' %}</span>
-                                <span slot="action-text">{% trans 'Archive participations' %}</span>
+                                <span slot="title">{% translate 'Archive participations' %}</span>
+                                <span slot="action-text">{% translate 'Archive participations' %}</span>
                                 <span slot="question">
                                     {% blocktrans trimmed with semester_name=semester.name %}
                                         Do you really want to archive all participations in the semester <strong>{{ semester_name }}</strong>?
@@ -106,22 +106,22 @@
                                     {% endblocktrans %}
                                 </span>
 
-                                <button slot="show-button" type="button" class="btn btn-sm btn-warning">{% trans 'Archive participations' %}</button>
+                                <button slot="show-button" type="button" class="btn btn-sm btn-warning">{% translate 'Archive participations' %}</button>
                             </confirmation-modal>
                         </form>
                     {% elif semester.participations_are_archived %}
-                        <button type="button" disabled class="btn btn-sm btn-success">{% trans 'Participations have been archived' %}</button>
+                        <button type="button" disabled class="btn btn-sm btn-success">{% translate 'Participations have been archived' %}</button>
                     {% else %}
                         <button type="button" disabled class="btn btn-sm btn-warning"
-                            data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'The participations in this semester can not be archived.' %}">
-                            {% trans 'Archive participations' %}</button>
+                            data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'The participations in this semester can not be archived.' %}">
+                            {% translate 'Archive participations' %}</button>
                     {% endif %}
                     {% if semester.grade_documents_can_be_deleted %}
                         <form reload-on-success method="POST" action="{% url 'staff:semester_delete_grade_documents' %}">
                             {% csrf_token %}
                             <confirmation-modal type="submit" name="semester_id" value="{{ semester.id }}" confirm-button-class="btn-danger">
-                                <span slot="title">{% trans 'Delete grade documents' %}</span>
-                                <span slot="action-text">{% trans 'Delete grade documents' %}</span>
+                                <span slot="title">{% translate 'Delete grade documents' %}</span>
+                                <span slot="action-text">{% translate 'Delete grade documents' %}</span>
                                 <span slot="question">
                                     {% blocktrans trimmed with semester_name=semester.name %}
                                         Do you really want to delete the grade documents in the semester <strong>{{ semester_name }}</strong>?
@@ -130,18 +130,18 @@
                                     {% endblocktrans %}
                                 </span>
 
-                                <button slot="show-button" type="button" class="btn btn-sm btn-warning">{% trans 'Delete grade documents' %}</button>
+                                <button slot="show-button" type="button" class="btn btn-sm btn-warning">{% translate 'Delete grade documents' %}</button>
                             </confirmation-modal>
                         </form>
                     {% elif semester.grade_documents_are_deleted %}
-                        <button type="button" class="btn btn-sm btn-success disabled">{% trans 'Grade documents have been deleted' %}</button>
+                        <button type="button" class="btn btn-sm btn-success disabled">{% translate 'Grade documents have been deleted' %}</button>
                     {% endif %}
                     {% if semester.results_can_be_archived %}
                         <form reload-on-success method="POST" action="{% url 'staff:semester_archive_results' %}">
                             {% csrf_token %}
                             <confirmation-modal type="submit" name="semester_id" value="{{ semester.id }}" confirm-button-class="btn-danger">
-                                <span slot="title">{% trans 'Archive results' %}</span>
-                                <span slot="action-text">{% trans 'Archive results' %}</span>
+                                <span slot="title">{% translate 'Archive results' %}</span>
+                                <span slot="action-text">{% translate 'Archive results' %}</span>
                                 <span slot="question">
                                     {% blocktrans trimmed with semester_name=semester.name %}
                                         Do you really want to archive the results in the semester <strong>{{ semester_name }}</strong>?
@@ -150,11 +150,11 @@
                                     {% endblocktrans %}
                                 </span>
 
-                                <button slot="show-button" type="button" class="btn btn-sm btn-warning">{% trans 'Archive results' %}</button>
+                                <button slot="show-button" type="button" class="btn btn-sm btn-warning">{% translate 'Archive results' %}</button>
                             </confirmation-modal>
                         </form>
                     {% elif semester.results_are_archived %}
-                        <button type="button" disabled class="btn btn-sm btn-success">{% trans 'Results have been archived' %}</button>
+                        <button type="button" disabled class="btn btn-sm btn-success">{% translate 'Results have been archived' %}</button>
                     {% endif %}
                 </div>
             </div>
@@ -163,21 +163,21 @@
 
     <div class="card collapsible mb-3">
         <div class="card-header d-flex">
-            <a class="collapse-toggle collapsed" data-bs-toggle="collapse" href="#overviewCard" aria-expanded="false" aria-controls="overviewCard" onclick="saveCollapseState()">{% trans 'Overview' %}</a>
+            <a class="collapse-toggle collapsed" data-bs-toggle="collapse" href="#overviewCard" aria-expanded="false" aria-controls="overviewCard" onclick="saveCollapseState()">{% translate 'Overview' %}</a>
             {% if request.user.is_manager %}
                 <div class="ms-auto">
                     {% if not semester.participations_are_archived %}
-                        <a href="{% url 'staff:semester_preparation_reminder' semester.id %}" class="btn btn-sm btn-light">{% trans 'Preparation reminder' %}</a>
-                        <a href="{% url 'staff:semester_grade_reminder' semester.id %}" class="btn btn-sm btn-light ms-2">{% trans 'Grade publish reminder' %}</a>
+                        <a href="{% url 'staff:semester_preparation_reminder' semester.id %}" class="btn btn-sm btn-light">{% translate 'Preparation reminder' %}</a>
+                        <a href="{% url 'staff:semester_grade_reminder' semester.id %}" class="btn btn-sm btn-light ms-2">{% translate 'Grade publish reminder' %}</a>
                     {% endif %}
                     <form id="form_activation_status" class="d-inline" method="post" action="{% url 'rewards:semester_activation_edit' semester.id %}">
                         {% csrf_token %}
                         <div class="btn-switch ms-2">
-                            <div class="btn-switch-label">{% trans 'Reward points active' %}</div>
+                            <div class="btn-switch-label">{% translate 'Reward points active' %}</div>
                             <div class="btn-switch btn-group icon-buttons">
                                 <confirmation-modal type="submit" name="activation_status" value="on" confirm-button-class="btn-primary">
-                                    <span slot="title">{% trans 'Activate reward points' %}</span>
-                                    <span slot="action-text">{% trans 'Activate reward points' %}</span>
+                                    <span slot="title">{% translate 'Activate reward points' %}</span>
+                                    <span slot="action-text">{% translate 'Activate reward points' %}</span>
                                     <span slot="question">
                                         {% blocktrans trimmed with semester_name=semester.name %}
                                             Do you want to activate the reward points for the semester <strong>{{ semester_name }}</strong>?
@@ -201,18 +201,18 @@
                 <table class="table">
                     <thead>
                         <tr>
-                            <th style="width: 19%">{% trans 'Degree' %}</th>
-                            <th style="width: 30%">{% trans 'Evaluation period' %}</th>
-                            <th style="width: 17%">{% trans 'Finished evaluations' %}</th>
-                            <th style="width: 17%">{% trans 'Reviewed text answers' %}</th>
-                            <th style="width: 17%">{% trans 'Participation' %}</th>
+                            <th style="width: 19%">{% translate 'Degree' %}</th>
+                            <th style="width: 30%">{% translate 'Evaluation period' %}</th>
+                            <th style="width: 17%">{% translate 'Finished evaluations' %}</th>
+                            <th style="width: 17%">{% translate 'Reviewed text answers' %}</th>
+                            <th style="width: 17%">{% translate 'Participation' %}</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for degree, stats in degree_stats.items %}
                         <tr{% if degree == 'total' %} class="table-total-stats"{% endif %}>
                             <td>
-                                {% if degree == 'total' %}{% trans 'Total' %}{% else %}{{ degree }}{% endif %}
+                                {% if degree == 'total' %}{% translate 'Total' %}{% else %}{{ degree }}{% endif %}
                             </td>
                             <td>
                                 {% if stats.num_evaluations != 0 %}
@@ -241,12 +241,12 @@
             <ul class="nav nav-pills" role="tablist">
                 <li class="nav-item">
                     <a class="nav-link active" id="evaluationsTab" data-bs-toggle="pill" href="#evaluations" role="tab" onclick="saveSelectedTab('evaluations');">
-                        <span class="fas fa-clipboard-check"></span> {% trans 'Evaluations' %}
+                        <span class="fas fa-clipboard-check"></span> {% translate 'Evaluations' %}
                     </a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" id="coursesTab" data-bs-toggle="pill" href="#courses" role="tab" onclick="saveSelectedTab('courses');">
-                        <span class="fas fa-chalkboard-user"></span> {% trans 'Courses' %}
+                        <span class="fas fa-chalkboard-user"></span> {% translate 'Courses' %}
                     </a>
                 </li>
             </ul>
@@ -254,25 +254,25 @@
                 {% if request.user.is_manager %}
                     {% if not semester.participations_are_archived %}
                         <a class="btn btn-sm btn-light" href="{% url 'staff:semester_import' semester.id %}">
-                            {% trans 'Import' %}
+                            {% translate 'Import' %}
                         </a>
                     {% endif %}
                     <div class="btn-group ms-2" role="group">
-                        <button type="button" id="btnExport" class="btn btn-sm btn-light dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Export' %}</button>
+                        <button type="button" id="btnExport" class="btn btn-sm btn-light dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% translate 'Export' %}</button>
                         <div class="dropdown-menu" aria-labelledby="btnExport">
-                            <a class="dropdown-item" href="{% url 'staff:semester_export' semester.id %}">{% trans 'Export results' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:semester_raw_export' semester.id %}">{% trans 'Export raw evaluation data' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:semester_participation_export' semester.id %}">{% trans 'Export participation data' %}</a>
-                            <a class="dropdown-item" href="{% url 'staff:vote_timestamps_export' semester.id %}">{% trans 'Export vote timestamps' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:semester_export' semester.id %}">{% translate 'Export results' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:semester_raw_export' semester.id %}">{% translate 'Export raw evaluation data' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:semester_participation_export' semester.id %}">{% translate 'Export participation data' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:vote_timestamps_export' semester.id %}">{% translate 'Export vote timestamps' %}</a>
                         </div>
                     </div>
                     {% if not semester.participations_are_archived %}
-                        <a href="{% url 'staff:semester_questionnaire_assign' semester.id %}" class="btn btn-sm btn-light ms-2">{% trans 'Assign questionnaires' %}</a>
+                        <a href="{% url 'staff:semester_questionnaire_assign' semester.id %}" class="btn btn-sm btn-light ms-2">{% translate 'Assign questionnaires' %}</a>
                     {% endif %}
                 {% endif %}
                 {% if request.user.is_reviewer %}
                     <a class="btn btn-sm btn-light ms-2" href="{% url 'staff:semester_flagged_textanswers' semester.id %}">
-                        {% trans 'Flagged textanswers' %}
+                        {% translate 'Flagged textanswers' %}
                     </a>
                 {% endif %}
             </div>
@@ -283,24 +283,24 @@
                     <div class="col-9">
                         {% if request.user.is_manager %}
                             <a class="btn btn-sm btn-dark" href="{% url 'staff:evaluation_create_for_semester' semester.id %}">
-                                {% trans 'Create evaluation' %}
+                                {% translate 'Create evaluation' %}
                             </a>
                             <a class="btn btn-sm btn-dark ms-2" href="{% url 'staff:single_result_create_for_semester' semester.id %}">
-                                {% trans 'Create single result' %}
+                                {% translate 'Create single result' %}
                             </a>
                         {% endif %}
                     </div>
                     <div class="col-3">
                         <div class="input-group">
-                            <input type="search" name="search-evaluation" class="form-control" placeholder="{% trans 'Search...' %}" />
-                            <button class="btn btn-light text-secondary" type="button" data-reset="search-evaluation" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Clear search filter' %}">
+                            <input type="search" name="search-evaluation" class="form-control" placeholder="{% translate 'Search...' %}" />
+                            <button class="btn btn-light text-secondary" type="button" data-reset="search-evaluation" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Clear search filter' %}">
                                 <span class="fas fa-delete-left"></span>
                             </button>
                         </div>
                     </div>
                 </div>
                 <div class="btn-switch mb-2" id="evaluation-filter-buttons">
-                    <div class="btn-switch-label my-auto pe-0">{% trans 'Filter' %}</div>
+                    <div class="btn-switch-label my-auto pe-0">{% translate 'Filter' %}</div>
                     <div>
                         <div class="btn-switch btn-group icon-buttons">
                             {% for approval_state in approval_states %}
@@ -316,61 +316,61 @@
                         <div class="btn-switch btn-group icon-buttons">
                             <button type="button" class="btn btn-sm btn-light" data-filter="evaluation_not_yet_started"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'Evaluation did not start yet' %}">
+                                title="{% translate 'Evaluation did not start yet' %}">
                                 <span class="fas fa-pause icon-gray"></span>
                             </button>
                             <button type="button" class="btn btn-sm btn-light" data-filter="in_evaluation"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'In evaluation' %}">
+                                title="{% translate 'In evaluation' %}">
                                 <span class="fas fa-play icon-gray"></span>
                             </button>
                             <button type="button" class="btn btn-sm btn-light" data-filter="evaluated"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'Evaluated' %}">
+                                title="{% translate 'Evaluated' %}">
                                 <span class="fas fa-stop icon-green"></span>
                             </button>
                         </div>
                         <div class="btn-switch btn-group icon-buttons">
                             <button type="button" class="btn btn-sm btn-light" data-filter="no_review"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'No text answers available or evaluation not yet finished' %}">
+                                title="{% translate 'No text answers available or evaluation not yet finished' %}">
                                 <span class="fas fa-comment icon-gray"></span>
                             </button>
                             <button type="button" class="btn btn-sm btn-light" data-filter="unreviewed_textanswers_urgent"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'Text answers awaiting urgent review because grading process is finished' %}">
+                                title="{% translate 'Text answers awaiting urgent review because grading process is finished' %}">
                                 <span class="fas fa-comment icon-red"></span>
                             </button>
                             <button type="button" class="btn btn-sm btn-light" data-filter="unreviewed_textanswers"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'Text answers awaiting review' %}">
+                                title="{% translate 'Text answers awaiting review' %}">
                                 <span class="fas fa-comment icon-yellow"></span>
                             </button>
                             <button type="button" class="btn btn-sm btn-light" data-filter="textanswers_reviewed"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'Text answers reviewed' %}">
+                                title="{% translate 'Text answers reviewed' %}">
                                 <span class="fas fa-comment icon-green"></span>
                             </button>
                         </div>
                         <div class="btn-switch btn-group icon-buttons">
                             <button type="button" class="btn btn-sm btn-light" data-filter="evaluation_not_finished"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'Evaluation not finished' %}">
+                                title="{% translate 'Evaluation not finished' %}">
                                 <span class="fas fa-chart-simple icon-gray"></span>
                             </button>
                             <button type="button" class="btn btn-sm btn-light" data-filter="results_not_published"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'Results not yet published although grading process is finished' %}">
+                                title="{% translate 'Results not yet published although grading process is finished' %}">
                                 <span class="fas fa-chart-simple icon-red"></span>
                             </button>
                             <button type="button" class="btn btn-sm btn-light" data-filter="results_not_yet_published"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'Results not yet published' %}">
+                                title="{% translate 'Results not yet published' %}">
                                 <span class="fas fa-chart-simple icon-yellow"></span>
                             </button>
                             <button type="button" class="btn btn-sm btn-light" data-filter="results_published"
                                 data-bs-toggle="tooltip" data-bs-placement="top" data-container=".btn-switch"
-                                title="{% trans 'Results published' %}">
+                                title="{% translate 'Results published' %}">
                                 <span class="fas fa-chart-simple icon-green"></span>
                             </button>
                         </div>
@@ -408,8 +408,8 @@
                                     <th class="col-order" data-col="state-evaluating"></th>
                                     <th class="col-order" data-col="state-textanswers"></th>
                                     <th class="col-order" data-col="state-results"></th>
-                                    <th class="col-order" data-col="name">{% trans 'Name' %}</th>
-                                    <th class="col-order" data-col="period">{% trans 'Evaluation period' %}</th>
+                                    <th class="col-order" data-col="name">{% translate 'Name' %}</th>
+                                    <th class="col-order" data-col="period">{% translate 'Evaluation period' %}</th>
                                     <th></th>
                                     <th></th>
                                 </tr>
@@ -425,7 +425,7 @@
                     {% else %}
                         <table class="table table-striped table-narrow table-vertically-aligned">
                             <tbody>
-                                <tr><td><i>{% trans 'There are no evaluations in this semester.' %}</i></td></tr>
+                                <tr><td><i>{% translate 'There are no evaluations in this semester.' %}</i></td></tr>
                             </tbody>
                         </table>
                     {% endif %}
@@ -434,42 +434,42 @@
                         <div class="my-2">
                             <button type="button" class="btn btn-sm btn-secondary"
                                 onclick="document.querySelectorAll('#evaluation_operation_form input[type=checkbox][name=evaluation]').forEach(c => {c.checked = true;})">
-                                {% trans 'Select all' %}
+                                {% translate 'Select all' %}
                             </button>
                             <button type="button" class="btn btn-sm btn-secondary"
                                 onclick="document.querySelectorAll('#evaluation_operation_form input[type=checkbox][name=evaluation]').forEach(c => {c.checked = false;})">
-                                {% trans 'Select none' %}
+                                {% translate 'Select none' %}
                             </button>
                         </div>
                         <div>
                             <button name="target_state" value="{{ Evaluation.State.PREPARED }}" type="submit" class="btn btn-sm btn-light"
-                                data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Evaluations in preparation or approved by editors' %}">
+                                data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Evaluations in preparation or approved by editors' %}">
                                 <span class="{{ Evaluation.State.NEW|approval_state_icon }}"></span>
                                 <span class="{{ Evaluation.State.EDITOR_APPROVED|approval_state_icon }}"></span>
-                                {% trans 'Ask for editor review' %}
+                                {% translate 'Ask for editor review' %}
                             </button>
                             <button name="target_state" value="{{ Evaluation.State.NEW }}" type="submit" class="btn btn-sm btn-light"
-                                data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Evaluations awaiting editor review, approved by editor or approved by manager' %}">
+                                data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Evaluations awaiting editor review, approved by editor or approved by manager' %}">
                                 <span class="{{ Evaluation.State.PREPARED|approval_state_icon }}"></span>
                                 <span class="{{ Evaluation.State.EDITOR_APPROVED|approval_state_icon }}"></span>
                                 <span class="{{ Evaluation.State.APPROVED|approval_state_icon }}"></span>
-                                {% trans 'Revert to preparation' %}
+                                {% translate 'Revert to preparation' %}
                             </button>
                             <button name="target_state" value="{{ Evaluation.State.IN_EVALUATION }}" type="submit" class="btn btn-sm btn-light"
-                                data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Evaluations waiting for evaluation period to start' %}">
+                                data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Evaluations waiting for evaluation period to start' %}">
                                 <span class="fas fa-pause icon-gray"></span>
-                                {% trans 'Start evaluation' %}
+                                {% translate 'Start evaluation' %}
                             </button>
                             <button name="target_state" value="{{ Evaluation.State.PUBLISHED }}" type="submit" class="btn btn-sm btn-light"
-                                data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Unpublished evaluations' %}">
+                                data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Unpublished evaluations' %}">
                                 <span class="fas fa-chart-simple icon-yellow"></span>
                                 <span class="fas fa-chart-simple icon-red"></span>
-                                {% trans 'Publish' %}
+                                {% translate 'Publish' %}
                             </button>
                             <button name="target_state" value="{{ Evaluation.State.REVIEWED }}" type="submit" class="btn btn-sm btn-light"
-                                data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Published evaluations' %}">
+                                data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Published evaluations' %}">
                                 <span class="fas fa-chart-simple icon-green"></span>
-                                {% trans 'Unpublish' %}
+                                {% translate 'Unpublish' %}
                             </button>
                         </div>
                     {% endif %}
@@ -480,14 +480,14 @@
                     <div class="col-9">
                         {% if request.user.is_manager %}
                             <a class="btn btn-sm btn-dark" href="{% url 'staff:course_create' semester.id %}">
-                                {% trans 'Create course' %}
+                                {% translate 'Create course' %}
                             </a>
                         {% endif %}
                     </div>
                     <div class="col-3">
                         <div class="input-group">
-                            <input type="search" name="search-course" class="form-control" placeholder="{% trans 'Search...' %}" />
-                            <button class="btn btn-light text-secondary" type="button" data-reset="search-course" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Clear search filter' %}">
+                            <input type="search" name="search-course" class="form-control" placeholder="{% translate 'Search...' %}" />
+                            <button class="btn btn-light text-secondary" type="button" data-reset="search-course" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Clear search filter' %}">
                                 <span class="fas fa-delete-left"></span>
                             </button>
                         </div>
@@ -512,9 +512,9 @@
                         </colgroup>
                         <thead>
                             <tr>
-                                <th class="col-order" data-col="name">{% trans 'Course' %}</th>
-                                <th class="col-order" data-col="responsible">{% trans 'Responsible' %}</th>
-                                <th class="col-order" data-col="evaluation-count">{% trans '#Evaluations' %}</th>
+                                <th class="col-order" data-col="name">{% translate 'Course' %}</th>
+                                <th class="col-order" data-col="responsible">{% translate 'Responsible' %}</th>
+                                <th class="col-order" data-col="evaluation-count">{% translate '#Evaluations' %}</th>
                                 <th></th>
                             </tr>
                         </thead>
@@ -534,7 +534,7 @@
                                     </td>
                                     <td data-col="evaluation-count" data-order="{{ course.evaluations.count }}">
                                         {% if course.evaluations.count == 0 %}
-                                            <span class="badge bg-warning">{% trans 'No evaluations' %}</span>
+                                            <span class="badge bg-warning">{% translate 'No evaluations' %}</span>
                                         {% else %}
                                             {{ course.evaluations.count }}
                                         {% endif %}
@@ -543,31 +543,31 @@
                                         {% if request.user.is_manager %}
                                             <a class="btn btn-sm btn-dark" data-bs-toggle="tooltip"
                                                 href="{% url 'staff:evaluation_create_for_course' course.id %}"
-                                                title="{% trans 'Create evaluation for this course' %}">
+                                                title="{% translate 'Create evaluation for this course' %}">
                                                 <span class="fas fa-clipboard-check"></span>
                                             </a>
                                             <a class="btn btn-sm btn-dark" data-bs-toggle="tooltip"
                                                 href="{% url 'staff:single_result_create_for_course' course.id %}"
-                                                title="{% trans 'Create single result for this course' %}">
+                                                title="{% translate 'Create single result for this course' %}">
                                                 <span class="fas fa-square-poll-vertical"></span>
                                         </a>
                                         <a class="btn btn-sm btn-dark" data-bs-toggle="tooltip"
                                             href="{% url 'staff:course_copy' course.id %}"
-                                            title="{% trans 'Copy course' %}">
+                                            title="{% translate 'Copy course' %}">
                                             <span class="fas fa-copy"></span>
                                             </a>
                                         {% endif %}
                                         {% if course.can_be_deleted_by_manager %}
                                             <confirmation-modal type="submit" form="course-deletion-form" name="course_id" value="{{ course.id }}" confirm-button-class="btn-danger">
-                                                <span slot="title">{% trans 'Delete course' %}</span>
-                                                <span slot="action-text">{% trans 'Delete course' %}</span>
+                                                <span slot="title">{% translate 'Delete course' %}</span>
+                                                <span slot="action-text">{% translate 'Delete course' %}</span>
                                                 <span slot="question">
                                                     {% blocktrans trimmed with course_name=course.name %}
                                                         Do you really want to delete the course <strong>{{ course_name }}</strong>?
                                                     {% endblocktrans %}
                                                 </span>
 
-                                                <button slot="show-button" type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
+                                                <button slot="show-button" type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Delete' %}">
                                                     <span class="fas fa-trash" aria-hidden="true"></span>
                                                 </button>
                                             </confirmation-modal>
@@ -580,7 +580,7 @@
                 {% else %}
                     <table class="table table-striped table-narrow table-vertically-aligned">
                         <tbody>
-                            <tr><td><i>{% trans 'There are no courses in this semester.' %}</i></td></tr>
+                            <tr><td><i>{% translate 'There are no courses in this semester.' %}</i></td></tr>
                         </tbody>
                     </table>
                 {% endif %}

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -18,7 +18,7 @@
                         <span slot="title">{% translate 'Make this the active semester' %}</span>
                         <span slot="action-text">{% translate 'Make active' %}</span>
                         <span slot="question">
-                            {% blocktrans trimmed %}
+                            {% blocktranslate trimmed %}
                                 Do you want to make this the active semester?
                             {% endblocktrans %}
                         </span>
@@ -41,7 +41,7 @@
                     <confirmation-modal type="submit" confirm-button-class="btn-danger">
                         <span slot="title">{% translate 'Delete semester' %}</span>
                         <span slot="question">
-                            {% blocktrans trimmed with semester_name=semester.name %}
+                            {% blocktranslate trimmed with semester_name=semester.name %}
                                 Do you really want to delete the semester <strong>{{ semester_name }}</strong>?
                                 All courses and evaluations will be deleted as well as all results.
                                 If you are sure, enter the name of the semester below.
@@ -100,7 +100,7 @@
                                 <span slot="title">{% translate 'Archive participations' %}</span>
                                 <span slot="action-text">{% translate 'Archive participations' %}</span>
                                 <span slot="question">
-                                    {% blocktrans trimmed with semester_name=semester.name %}
+                                    {% blocktranslate trimmed with semester_name=semester.name %}
                                         Do you really want to archive all participations in the semester <strong>{{ semester_name }}</strong>?
                                         Further changes to the evaluations won't be possible and you can't undo this action.
                                     {% endblocktrans %}
@@ -123,7 +123,7 @@
                                 <span slot="title">{% translate 'Delete grade documents' %}</span>
                                 <span slot="action-text">{% translate 'Delete grade documents' %}</span>
                                 <span slot="question">
-                                    {% blocktrans trimmed with semester_name=semester.name %}
+                                    {% blocktranslate trimmed with semester_name=semester.name %}
                                         Do you really want to delete the grade documents in the semester <strong>{{ semester_name }}</strong>?
                                         This will delete all existing grade documents for this semester's courses and will disable new uploads.
                                         You can't undo this action.
@@ -143,7 +143,7 @@
                                 <span slot="title">{% translate 'Archive results' %}</span>
                                 <span slot="action-text">{% translate 'Archive results' %}</span>
                                 <span slot="question">
-                                    {% blocktrans trimmed with semester_name=semester.name %}
+                                    {% blocktranslate trimmed with semester_name=semester.name %}
                                         Do you really want to archive the results in the semester <strong>{{ semester_name }}</strong>?
                                         This will make the results of all evaluations inaccessible for all users except their contributors and managers.
                                         You can't undo this action.
@@ -179,7 +179,7 @@
                                     <span slot="title">{% translate 'Activate reward points' %}</span>
                                     <span slot="action-text">{% translate 'Activate reward points' %}</span>
                                     <span slot="question">
-                                        {% blocktrans trimmed with semester_name=semester.name %}
+                                        {% blocktranslate trimmed with semester_name=semester.name %}
                                             Do you want to activate the reward points for the semester <strong>{{ semester_name }}</strong>?
                                             The activation will allow participants to receive reward points when voting and will also grant all eligible points for participants who have already voted so far.
                                             The process will take a while.
@@ -562,7 +562,7 @@
                                                 <span slot="title">{% translate 'Delete course' %}</span>
                                                 <span slot="action-text">{% translate 'Delete course' %}</span>
                                                 <span slot="question">
-                                                    {% blocktrans trimmed with course_name=course.name %}
+                                                    {% blocktranslate trimmed with course_name=course.name %}
                                                         Do you really want to delete the course <strong>{{ course_name }}</strong>?
                                                     {% endblocktrans %}
                                                 </span>

--- a/evap/staff/templates/staff_semester_view_evaluation.html
+++ b/evap/staff/templates/staff_semester_view_evaluation.html
@@ -6,7 +6,7 @@
 <td>
     {% if request.user.is_manager and not info_only and not semester.participations_are_archived %}
         {% if state <= evaluation.State.APPROVED or state >= evaluation.State.REVIEWED %}
-            <div class="form-check" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Select for evaluation operation' %}">
+            <div class="form-check" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Select for evaluation operation' %}">
                 <input class="form-check-input" type="checkbox" name="evaluation" id="evaluation{{ evaluation.id }}" value="{{ evaluation.id }}" />
                 <label class="form-check-label" for="evaluation{{ evaluation.id }}"></label>
             </div>
@@ -22,57 +22,57 @@
 
 {% if state < evaluation.State.APPROVED %}
     <td class="icon" data-col="state-evaluating" data-order="1" data-filter="evaluation_not_yet_started">
-        <span class="fas fa-pause icon-gray" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Evaluation did not start yet' %}"></span>
+        <span class="fas fa-pause icon-gray" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Evaluation did not start yet' %}"></span>
     </td>
 {% elif state == evaluation.State.APPROVED %}
     <td class="icon" data-col="state-evaluating" data-order="1" data-filter="evaluation_not_yet_started">
-        <span class="fas fa-pause icon-gray" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Waiting for evaluation period to start' %}"></span>
+        <span class="fas fa-pause icon-gray" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Waiting for evaluation period to start' %}"></span>
     </td>
 {% elif state == evaluation.State.IN_EVALUATION %}
     <td class="icon" data-col="state-evaluating" data-order="2" data-filter="in_evaluation">
-        <span class="fas fa-play icon-gray" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'In evaluation' %}"></span>
+        <span class="fas fa-play icon-gray" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'In evaluation' %}"></span>
     </td>
 {% elif state >= evaluation.State.EVALUATED %}
     <td class="icon" data-col="state-evaluating" data-order="3" data-filter="evaluated">
-        <span class="fas fa-stop icon-green" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Evaluated' %}"></span>
+        <span class="fas fa-stop icon-green" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Evaluated' %}"></span>
     </td>
 {% endif %}
 
 {% if evaluation.textanswer_review_state == evaluation.TextAnswerReviewState.NO_TEXTANSWERS or evaluation.textanswer_review_state == evaluation.TextAnswerReviewState.NO_REVIEW_NEEDED %}
     <td class="icon" data-col="state-textanswers" data-order="3" data-filter="no_review">
-        <span class="fas fa-comment icon-gray" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'No text answers available or evaluation not yet finished' %}"></span>
+        <span class="fas fa-comment icon-gray" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'No text answers available or evaluation not yet finished' %}"></span>
     </td>
 {% elif evaluation.textanswer_review_state == evaluation.TextAnswerReviewState.REVIEW_URGENT %}
     <td class="icon" data-col="state-textanswers" data-order="1" data-filter="unreviewed_textanswers_urgent">
-        <span class="fas fa-comment icon-red" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Text answers awaiting urgent review because grading process is finished' %}"></span>
+        <span class="fas fa-comment icon-red" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Text answers awaiting urgent review because grading process is finished' %}"></span>
     </td>
 {% elif evaluation.textanswer_review_state == evaluation.TextAnswerReviewState.REVIEW_NEEDED %}
     <td class="icon" data-col="state-textanswers" data-order="2" data-filter="unreviewed_textanswers">
-        <span class="fas fa-comment icon-yellow" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Text answers awaiting review' %}"></span>
+        <span class="fas fa-comment icon-yellow" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Text answers awaiting review' %}"></span>
     </td>
 {% else %}
     <td class="icon" data-col="state-textanswers" data-order="4" data-filter="textanswers_reviewed">
-        <span class="fas fa-comment icon-green" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Text answers reviewed' %}"></span>
+        <span class="fas fa-comment icon-green" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Text answers reviewed' %}"></span>
     </td>
 {% endif %}
 
 {% if state < evaluation.State.REVIEWED %}
     <td class="icon" data-col="state-results" data-order="2" data-filter="evaluation_not_finished">
-        <span class="fas fa-chart-simple icon-gray" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Evaluation not finished' %}"></span>
+        <span class="fas fa-chart-simple icon-gray" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Evaluation not finished' %}"></span>
     </td>
 {% elif state == evaluation.State.REVIEWED %}
     {% if evaluation.is_single_result or evaluation.grading_process_is_finished %}
         <td class="icon text-center" data-col="state-results" data-order="0" data-filter="results_not_published">
-            <span class="fas fa-chart-simple icon-red" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Results not yet published although grading process is finished' %}"></span>
+            <span class="fas fa-chart-simple icon-red" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Results not yet published although grading process is finished' %}"></span>
         </td>
     {% else %}
         <td class="icon text-center" data-col="state-results" data-order="1" data-filter="results_not_yet_published">
-            <span class="fas fa-chart-simple icon-yellow" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Results not yet published' %}"></span>
+            <span class="fas fa-chart-simple icon-yellow" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Results not yet published' %}"></span>
         </td>
     {% endif %}
 {% elif state == evaluation.State.PUBLISHED %}
     <td class="icon" data-col="state-results" data-order="3" data-filter="results_published">
-        <span class="fas fa-chart-simple icon-green" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Results published' %}"></span>
+        <span class="fas fa-chart-simple icon-green" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Results published' %}"></span>
     </td>
 {% endif %}
 
@@ -80,7 +80,7 @@
     <div>
     {% if not info_only and request.user.is_manager %}
         <a href="{% url 'staff:evaluation_edit' evaluation.id %}">{{ evaluation.full_name }}</a>
-        <a class="small no-underline" href="{% url 'staff:course_edit' evaluation.course.id %}" data-bs-toggle="tooltip" data-bs-placement="right" title="{% trans 'Edit course' %}">
+        <a class="small no-underline" href="{% url 'staff:course_edit' evaluation.course.id %}" data-bs-toggle="tooltip" data-bs-placement="right" title="{% translate 'Edit course' %}">
             <span class="fas fa-chalkboard-user"></span>
         </a>
     {% else %}
@@ -90,26 +90,26 @@
     <div class="fst-italic">
         {{ evaluation.course.responsibles_names }}
         {% if info_only or not request.user.is_manager or state >= evaluation.State.IN_EVALUATION %}
-            <span class="small" data-bs-toggle="tooltip" data-bs-placement="right" title="{% trans 'Number of contributors' %}">
+            <span class="small" data-bs-toggle="tooltip" data-bs-placement="right" title="{% translate 'Number of contributors' %}">
                 ({{ evaluation.num_contributors }} <span class="fas fa-person-chalkboard"></span>)
             </span>
         {% else %}
-            <a class="small no-underline" href="{% url 'staff:evaluation_person_management' evaluation.id %}" data-bs-toggle="tooltip" data-bs-placement="right" title="{% trans 'Manage contributors' %}">
+            <a class="small no-underline" href="{% url 'staff:evaluation_person_management' evaluation.id %}" data-bs-toggle="tooltip" data-bs-placement="right" title="{% translate 'Manage contributors' %}">
                 ({{ evaluation.num_contributors }} <span class="fas fa-person-chalkboard"></span>)
             </a>
         {% endif %}
     </div>
     {% include 'evaluation_badges.html' with mode='manager' %}
     {% if evaluation.num_course_evaluations > 1 %}
-        <span class="badge rounded-pill bg-dark" data-bs-toggle="tooltip" data-bs-placement="right" title="{% trans 'Weight' %}">{{ evaluation.weight }}</span>
+        <span class="badge rounded-pill bg-dark" data-bs-toggle="tooltip" data-bs-placement="right" title="{% translate 'Weight' %}">{{ evaluation.weight }}</span>
     {% endif %}
 
     {% if state < evaluation.State.APPROVED %}
         {% if not evaluation.all_contributions_have_questionnaires %}
             {% if not evaluation.general_contribution_has_questionnaires %}
-                <span class="badge bg-danger">{% trans 'Evaluation has no questionnaires' %}</span>
+                <span class="badge bg-danger">{% translate 'Evaluation has no questionnaires' %}</span>
             {% else %}
-                <span class="badge bg-warning">{% trans 'Not all contributors have questionnaires' %}</span>
+                <span class="badge bg-warning">{% translate 'Not all contributors have questionnaires' %}</span>
             {% endif %}
         {% endif %}
     {% endif %}
@@ -121,63 +121,63 @@
     {% if not evaluation.is_single_result %}
         <td class="multi-progress-bar">
             {% if evaluation.can_publish_average_grade %}
-                <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Number of voters' %}">
+                <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Number of voters' %}">
                     {% include 'progress_bar.html' with done=evaluation.num_voters total=evaluation.num_participants icon='user' %}
                 </span>
             {% else %}
-                <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Not enough voters to publish average grade' %}">
+                <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Not enough voters to publish average grade' %}">
                     {% include 'progress_bar.html' with done=evaluation.num_voters total=evaluation.num_participants icon='user' warning=True %}
                 </span>
             {% endif %}
             {% if evaluation.num_textanswers > 0 and state != evaluation.State.PUBLISHED and not info_only %}
-                <a class="no-underline" href="{% url 'staff:evaluation_textanswers' evaluation.id %}" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Review text answers' %}">
+                <a class="no-underline" href="{% url 'staff:evaluation_textanswers' evaluation.id %}" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Review text answers' %}">
                     {% include 'progress_bar.html' with done=evaluation.num_reviewed_textanswers total=evaluation.num_textanswers icon='comment' %}
                 </a>
             {% elif info_only %}
-                <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Number of text answers' %}">
+                <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Number of text answers' %}">
                     {% include 'progress_bar.html' with done=evaluation.num_reviewed_textanswers total=evaluation.num_textanswers icon='comment' %}
                 </span>
             {% else %}
-                <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Number of text answers' %}">
+                <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Number of text answers' %}">
                     <span class="fas fa-comment"></span> {{ evaluation.num_textanswers }}
                 </span>
                 <br />
             {% endif %}
             {% if evaluation.wait_for_grade_upload_before_publishing %}
                 {% if info_only or not request.user.is_manager %}
-                    <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Grade documents (Midterm, Final)' %}">
+                    <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Grade documents (Midterm, Final)' %}">
                         <span class="fas fa-file"></span>
                         {% blocktrans with midterm=evaluation.midterm_grade_documents_count final=evaluation.final_grade_documents_count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}
                     </span>
                 {% else %}
-                    <a href="{% url 'grades:course_view' evaluation.course.id %}" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Grade documents (Midterm, Final)' %}">
+                    <a href="{% url 'grades:course_view' evaluation.course.id %}" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Grade documents (Midterm, Final)' %}">
                         <span class="fas fa-file"></span>
                         {% blocktrans with midterm=evaluation.midterm_grade_documents_count final=evaluation.final_grade_documents_count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}
                     </a>
                 {% endif %}
                 {% if evaluation.final_grade_documents_count %}
-                    <span class="fas fa-check" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Final grades have been uploaded' %}"></span>
+                    <span class="fas fa-check" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Final grades have been uploaded' %}"></span>
                 {% elif evaluation.course.gets_no_grade_documents %}
-                    <span class="fas fa-check" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'It was confirmed that final grades have been submitted' %}"></span>
+                    <span class="fas fa-check" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'It was confirmed that final grades have been submitted' %}"></span>
                 {% endif %}
             {% endif %}
         </td>
     {% else %}
         <td>
-            <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Number of voters' %}">
+            <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Number of voters' %}">
                 <span class="fas fa-user"></span> {{ evaluation.num_voters }}
             </span>
         </td>
     {% endif %}
 {% elif info_only or not request.user.is_manager %}
     <td>
-        <span {% if evaluation.num_participants == 0 %}class="text-danger" {% endif %}data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Number of participants' %}">
+        <span {% if evaluation.num_participants == 0 %}class="text-danger" {% endif %}data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Number of participants' %}">
             <span class="fas fa-user"></span> {{ evaluation.num_participants }}
         </span>
     </td>
 {% else %}
     <td>
-        <a class="no-underline{% if evaluation.num_participants == 0 %} text-danger{% endif %}" href="{% url 'staff:evaluation_person_management' evaluation.id %}" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Manage participants' %}">
+        <a class="no-underline{% if evaluation.num_participants == 0 %} text-danger{% endif %}" href="{% url 'staff:evaluation_person_management' evaluation.id %}" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Manage participants' %}">
             <span class="fas fa-user"></span> {{ evaluation.num_participants }}
         </a>
     </td>
@@ -185,39 +185,39 @@
 <td class="icon-buttons">
     {% if not info_only %}
         {% if not evaluation.is_single_result and request.user.is_manager %}
-            <a href="{% url 'staff:evaluation_copy' evaluation.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" title="{% trans "Copy" %}">
+            <a href="{% url 'staff:evaluation_copy' evaluation.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" title="{% translate "Copy" %}">
                 <span class="fas fa-copy"></span>
             </a>
         {% endif %}
         {% if request.user.is_manager %}
-            <a href="{% url 'staff:evaluation_email' evaluation.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Send email' %}">
+            <a href="{% url 'staff:evaluation_email' evaluation.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Send email' %}">
                 <span class="fas fa-envelope" aria-hidden="true"></span>
             </a>
         {% endif %}
         {% if state < evaluation.State.IN_EVALUATION %}
-            <a href="{% url 'staff:evaluation_preview' evaluation.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Preview' %}">
+            <a href="{% url 'staff:evaluation_preview' evaluation.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Preview' %}">
                 <span class="fas fa-eye" aria-hidden="true"></span>
             </a>
         {% elif state < evaluation.State.PUBLISHED and evaluation|can_results_page_be_seen_by:request.user %}
-            <a href="{% url 'results:evaluation_detail' semester.id evaluation.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Preview results' %}">
+            <a href="{% url 'results:evaluation_detail' semester.id evaluation.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Preview results' %}">
                 <span class="fas fa-chart-simple" aria-hidden="true"></span>
             </a>
         {% elif state == evaluation.State.PUBLISHED and evaluation|can_results_page_be_seen_by:request.user %}
-            <a href="{% url 'results:evaluation_detail' semester.id evaluation.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Results' %}">
+            <a href="{% url 'results:evaluation_detail' semester.id evaluation.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Results' %}">
                 <span class="fas fa-chart-simple" aria-hidden="true"></span>
             </a>
         {% endif %}
         {% if request.user.is_manager and evaluation.can_be_deleted_by_manager %}
             <confirmation-modal type="submit" form="evaluation-deletion-form" name="evaluation_id" value="{{ evaluation.id }}" confirm-button-class="btn-danger">
-                <span slot="title">{% trans 'Delete evaluation' %}</span>
-                <span slot="action-text">{% trans 'Delete evaluation' %}</span>
+                <span slot="title">{% translate 'Delete evaluation' %}</span>
+                <span slot="action-text">{% translate 'Delete evaluation' %}</span>
                 <span slot="question">
                     {% blocktrans trimmed with evaluation_name=evaluation.full_name %}
                         Do you really want to delete the evaluation <strong>{{ evaluation_name }}</strong>?
                     {% endblocktrans %}
                 </span>
 
-                <button slot="show-button" type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Delete' %}">
+                <button slot="show-button" type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Delete' %}">
                     <span class="fas fa-trash" aria-hidden="true"></span>
                 </button>
             </confirmation-modal>

--- a/evap/staff/templates/staff_semester_view_evaluation.html
+++ b/evap/staff/templates/staff_semester_view_evaluation.html
@@ -147,12 +147,12 @@
                 {% if info_only or not request.user.is_manager %}
                     <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Grade documents (Midterm, Final)' %}">
                         <span class="fas fa-file"></span>
-                        {% blocktrans with midterm=evaluation.midterm_grade_documents_count final=evaluation.final_grade_documents_count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}
+                        {% blocktranslate with midterm=evaluation.midterm_grade_documents_count final=evaluation.final_grade_documents_count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}
                     </span>
                 {% else %}
                     <a href="{% url 'grades:course_view' evaluation.course.id %}" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Grade documents (Midterm, Final)' %}">
                         <span class="fas fa-file"></span>
-                        {% blocktrans with midterm=evaluation.midterm_grade_documents_count final=evaluation.final_grade_documents_count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}
+                        {% blocktranslate with midterm=evaluation.midterm_grade_documents_count final=evaluation.final_grade_documents_count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}
                     </a>
                 {% endif %}
                 {% if evaluation.final_grade_documents_count %}
@@ -212,7 +212,7 @@
                 <span slot="title">{% translate 'Delete evaluation' %}</span>
                 <span slot="action-text">{% translate 'Delete evaluation' %}</span>
                 <span slot="question">
-                    {% blocktrans trimmed with evaluation_name=evaluation.full_name %}
+                    {% blocktranslate trimmed with evaluation_name=evaluation.full_name %}
                         Do you really want to delete the evaluation <strong>{{ evaluation_name }}</strong>?
                     {% endblocktrans %}
                 </span>

--- a/evap/staff/templates/staff_semester_view_evaluation.html
+++ b/evap/staff/templates/staff_semester_view_evaluation.html
@@ -147,12 +147,12 @@
                 {% if info_only or not request.user.is_manager %}
                     <span data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Grade documents (Midterm, Final)' %}">
                         <span class="fas fa-file"></span>
-                        {% blocktranslate with midterm=evaluation.midterm_grade_documents_count final=evaluation.final_grade_documents_count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}
+                        {% blocktranslate with midterm=evaluation.midterm_grade_documents_count final=evaluation.final_grade_documents_count %}M: {{ midterm }}, F: {{ final }}{% endblocktranslate %}
                     </span>
                 {% else %}
                     <a href="{% url 'grades:course_view' evaluation.course.id %}" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Grade documents (Midterm, Final)' %}">
                         <span class="fas fa-file"></span>
-                        {% blocktranslate with midterm=evaluation.midterm_grade_documents_count final=evaluation.final_grade_documents_count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}
+                        {% blocktranslate with midterm=evaluation.midterm_grade_documents_count final=evaluation.final_grade_documents_count %}M: {{ midterm }}, F: {{ final }}{% endblocktranslate %}
                     </a>
                 {% endif %}
                 {% if evaluation.final_grade_documents_count %}
@@ -214,7 +214,7 @@
                 <span slot="question">
                     {% blocktranslate trimmed with evaluation_name=evaluation.full_name %}
                         Do you really want to delete the evaluation <strong>{{ evaluation_name }}</strong>?
-                    {% endblocktrans %}
+                    {% endblocktranslate %}
                 </span>
 
                 <button slot="show-button" type="button" class="btn btn-sm btn-outline-danger" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Delete' %}">

--- a/evap/staff/templates/staff_single_result_form.html
+++ b/evap/staff/templates/staff_single_result_form.html
@@ -6,7 +6,7 @@
         {% if form.instance.id %}
             {{ evaluation.full_name }} ({{ evaluation.course.semester.name }})
         {% else %}
-            {% trans 'Create single result' %}
+            {% translate 'Create single result' %}
         {% endif %}
     </h3>
     <form id="single-result-form" method="POST" class="form-horizontal multiselect-form">
@@ -20,7 +20,7 @@
         {% if editable %}
             <div class="card card-submit-area text-center mb-3">
                 <div class="card-body">
-                    <button type="submit" class="btn btn-primary">{% trans 'Save single result' %}</button>
+                    <button type="submit" class="btn btn-primary">{% translate 'Save single result' %}</button>
                 </div>
             </div>
         {% endif %}

--- a/evap/staff/templates/staff_template_form.html
+++ b/evap/staff/templates/staff_template_form.html
@@ -4,7 +4,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Templates' %}</li>
+    <li class="breadcrumb-item">{% translate 'Templates' %}</li>
     <li class="breadcrumb-item">{{ template.name }}</li>
 {% endblock %}
 
@@ -19,9 +19,9 @@
                     {% include 'bootstrap_form.html' with form=form email_form=True fields_as_pills=form.visible_fields|slice:"-2:" %}
                 </div>
                 <div class="col-3">
-                    <p>{% trans 'The following variables are available for this email template:' %}</p>
+                    <p>{% translate 'The following variables are available for this email template:' %}</p>
                     {% for variable in available_variables %}
-                        <button type="button" class="btn btn-sm btn-link text-dark pe-1" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Copy to clipboard' %}" onClick="copyToClipboard('{{ variable }}')">
+                        <button type="button" class="btn btn-sm btn-link text-dark pe-1" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Copy to clipboard' %}" onClick="copyToClipboard('{{ variable }}')">
                             <span class="fas fa-clipboard"></span>
                         </button>
                         <code>{{ variable }}</code>
@@ -32,7 +32,7 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save template' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save template' %}</button>
             </div>
         </div>
     </form>

--- a/evap/staff/templates/staff_text_answer_warnings.html
+++ b/evap/staff/templates/staff_text_answer_warnings.html
@@ -5,7 +5,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Text answer warnings' %}</li>
+    <li class="breadcrumb-item">{% translate 'Text answer warnings' %}</li>
 {% endblock %}
 
 {% block content %}
@@ -28,10 +28,10 @@
                     <thead>
                         <tr>
                             <th class="movable"></th>
-                            <th>{% trans 'Trigger strings (case-insensitive)' %}</th>
-                            <th>{% trans 'Warning text (German)' %}</th>
-                            <th>{% trans 'Warning text (English)' %}</th>
-                            <th class="text-end">{% trans 'Actions' %}</th>
+                            <th>{% translate 'Trigger strings (case-insensitive)' %}</th>
+                            <th>{% translate 'Warning text (German)' %}</th>
+                            <th>{% translate 'Warning text (English)' %}</th>
+                            <th class="text-end">{% translate 'Actions' %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -63,21 +63,21 @@
         </div>
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save text answer warnings' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save text answer warnings' %}</button>
             </div>
         </div>
         <div class="card">
             <div class="card-header">
-                {% trans 'Preview' %}
+                {% translate 'Preview' %}
             </div>
             <div class="card-body">
                 <p>
-                    {% trans 'Changes of the form above are only reflected after the form has been saved.' %}
+                    {% translate 'Changes of the form above are only reflected after the form has been saved.' %}
                 </p>
                 <div class="row">
                     <div class="col-question col-lg-4 col-xl-5 d-flex flex-column">
                         <label for="preview-textarea">
-                            {% trans 'Test textarea' %}
+                            {% translate 'Test textarea' %}
                         </label>
                         {% include 'student_text_answer_warnings.html' with text_answer_warnings=text_answer_warnings %}
                     </div>

--- a/evap/staff/templates/staff_user_badges.html
+++ b/evap/staff/templates/staff_user_badges.html
@@ -1,28 +1,28 @@
 {% if user.pk %}
     {% if user.is_manager %}
-        <span class="badge bg-primary">{% trans 'Manager' %}</span>
+        <span class="badge bg-primary">{% translate 'Manager' %}</span>
     {% elif user.is_reviewer %}
-        <span class="badge bg-primary">{% trans 'Reviewer' %}</span>
+        <span class="badge bg-primary">{% translate 'Reviewer' %}</span>
     {% endif %}
     {% if user.is_grade_publisher %}
-        <span class="badge bg-primary">{% trans 'Grade publisher' %}</span>
+        <span class="badge bg-primary">{% translate 'Grade publisher' %}</span>
     {% endif %}
     {% if user.is_contributor %}
-        <span class="badge bg-info">{% trans 'Contributor' %}</span>
+        <span class="badge bg-info">{% translate 'Contributor' %}</span>
     {% endif %}
     {% if user.is_responsible %}
-        <span class="badge bg-info">{% trans 'Responsible' %}</span>
+        <span class="badge bg-info">{% translate 'Responsible' %}</span>
     {% endif %}
     {% if user.is_proxy_user %}
-        <span class="badge bg-dark">{% trans 'Proxy user' %}</span>
+        <span class="badge bg-dark">{% translate 'Proxy user' %}</span>
     {% endif %}
     {% if user.is_external %}
-        <span class="badge bg-dark">{% trans 'External' %}</span>
+        <span class="badge bg-dark">{% translate 'External' %}</span>
     {% endif %}
     {% if not user.is_active %}
-        <span class="badge bg-danger">{% trans 'Inactive' %}</span>
+        <span class="badge bg-danger">{% translate 'Inactive' %}</span>
     {% endif %}
     {% if not user.email %}
-        <span class="badge bg-danger">{% trans 'No email' %}</span>
+        <span class="badge bg-danger">{% translate 'No email' %}</span>
     {% endif %}
 {% endif %}

--- a/evap/staff/templates/staff_user_bulk_update.html
+++ b/evap/staff/templates/staff_user_bulk_update.html
@@ -14,7 +14,7 @@
         {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
-                <p>{% blocktrans %}Upload a text file containing one user per line formatted as "username,email". Users in this file will be updated or created. All users that are not in this file will be deleted if possible. If they can't be deleted they will be marked inactive.{% endblocktrans %}</p>
+                <p>{% blocktranslate %}Upload a text file containing one user per line formatted as "username,email". Users in this file will be updated or created. All users that are not in this file will be deleted if possible. If they can't be deleted they will be marked inactive.{% endblocktrans %}</p>
                 {% include 'bootstrap_form.html' with form=form %}
             </div>
         </div>

--- a/evap/staff/templates/staff_user_bulk_update.html
+++ b/evap/staff/templates/staff_user_bulk_update.html
@@ -14,7 +14,7 @@
         {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
-                <p>{% blocktranslate %}Upload a text file containing one user per line formatted as "username,email". Users in this file will be updated or created. All users that are not in this file will be deleted if possible. If they can't be deleted they will be marked inactive.{% endblocktrans %}</p>
+                <p>{% blocktranslate %}Upload a text file containing one user per line formatted as "username,email". Users in this file will be updated or created. All users that are not in this file will be deleted if possible. If they can't be deleted they will be marked inactive.{% endblocktranslate %}</p>
                 {% include 'bootstrap_form.html' with form=form %}
             </div>
         </div>

--- a/evap/staff/templates/staff_user_bulk_update.html
+++ b/evap/staff/templates/staff_user_bulk_update.html
@@ -2,13 +2,13 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% trans 'Users' %}</a></li>
-    <li class="breadcrumb-item">{% trans 'Bulk update' %}</li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
+    <li class="breadcrumb-item">{% translate 'Bulk update' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
-    <h3>{% trans 'Bulk update users' %}</h3>
+    <h3>{% translate 'Bulk update users' %}</h3>
 
     <form id="user-bulk-update-form" enctype="multipart/form-data" method="POST" class="form-horizontal">
         {% csrf_token %}
@@ -21,10 +21,10 @@
         <div class="card card-submit-area card-submit-area-2 text-center mb-3">
             <div class="card-body">
                 {% if not test_passed %}
-                    <button name="operation" value="test" type="submit" class="btn btn-primary form-submit-btn">{% trans 'Upload and test' %}</button>
+                    <button name="operation" value="test" type="submit" class="btn btn-primary form-submit-btn">{% translate 'Upload and test' %}</button>
                 {% else %}
-                    <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
-                    <button name="operation" value="bulk_update" type="submit" class="btn btn-primary form-submit-btn">{% trans 'Bulk update with uploaded file' %}</button>
+                    <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% translate 'Upload and test' %}</button>
+                    <button name="operation" value="bulk_update" type="submit" class="btn btn-primary form-submit-btn">{% translate 'Bulk update with uploaded file' %}</button>
                 {% endif %}
             </div>
         </div>

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -4,11 +4,11 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% trans 'Users' %}</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
     {% if form.instance.id %}
         <li class="breadcrumb-item">{{ form.instance.full_name }}</li>
     {% else %}
-        <li class="breadcrumb-item">{% trans 'Create user' %}</li>
+        <li class="breadcrumb-item">{% translate 'Create user' %}</li>
     {% endif %}
 {% endblock %}
 
@@ -16,7 +16,7 @@
     {{ block.super }}
 
     <div class="d-flex">
-        <h3>{% if form.instance.id %}{% trans 'Edit user' %}{% else %}{% trans 'Create user' %}{% endif %}</h3>
+        <h3>{% if form.instance.id %}{% translate 'Edit user' %}{% else %}{% translate 'Create user' %}{% endif %}</h3>
         {% if form.instance.id %}
             <div class="ms-auto d-print-none">
                 {% if has_due_evaluations %}
@@ -25,21 +25,21 @@
                             {% csrf_token %}
 
                             <confirmation-modal type="submit" name="user_id" value="{{ form.instance.id }}" confirm-button-class="btn-primary">
-                                <span slot="title">{% trans 'Send notification email' %}</span>
-                                <span slot="action-text">{% trans 'Send email' %}</span>
+                                <span slot="title">{% translate 'Send notification email' %}</span>
+                                <span slot="action-text">{% translate 'Send email' %}</span>
                                 <span slot="question">
                                     {% blocktrans trimmed %}
                                         The email will notify the user about all their due evaluations. Do you want to send the email now?
                                     {% endblocktrans %}
                                 </span>
 
-                                <button slot="show-button" type="button" class="btn btn-sm btn-light">{% trans 'Resend evaluation started email' %}</button>
+                                <button slot="show-button" type="button" class="btn btn-sm btn-light">{% translate 'Resend evaluation started email' %}</button>
                             </confirmation-modal>
                         </form>
                     </div>
                 {% else %}
-                    <div title="{% trans 'This user currently has no due evaluations.' %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
-                        <button disabled type="button" class="btn btn-sm btn-light">{% trans 'Resend evaluation started email' %}</button>
+                    <div title="{% translate 'This user currently has no due evaluations.' %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
+                        <button disabled type="button" class="btn btn-sm btn-light">{% translate 'Resend evaluation started email' %}</button>
                     </div>
                 {% endif %}
             </div>
@@ -49,9 +49,9 @@
     {% if user_with_same_email %}
         <div class="alert alert-warning alert-dismissible">
             <p>
-                {% trans "A user with this email address already exists. You probably want to merge the users." %}
+                {% translate "A user with this email address already exists. You probably want to merge the users." %}
             </p>
-            <a type="button" class="btn btn-primary btn-sm" href="{% url 'staff:user_merge' user_with_same_email.id form.instance.id %}">{% trans "Merge both users" %}</a>
+            <a type="button" class="btn btn-primary btn-sm" href="{% url 'staff:user_merge' user_with_same_email.id form.instance.id %}">{% translate "Merge both users" %}</a>
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
         </div>
     {% endif %}
@@ -71,13 +71,13 @@
         {% if form.instance.pk %}
             <div class="card mb-3">
                 <div class="card-body">
-                    <h5 class="card-title">{% trans 'Represented Users' %}</h5>
+                    <h5 class="card-title">{% translate 'Represented Users' %}</h5>
                     {% include 'user_list_with_links.html' with users=form.instance.represented_users.all %}
                 </div>
             </div>
             <div class="card mb-3">
                 <div class="card-body">
-                    <h5 class="card-title">{% trans 'CC-User for' %}</h5>
+                    <h5 class="card-title">{% translate 'CC-User for' %}</h5>
                     {% include 'user_list_with_links.html' with users=form.instance.ccing_users.all %}
                 </div>
             </div>
@@ -85,9 +85,9 @@
                 <div class="card mb-3">
                     <div class="card-body">
                         <div class="d-flex">
-                            <h5 class="card-title me-auto">{% trans 'Export evaluation results' %}</h5>
+                            <h5 class="card-title me-auto">{% translate 'Export evaluation results' %}</h5>
                             <div>
-                                <a href="{% url 'staff:export_contributor_results' form.instance.id %}" class="btn btn-sm btn-light">{% trans 'Export all results' %}</a>
+                                <a href="{% url 'staff:export_contributor_results' form.instance.id %}" class="btn btn-sm btn-light">{% translate 'Export all results' %}</a>
                             </div>
                         </div>
                         <ul>
@@ -115,7 +115,7 @@
         {% endif %}
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% trans 'Save user' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Save user' %}</button>
                 {% if form.instance and form.instance.can_be_deleted_by_manager %}
 
 
@@ -123,8 +123,8 @@
                         {% csrf_token %}
 
                         <confirmation-modal type="submit" name="user_id" value="{{ form.instance.id }}" confirm-button-class="btn-danger">
-                            <span slot="title">{% trans 'Delete user' %}</span>
-                            <span slot="action-text">{% trans 'Delete user' %}</span>
+                            <span slot="title">{% translate 'Delete user' %}</span>
+                            <span slot="action-text">{% translate 'Delete user' %}</span>
                             <span slot="question">
                                 {% blocktrans trimmed with user_fullname=form.instance.full_name %}
                                     Do you really want to delete the user <strong>{{ user_fullname }}</strong>?<br/>
@@ -132,13 +132,13 @@
                                 {% endblocktrans %}
                             </span>
 
-                            <button slot="show-button" type="button" class="btn btn-danger">{% trans 'Delete user' %}</button>
+                            <button slot="show-button" type="button" class="btn btn-danger">{% translate 'Delete user' %}</button>
                         </confirmation-modal>
                     </form>
                 {% else %}
                     <span tabindex="0" data-bs-toggle="tooltip" title="{% blocktrans %}This user contributes to an evaluation, participates in an evaluation whose participations haven't been archived yet or has special rights and as such cannot be deleted.{% endblocktrans %}">
                     <button type="button" disabled class="btn btn-danger">
-                        {% trans 'Delete user' %}
+                        {% translate 'Delete user' %}
                     </button>
                 {% endif %}
             </div>

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -30,7 +30,7 @@
                                 <span slot="question">
                                     {% blocktranslate trimmed %}
                                         The email will notify the user about all their due evaluations. Do you want to send the email now?
-                                    {% endblocktrans %}
+                                    {% endblocktranslate %}
                                 </span>
 
                                 <button slot="show-button" type="button" class="btn btn-sm btn-light">{% translate 'Resend evaluation started email' %}</button>
@@ -129,14 +129,14 @@
                                 {% blocktranslate trimmed with user_fullname=form.instance.full_name %}
                                     Do you really want to delete the user <strong>{{ user_fullname }}</strong>?<br/>
                                     This person will also be removed from every other user having this person as a delegated or CC-user.
-                                {% endblocktrans %}
+                                {% endblocktranslate %}
                             </span>
 
                             <button slot="show-button" type="button" class="btn btn-danger">{% translate 'Delete user' %}</button>
                         </confirmation-modal>
                     </form>
                 {% else %}
-                    <span tabindex="0" data-bs-toggle="tooltip" title="{% blocktranslate %}This user contributes to an evaluation, participates in an evaluation whose participations haven't been archived yet or has special rights and as such cannot be deleted.{% endblocktrans %}">
+                    <span tabindex="0" data-bs-toggle="tooltip" title="{% blocktranslate %}This user contributes to an evaluation, participates in an evaluation whose participations haven't been archived yet or has special rights and as such cannot be deleted.{% endblocktranslate %}">
                     <button type="button" disabled class="btn btn-danger">
                         {% translate 'Delete user' %}
                     </button>

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -28,7 +28,7 @@
                                 <span slot="title">{% translate 'Send notification email' %}</span>
                                 <span slot="action-text">{% translate 'Send email' %}</span>
                                 <span slot="question">
-                                    {% blocktrans trimmed %}
+                                    {% blocktranslate trimmed %}
                                         The email will notify the user about all their due evaluations. Do you want to send the email now?
                                     {% endblocktrans %}
                                 </span>
@@ -126,7 +126,7 @@
                             <span slot="title">{% translate 'Delete user' %}</span>
                             <span slot="action-text">{% translate 'Delete user' %}</span>
                             <span slot="question">
-                                {% blocktrans trimmed with user_fullname=form.instance.full_name %}
+                                {% blocktranslate trimmed with user_fullname=form.instance.full_name %}
                                     Do you really want to delete the user <strong>{{ user_fullname }}</strong>?<br/>
                                     This person will also be removed from every other user having this person as a delegated or CC-user.
                                 {% endblocktrans %}
@@ -136,7 +136,7 @@
                         </confirmation-modal>
                     </form>
                 {% else %}
-                    <span tabindex="0" data-bs-toggle="tooltip" title="{% blocktrans %}This user contributes to an evaluation, participates in an evaluation whose participations haven't been archived yet or has special rights and as such cannot be deleted.{% endblocktrans %}">
+                    <span tabindex="0" data-bs-toggle="tooltip" title="{% blocktranslate %}This user contributes to an evaluation, participates in an evaluation whose participations haven't been archived yet or has special rights and as such cannot be deleted.{% endblocktrans %}">
                     <button type="button" disabled class="btn btn-danger">
                         {% translate 'Delete user' %}
                     </button>

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -39,7 +39,7 @@
                         <span slot="question">
                             {% blocktranslate trimmed %}
                                 Do you really want to import the users from the Excel file?
-                            {% endblocktrans %}
+                            {% endblocktranslate %}
                         </span>
 
                         <button slot="show-button" type="button" class="btn btn-primary form-submit-button">{% translate 'Import previously uploaded file' %}</button>

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -4,13 +4,13 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% trans 'Users' %}</a></li>
-    <li class="breadcrumb-item">{% trans 'Import users' %}</li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
+    <li class="breadcrumb-item">{% translate 'Import users' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
-    <h3>{% trans 'Import users' %}</h3>
+    <h3>{% translate 'Import users' %}</h3>
 
     {% include 'staff_message_rendering_template.html' with importer_log=importer_log %}
 
@@ -19,10 +19,10 @@
         <div class="card mb-3">
             <div class="card-body">
                 <p>
-                    {% trans 'Upload Excel file' %}
-                    (<a href="{% url 'staff:download_sample_file' 'sample_user.xlsx' %}">{% trans 'Download sample file' %}</a>,
-                    <button type="button" class="btn btn-link" onclick="copyHeaders(['Title', 'First name', 'Last name', 'Email'])">{% trans 'Copy headers to clipboard' %}</button>).
-                    {% trans 'This will create all contained users.' %}
+                    {% translate 'Upload Excel file' %}
+                    (<a href="{% url 'staff:download_sample_file' 'sample_user.xlsx' %}">{% translate 'Download sample file' %}</a>,
+                    <button type="button" class="btn btn-link" onclick="copyHeaders(['Title', 'First name', 'Last name', 'Email'])">{% translate 'Copy headers to clipboard' %}</button>).
+                    {% translate 'This will create all contained users.' %}
                 </p>
                 {% include 'bootstrap_form.html' with form=excel_form %}
             </div>
@@ -30,19 +30,19 @@
         <div class="card card-submit-area{% if test_passed %} card-submit-area-2{% endif %} text-center mb-3">
             <div class="card-body">
                 {% if not test_passed %}
-                    <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
+                    <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% translate 'Upload and test' %}</button>
                 {% else %}
-                    <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% trans 'Upload and test' %}</button>
+                    <button name="operation" value="test" type="submit" class="btn btn-light form-submit-btn">{% translate 'Upload and test' %}</button>
                     <confirmation-modal type="submit" name="operation" value="import">
-                        <span slot="title">{% trans 'Import Users' %}</span>
-                        <span slot="action-text">{% trans 'Import Users' %}</span>
+                        <span slot="title">{% translate 'Import Users' %}</span>
+                        <span slot="action-text">{% translate 'Import Users' %}</span>
                         <span slot="question">
                             {% blocktrans trimmed %}
                                 Do you really want to import the users from the Excel file?
                             {% endblocktrans %}
                         </span>
 
-                        <button slot="show-button" type="button" class="btn btn-primary form-submit-button">{% trans 'Import previously uploaded file' %}</button>
+                        <button slot="show-button" type="button" class="btn btn-primary form-submit-button">{% translate 'Import previously uploaded file' %}</button>
                     </confirmation-modal>
                 {% endif %}
             </div>

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -37,7 +37,7 @@
                         <span slot="title">{% translate 'Import Users' %}</span>
                         <span slot="action-text">{% translate 'Import Users' %}</span>
                         <span slot="question">
-                            {% blocktrans trimmed %}
+                            {% blocktranslate trimmed %}
                                 Do you really want to import the users from the Excel file?
                             {% endblocktrans %}
                         </span>

--- a/evap/staff/templates/staff_user_index.html
+++ b/evap/staff/templates/staff_user_index.html
@@ -4,7 +4,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% trans 'Users' %}</li>
+    <li class="breadcrumb-item">{% translate 'Users' %}</li>
 {% endblock %}
 
 {% block content %}
@@ -15,12 +15,12 @@
             <div class="card h-100">
                 <div class="card-body">
                     <ul>
-                        <li><a href="{% url 'staff:user_list' %}" class="">{% trans 'User list' %}</a></li>
-                        <li><a href="{% url 'staff:user_import' %}" class="">{% trans 'Import users' %}</a></li>
-                        <li><a href="{% url 'staff:user_merge_selection' %}" class="">{% trans 'Merge users' %}</a></li>
-                        <li><a href="{% url 'staff:user_bulk_update' %}" class="">{% trans 'Bulk update users' %}</a></li>
+                        <li><a href="{% url 'staff:user_list' %}" class="">{% translate 'User list' %}</a></li>
+                        <li><a href="{% url 'staff:user_import' %}" class="">{% translate 'Import users' %}</a></li>
+                        <li><a href="{% url 'staff:user_merge_selection' %}" class="">{% translate 'Merge users' %}</a></li>
+                        <li><a href="{% url 'staff:user_bulk_update' %}" class="">{% translate 'Bulk update users' %}</a></li>
                     </ul>
-                    <a href="{% url 'staff:user_create' %}" class="btn btn-sm btn-dark mt-2">{% trans 'Create new user' %}</a>
+                    <a href="{% url 'staff:user_create' %}" class="btn btn-sm btn-dark mt-2">{% translate 'Create new user' %}</a>
                 </div>
             </div>
         </div>
@@ -29,12 +29,12 @@
                 <div class="card-body">
                     <form id="user-edit-form" method="POST" class="form-horizontal">
                         {% csrf_token %}
-                        <h4 class="card-title">{% trans 'Edit user' %}</h4>
+                        <h4 class="card-title">{% translate 'Edit user' %}</h4>
                         {% include 'bootstrap_form_field_widget.html' with field=form.user %}
                     </form>
                 </div>
                 <div class="card-footer text-center card-submit-area d-flex">
-                    <button type="submit" form="user-edit-form" class="btn btn-primary mx-auto my-auto">{% trans 'Edit' %}</button>
+                    <button type="submit" form="user-edit-form" class="btn btn-primary mx-auto my-auto">{% translate 'Edit' %}</button>
                 </div>
             </div>
         </div>

--- a/evap/staff/templates/staff_user_list.html
+++ b/evap/staff/templates/staff_user_list.html
@@ -4,8 +4,8 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% trans 'Users' %}</a></li>
-    <li class="breadcrumb-item">{% trans 'User list' %}</li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
+    <li class="breadcrumb-item">{% translate 'User list' %}</li>
 {% endblock %}
 
 {% block content %}
@@ -13,22 +13,22 @@
     <div class="row mb-3 align-items-center">
         <div class="col-auto">
             <div class="btn-switch btn-switch-light">
-                <div class="btn-switch-label">{% trans 'Inactive users' %}</div>
+                <div class="btn-switch-label">{% translate 'Inactive users' %}</div>
                 <div class="btn-switch btn-group">
                     <a href="{% url 'staff:user_list' %}?filter_users=false" role="button" class="btn btn-sm btn-light{% if not filter_users %} active{% endif %}">
-                        {% trans 'Show' %}
+                        {% translate 'Show' %}
                     </a>
                     <a href="{% url 'staff:user_list' %}?filter_users=true" role="button" class="btn btn-sm btn-light{% if filter_users %} active{% endif %}">
-                        {% trans 'Hide' %}
+                        {% translate 'Hide' %}
                     </a>
                 </div>
             </div>
         </div>
         <div class="col-3 ms-auto">
             <div class="input-group">
-                <input type="search" name="search" class="form-control" placeholder="{% trans 'Search...' %}" />
+                <input type="search" name="search" class="form-control" placeholder="{% translate 'Search...' %}" />
                 <div class="input-group-append">
-                    <button class="btn btn-light text-secondary" type="button" data-reset="search" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Clear search filter' %}">
+                    <button class="btn btn-light text-secondary" type="button" data-reset="search" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Clear search filter' %}">
                         <span class="fas fa-backspace"></span>
                     </button>
                 </div>
@@ -41,9 +41,9 @@
             <table class="table table-vertically-aligned table-seamless-links user-table">
                 <thead>
                     <tr>
-                        <th style="width: 25%">{% trans 'Name' %}</th>
-                        <th style="width: 35%">{% trans 'Email' %}</th>
-                        <th style="width: 30%">{% trans 'Information' %}</th>
+                        <th style="width: 25%">{% translate 'Name' %}</th>
+                        <th style="width: 35%">{% translate 'Email' %}</th>
+                        <th style="width: 30%">{% translate 'Information' %}</th>
                         <th style="width: 10%"></th>
                     </tr>
                 </thead>

--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -131,7 +131,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td><strong>{% blocktrans %}CC'ing users{% endblocktrans %}</strong></td>
+                        <td><strong>{% blocktranslate %}CC'ing users{% endblocktrans %}</strong></td>
                         <td{% if main_user.ccing_users.all %} class="table-info"{% endif %}>
                             {% for user in main_user.ccing_users.all %}
                                 {{ user.full_name }}{% if not forloop.last %},{% endif %}
@@ -239,7 +239,7 @@
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
                 {% if errors %}
-                    {% blocktrans %}The users can't be merged, because either contributions or participations for the same evaluation exist or the users are responsible for the same courses.{% endblocktrans %}
+                    {% blocktranslate %}The users can't be merged, because either contributions or participations for the same evaluation exist or the users are responsible for the same courses.{% endblocktrans %}
                 {% elif warnings %}
                     <button type="submit" class="btn btn-warning"><span class="fas fa-triangle-exclamation"></span> {% translate 'Merge users' %}</button>
                 {% else %}

--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -4,16 +4,16 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% trans 'Users' %}</a></li>
-    <li class="breadcrumb-item">{% trans 'Merge users' %}</li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
+    <li class="breadcrumb-item">{% translate 'Merge users' %}</li>
 {% endblock %}
 
 {% block content %}
     {{ block.super }}
     <div class="d-flex">
-        <h3>{% trans 'Merge users' %}</h3> 
+        <h3>{% translate 'Merge users' %}</h3> 
         <div class="ms-auto"> 
-            <a class="btn btn-sm btn-light" href="{% url 'staff:user_merge' main_user_id=other_user.pk other_user_id=main_user.pk %}">{% trans 'Swap users' %}</a>
+            <a class="btn btn-sm btn-light" href="{% url 'staff:user_merge' main_user_id=other_user.pk other_user_id=main_user.pk %}">{% translate 'Swap users' %}</a>
         </div>
     </div>
     <div class="card mb-3">
@@ -22,44 +22,44 @@
                 <thead>
                     <tr>
                         <th style="width: 25%"></th>
-                        <th style="width: 25%">{% trans 'Main user' %}</th>
-                        <th style="width: 25%">{% trans 'Other user' %}</th>
-                        <th style="width: 25%">{% trans 'Merged user' %}</th>
+                        <th style="width: 25%">{% translate 'Main user' %}</th>
+                        <th style="width: 25%">{% translate 'Other user' %}</th>
+                        <th style="width: 25%">{% translate 'Merged user' %}</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <td><strong>{% trans 'Title' %}</strong></td>
+                        <td><strong>{% translate 'Title' %}</strong></td>
                         <td{% if main_user.title == merged_user.title %} class="table-info"{% endif %}>{{ main_user.title|default_if_none:"" }}</td>
                         <td{% if other_user.title == merged_user.title %} class="table-info"{% endif %}>{{ other_user.title|default_if_none:"" }}</td>
                         <td{% if merged_user.title %} class="table-success"{% endif %}>{{ merged_user.title|default_if_none:"" }}</td>
                     </tr>
                     <tr>
-                        <td><strong>{% trans 'First name' %}</strong></td>
+                        <td><strong>{% translate 'First name' %}</strong></td>
                         <td{% if main_user.first_name_given == merged_user.first_name_given %} class="table-info"{% endif %}>{{ main_user.first_name_given|default_if_none:"" }}</td>
                         <td{% if other_user.first_name_given == merged_user.first_name_given %} class="table-info"{% endif %}>{{ other_user.first_name_given|default_if_none:"" }}</td>
                         <td{% if merged_user.first_name_given %} class="table-success"{% endif %}>{{ merged_user.first_name_given|default_if_none:"" }}</td>
                     </tr>
                     <tr>
-                        <td><strong>{% trans 'Display name' %}</strong></td>
+                        <td><strong>{% translate 'Display name' %}</strong></td>
                         <td{% if main_user.first_name_chosen == merged_user.first_name_chosen %} class="table-info"{% endif %}>{{ main_user.first_name_chosen|default_if_none:"" }}</td>
                         <td{% if other_user.first_name_chosen == merged_user.first_name_chosen %} class="table-info"{% endif %}>{{ other_user.first_name_chosen|default_if_none:"" }}</td>
                         <td{% if merged_user.first_name_chosen %} class="table-success"{% endif %}>{{ merged_user.first_name_chosen|default_if_none:"" }}</td>
                     </tr>
                     <tr>
-                        <td><strong>{% trans 'Last name' %}</strong></td>
+                        <td><strong>{% translate 'Last name' %}</strong></td>
                         <td{% if main_user.last_name == merged_user.last_name %} class="table-info"{% endif %}>{{ main_user.last_name|default_if_none:"" }}</td>
                         <td{% if other_user.last_name == merged_user.last_name %} class="table-info"{% endif %}>{{ other_user.last_name|default_if_none:"" }}</td>
                         <td{% if merged_user.last_name %} class="table-success"{% endif %}>{{ merged_user.last_name|default_if_none:"" }}</td>
                     </tr>
                     <tr>
-                        <td><strong>{% trans 'Email' %}</strong></td>
+                        <td><strong>{% translate 'Email' %}</strong></td>
                         <td{% if main_user.email == merged_user.email %} class="table-info"{% endif %}>{{ main_user.email|default_if_none:"" }}</td>
                         <td{% if other_user.email == merged_user.email %} class="table-info"{% endif %}>{{ other_user.email|default_if_none:"" }}</td>
                         <td{% if merged_user.email %} class="table-success"{% endif %}>{{ merged_user.email|default_if_none:"" }}</td>
                     </tr>
                     <tr>
-                        <td><strong>{% trans 'Groups' %}</strong></td>
+                        <td><strong>{% translate 'Groups' %}</strong></td>
                         <td{% if main_user.groups.all %} class="table-info"{% endif %}>
                             {% for group in main_user.groups.all %}
                                 <span class="badge bg-secondary">{{ group.name }}</span>
@@ -77,7 +77,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td><strong>{% trans 'Delegates' %}</strong></td>
+                        <td><strong>{% translate 'Delegates' %}</strong></td>
                         <td{% if main_user.delegates.all %} class="table-info"{% endif %}>
                             {% for user in main_user.delegates.all %}
                                 {{ user.full_name }}{% if not forloop.last %},{% endif %}
@@ -95,7 +95,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td><strong>{% trans 'Represented users' %}</strong></td>
+                        <td><strong>{% translate 'Represented users' %}</strong></td>
                         <td{% if main_user.represented_users.all %} class="table-info"{% endif %}>
                             {% for user in main_user.represented_users.all %}
                                 {{ user.full_name }}{% if not forloop.last %},{% endif %}
@@ -113,7 +113,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td><strong>{% trans 'CC users' %}</strong></td>
+                        <td><strong>{% translate 'CC users' %}</strong></td>
                         <td{% if main_user.cc_users.all %} class="table-info"{% endif %}>
                             {% for user in main_user.cc_users.all %}
                                 {{ user.full_name }}{% if not forloop.last %},{% endif %}
@@ -150,7 +150,7 @@
                     </tr>
 
                     <tr{% if 'courses_responsible_for' in errors %} class="table-danger"{% endif %}>
-                        <td><strong>{% trans 'Courses responsible for' %}</strong></td>
+                        <td><strong>{% translate 'Courses responsible for' %}</strong></td>
                         {% regroup main_user.get_sorted_courses_responsible_for by semester as course_list %}
                         <td{% if course_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=course_list %}
@@ -166,7 +166,7 @@
                     </tr>
 
                     <tr{% if 'contributions' in errors %} class="table-danger"{% endif %}>
-                        <td><strong>{% trans 'Contributions' %}</strong></td>
+                        <td><strong>{% translate 'Contributions' %}</strong></td>
                         {% regroup main_user.get_sorted_contributions by evaluation.course.semester as contribution_list %}
                         <td{% if contribution_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=contribution_list %}
@@ -182,7 +182,7 @@
                     </tr>
 
                     <tr{% if 'evaluations_participating_in' in errors %} class="table-danger"{% endif %}>
-                        <td><strong>{% trans 'Participated in' %}</strong></td>
+                        <td><strong>{% translate 'Participated in' %}</strong></td>
                         {% regroup main_user.get_sorted_evaluations_participating_in by course.semester as participation_list %}
                         <td{% if participation_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=participation_list %}
@@ -198,7 +198,7 @@
                     </tr>
 
                     <tr{% if 'evaluations_voted_for' in errors %} class="table-danger"{% endif %}>
-                        <td><strong>{% trans 'Voted for' %}</strong></td>
+                        <td><strong>{% translate 'Voted for' %}</strong></td>
                         {% regroup main_user.get_sorted_evaluations_voted_for by course.semester as voting_list %}
                         <td{% if voting_list|length > 0 %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_grouped_list.html" with grouped_list=voting_list %}
@@ -214,14 +214,14 @@
                     </tr>
 
                     <tr>
-                        <td><strong>{% trans 'Reward points' %}</strong></td>
+                        <td><strong>{% translate 'Reward points' %}</strong></td>
                         <td{% if main_user.reward_point_grantings.all %} class="table-info"{% endif %}>
                             {% include "staff_user_merge_reward_points_list.html" with user=main_user %}
                         </td>
                         <td{% if other_user.reward_point_grantings.all and not 'rewards' in warnings %} class="table-info"
                         {% elif other_user.reward_point_grantings.all and 'rewards' in warnings %} class="table-warning"{% endif %}>
                             {% if 'rewards' in warnings %}
-                                <span class="fas fa-triangle-exclamation"></span> {% trans 'The rewards of this user will be deleted and not be merged into the other user.' %}<br /><br />
+                                <span class="fas fa-triangle-exclamation"></span> {% translate 'The rewards of this user will be deleted and not be merged into the other user.' %}<br /><br />
                             {% endif %}
                             {% include "staff_user_merge_reward_points_list.html" with user=other_user %}
                         </td>
@@ -241,9 +241,9 @@
                 {% if errors %}
                     {% blocktrans %}The users can't be merged, because either contributions or participations for the same evaluation exist or the users are responsible for the same courses.{% endblocktrans %}
                 {% elif warnings %}
-                    <button type="submit" class="btn btn-warning"><span class="fas fa-triangle-exclamation"></span> {% trans 'Merge users' %}</button>
+                    <button type="submit" class="btn btn-warning"><span class="fas fa-triangle-exclamation"></span> {% translate 'Merge users' %}</button>
                 {% else %}
-                    <button type="submit" class="btn btn-primary">{% trans 'Merge users' %}</button>
+                    <button type="submit" class="btn btn-primary">{% translate 'Merge users' %}</button>
                 {% endif %}
             </div>
         </div>

--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -131,7 +131,7 @@
                         </td>
                     </tr>
                     <tr>
-                        <td><strong>{% blocktranslate %}CC'ing users{% endblocktrans %}</strong></td>
+                        <td><strong>{% blocktranslate %}CC'ing users{% endblocktranslate %}</strong></td>
                         <td{% if main_user.ccing_users.all %} class="table-info"{% endif %}>
                             {% for user in main_user.ccing_users.all %}
                                 {{ user.full_name }}{% if not forloop.last %},{% endif %}
@@ -239,7 +239,7 @@
         <div class="card card-submit-area text-center mb-3">
             <div class="card-body">
                 {% if errors %}
-                    {% blocktranslate %}The users can't be merged, because either contributions or participations for the same evaluation exist or the users are responsible for the same courses.{% endblocktrans %}
+                    {% blocktranslate %}The users can't be merged, because either contributions or participations for the same evaluation exist or the users are responsible for the same courses.{% endblocktranslate %}
                 {% elif warnings %}
                     <button type="submit" class="btn btn-warning"><span class="fas fa-triangle-exclamation"></span> {% translate 'Merge users' %}</button>
                 {% else %}

--- a/evap/staff/templates/staff_user_merge_reward_points_list.html
+++ b/evap/staff/templates/staff_user_merge_reward_points_list.html
@@ -1,5 +1,5 @@
 {% if user.reward_point_grantings.all %}
-    {% trans 'Grantings' %}:
+    {% translate 'Grantings' %}:
     <ul>
         {% for reward_point_granting in user.reward_point_grantings.all %}
             <li>{{ reward_point_granting.semester.name }} ({{ reward_point_granting.value }})</li>
@@ -7,7 +7,7 @@
     </ul>
 {% endif %}
 {% if user.reward_point_redemptions.all %}
-    {% trans 'Redemptions' %}:
+    {% translate 'Redemptions' %}:
     <ul>
         {% for reward_point_redemption in user.reward_point_redemptions.all %}
             <li>{{ reward_point_redemption.event.name }} ({{ reward_point_redemption.value }})</li>

--- a/evap/staff/templates/staff_user_merge_selection.html
+++ b/evap/staff/templates/staff_user_merge_selection.html
@@ -2,8 +2,8 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% trans 'Users' %}</a></li>
-    <li class="breadcrumb-item">{% trans 'Merge users' %}</li>
+    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
+    <li class="breadcrumb-item">{% translate 'Merge users' %}</li>
 {% endblock %}
 
 {% block content %}
@@ -12,22 +12,22 @@
         <div class="col">
             <div class="card">
                 <div class="card-body">
-                    <h4 class="card-title">{% trans 'Merge users' %}</h4>
+                    <h4 class="card-title">{% translate 'Merge users' %}</h4>
                     <form id="user-selection-form" method="POST" class="form-horizontal">
                         {% csrf_token %}
-                        <p>{% trans 'Select the users you want to merge.' %}</p>
+                        <p>{% translate 'Select the users you want to merge.' %}</p>
                         {% include 'bootstrap_form.html' with form=form wide=True %}
                     </form>
                 </div>
                 <div class="card-footer text-center card-submit-area d-flex">
-                    <button type="submit" form="user-selection-form" class="btn btn-light mx-auto my-auto">{% trans 'Show merge info' %}</button>
+                    <button type="submit" form="user-selection-form" class="btn btn-light mx-auto my-auto">{% translate 'Show merge info' %}</button>
                 </div>
             </div>
         </div>
         <div class="col">
             <div class="card">
                 <div class="card-body">
-                    <h4 class="card-title">{% trans 'Merge suggestions' %}</h4>
+                    <h4 class="card-title">{% translate 'Merge suggestions' %}</h4>
                     <table class="table table-striped table-narrow table-vertically-aligned">
                         <tbody>
                             {% for main_user, merge_candidate in suggested_merges %}
@@ -41,7 +41,7 @@
                                         {{ merge_candidate.email }}
                                     </td>
                                     <td class="text-end">
-                                        <a href="{% url 'staff:user_merge' main_user.id merge_candidate.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Show merge info' %}">
+                                        <a href="{% url 'staff:user_merge' main_user.id merge_candidate.id %}" class="btn btn-sm btn-light" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Show merge info' %}">
                                             <span class="fas fa-object-group"></span>
                                         </a>
                                     </td>

--- a/evap/student/templates/student_index.html
+++ b/evap/student/templates/student_index.html
@@ -3,7 +3,7 @@
 {% load infotext_templatetags %}
 {% load evaluation_filters %}
 
-{% block title %}{% trans 'Evaluation' %} - {{ block.super }}{% endblock %}
+{% block title %}{% translate 'Evaluation' %} - {{ block.super }}{% endblock %}
 
 {% block content %}
     {{ block.super }}
@@ -20,7 +20,7 @@
     {% if unfinished_evaluations %}
         <div class="card card-outline-primary mb-3">
             <div class="card-header">
-                {% trans 'Open and upcoming evaluations' %}
+                {% translate 'Open and upcoming evaluations' %}
             </div>
             <div class="card-body table-responsive">
                 {% include 'student_index_unfinished_evaluations_list.html' %}

--- a/evap/student/templates/student_index_evaluation_period.html
+++ b/evap/student/templates/student_index_evaluation_period.html
@@ -2,27 +2,27 @@
 
 {% if evaluation.state == evaluation.State.PREPARED or evaluation.state == evaluation.State.EDITOR_APPROVED %}
     <span class="small text-secondary" data-bs-toggle="tooltip" data-bs-placement="left"
-        title="{% trans 'The evaluation is currently prepared by the lecturers and the evaluation team.' %} {% trans 'You will receive an email when the evaluation period begins.' %}">
-        <i>{% trans 'In preparation' %}</i>
+        title="{% translate 'The evaluation is currently prepared by the lecturers and the evaluation team.' %} {% translate 'You will receive an email when the evaluation period begins.' %}">
+        <i>{% translate 'In preparation' %}</i>
     </span>
 {% elif evaluation.state == evaluation.State.APPROVED %}
     <span class="small{%if evaluation.hours_until_evaluation < 12 %} text-primary{% endif %}" data-bs-toggle="tooltip" data-bs-placement="left"
-        title="{% trans 'Evaluation period' %}:<br />{{ evaluation.vote_start_datetime }} &ndash; {{ evaluation.vote_end_date }}<br /><br />{% trans 'You will receive an email when the evaluation period begins.' %}">
+        title="{% translate 'Evaluation period' %}:<br />{{ evaluation.vote_start_datetime }} &ndash; {{ evaluation.vote_end_date }}<br /><br />{% translate 'You will receive an email when the evaluation period begins.' %}">
         <span class="far fa-clock"></span>
-        {% trans 'Begins in' %} {{ evaluation.vote_start_datetime|timeuntil }}
+        {% translate 'Begins in' %} {{ evaluation.vote_start_datetime|timeuntil }}
     </span>
 {% elif evaluation.state == evaluation.State.IN_EVALUATION and not evaluation.voted_for %}
     {% if evaluation.hours_left_for_evaluation < evaluation_end_warning_period %}
         <span class="small badge bg-danger" data-bs-toggle="tooltip" data-bs-placement="left"
-            title="{% trans 'Evaluation period' %}:<br />{{ evaluation.vote_start_datetime }} &ndash; {{ evaluation.vote_end_date }}<br /><br />{% trans 'The evaluation period will end soon. You only have a few hours left.' %}">
+            title="{% translate 'Evaluation period' %}:<br />{{ evaluation.vote_start_datetime }} &ndash; {{ evaluation.vote_end_date }}<br /><br />{% translate 'The evaluation period will end soon. You only have a few hours left.' %}">
             <span class="far fa-clock"></span>
-            {% trans 'Ends in' %} {{ evaluation.vote_end_datetime|timeuntil }}
+            {% translate 'Ends in' %} {{ evaluation.vote_end_datetime|timeuntil }}
         </span>
     {% else %}
         <span class="small{% if evaluation.display_hours_left_for_evaluation < 48 %} badge bg-warning{% endif %}" data-bs-toggle="tooltip" data-bs-placement="left"
-            title="{% trans 'Evaluation period' %}:<br />{{ evaluation.vote_start_datetime }} &ndash; {{ evaluation.vote_end_date }}">
+            title="{% translate 'Evaluation period' %}:<br />{{ evaluation.vote_start_datetime }} &ndash; {{ evaluation.vote_end_date }}">
             <span class="far fa-clock"></span>
-            {% trans 'Ends in' %} {{ evaluation.display_vote_end_datetime|timeuntil }}
+            {% translate 'Ends in' %} {{ evaluation.display_vote_end_datetime|timeuntil }}
         </span>
     {% endif %}
 {% endif %}

--- a/evap/student/templates/student_index_semester_evaluations_list.html
+++ b/evap/student/templates/student_index_semester_evaluations_list.html
@@ -9,7 +9,7 @@
                 </span>
                 {% if semester.results_are_archived %}
                     <span class="archive-info">
-                        <span class="fas fa-box-archive"></span> {% trans 'The results of this semester have been archived.' %}
+                        <span class="fas fa-box-archive"></span> {% translate 'The results of this semester have been archived.' %}
                     </span>
                 {% endif %}
             </div>
@@ -54,7 +54,7 @@
                                     <td>
                                         {% if semester.results_are_archived %}
                                         {% elif course.not_all_evaluations_are_published %}
-                                            <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'The total grade will be calculated once all evaluation results have been published.' %}">
+                                            <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'The total grade will be calculated once all evaluation results have been published.' %}">
                                                 {% include 'distribution_with_grade_disabled.html' with icon="fas fa-hourglass" %}
                                             </div>
                                         {% else %}
@@ -75,17 +75,17 @@
                                     <td class="ps-2 fs-5">
                                         {% if not evaluation.is_single_result %}
                                             {% if evaluation.voted_for %}
-                                                <span class="text text-success" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'You gave us your feedback in this evaluation. Thank you!' %}"><span class="fas fa-fw fa-check" aria-hidden="true"></span></span>
+                                                <span class="text text-success" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'You gave us your feedback in this evaluation. Thank you!' %}"><span class="fas fa-fw fa-check" aria-hidden="true"></span></span>
                                             {% elif evaluation.participates_in %}
                                                 {% if evaluation.state > evaluation.State.IN_EVALUATION %}
-                                                    <span class="text text-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'You did not take part in this evaluation.' %}"><span class="fas fa-fw fa-xmark" aria-hidden="true"></span></span>
+                                                    <span class="text text-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'You did not take part in this evaluation.' %}"><span class="fas fa-fw fa-xmark" aria-hidden="true"></span></span>
                                                 {% elif evaluation.state == evaluation.State.IN_EVALUATION %}
-                                                    <span class="text text-primary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'You can take part in this evaluation.' %}"><span class="fas fa-fw fa-arrow-right" aria-hidden="true"></span></span>
+                                                    <span class="text text-primary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'You can take part in this evaluation.' %}"><span class="fas fa-fw fa-arrow-right" aria-hidden="true"></span></span>
                                                 {% else %}
-                                                    <span class="text text-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'This evaluation will start in the future.' %}"><span class="far fa-fw fa-hourglass" aria-hidden="true"></span></span>
+                                                    <span class="text text-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'This evaluation will start in the future.' %}"><span class="far fa-fw fa-hourglass" aria-hidden="true"></span></span>
                                                 {% endif %}
                                             {% else %}
-                                                <span class="text text-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'You are not listed as a participant for this evaluation.' %}">
+                                                <span class="text text-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'You are not listed as a participant for this evaluation.' %}">
                                                     <span class="fas fa-fw fa-minus"></span>
                                                 </span>
                                             {% endif %}
@@ -128,10 +128,10 @@
                                             <span class="badge bg-secondary">{{ course.type }}</span>
                                         {% endif %}
                                         {% if evaluation.is_midterm_evaluation %}
-                                            <span class="badge bg-dark">{% trans 'Midterm evaluation' %}</span>
+                                            <span class="badge bg-dark">{% translate 'Midterm evaluation' %}</span>
                                         {% endif %}
                                         {% if evaluation.is_single_result %}
-                                            <span class="badge bg-success">{% trans 'Single result' %}</span>
+                                            <span class="badge bg-success">{% translate 'Single result' %}</span>
                                         {% endif %}
                                         {% if course.evaluation_count == 1 %}
                                             <i class="small">{{ course.responsibles_names }}</i>
@@ -141,7 +141,7 @@
                                         {% if not semester.results_are_archived %}
                                             {% if evaluation.is_single_result %}
                                                 {% if evaluation.state == evaluation.State.PUBLISHED %}
-                                                    <span data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'Individual participants are not stored for single results. The number shown here is the number of votes received.' %}">
+                                                    <span data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Individual participants are not stored for single results. The number shown here is the number of votes received.' %}">
                                                         {% include 'progress_bar_fill.html' with icon='user' total=evaluation.single_result_rating_result.count_sum fill=100 %}
                                                     </span>
                                                 {% endif %}
@@ -157,11 +157,11 @@
                                     <td class="text-end">
                                         {% if not semester.results_are_archived %}
                                             {% if evaluation.state == evaluation.State.IN_EVALUATION and evaluation.participates_in and not evaluation.voted_for and evaluation.is_in_evaluation_period  %}
-                                                <a class="btn btn-sm btn-primary btn-row-hover" href="{% url 'student:vote' evaluation.id %}">{% trans 'Evaluate' %}</a>
+                                                <a class="btn btn-sm btn-primary btn-row-hover" href="{% url 'student:vote' evaluation.id %}">{% translate 'Evaluate' %}</a>
                                             {% elif evaluation.state == evaluation.State.PUBLISHED %}
                                                 {% include 'evaluation_result_widget.html' with course_or_evaluation=evaluation %}
                                             {% elif not evaluation.participates_in or evaluation.voted_for and evaluation.State.IN_EVALUATION <= evaluation.state and evaluation.state <= evaluation.State.REVIEWED %}
-                                                <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% if evaluation|weight_info %}{% blocktrans with percentage=evaluation|weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktrans %} {% endif %}{% trans 'The results have not been published yet.' %}{% if evaluation.participates_in %} {% trans 'You will receive an email when the results are published.' %}{% endif %}">
+                                                <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% if evaluation|weight_info %}{% blocktrans with percentage=evaluation|weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktrans %} {% endif %}{% translate 'The results have not been published yet.' %}{% if evaluation.participates_in %} {% translate 'You will receive an email when the results are published.' %}{% endif %}">
                                                     {% include 'distribution_with_grade_disabled.html' with icon="fas fa-hourglass" weight_info=evaluation|weight_info %}
                                                 </div>
                                             {% endif %}

--- a/evap/student/templates/student_index_semester_evaluations_list.html
+++ b/evap/student/templates/student_index_semester_evaluations_list.html
@@ -161,7 +161,7 @@
                                             {% elif evaluation.state == evaluation.State.PUBLISHED %}
                                                 {% include 'evaluation_result_widget.html' with course_or_evaluation=evaluation %}
                                             {% elif not evaluation.participates_in or evaluation.voted_for and evaluation.State.IN_EVALUATION <= evaluation.state and evaluation.state <= evaluation.State.REVIEWED %}
-                                                <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% if evaluation|weight_info %}{% blocktranslate with percentage=evaluation|weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktrans %} {% endif %}{% translate 'The results have not been published yet.' %}{% if evaluation.participates_in %} {% translate 'You will receive an email when the results are published.' %}{% endif %}">
+                                                <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% if evaluation|weight_info %}{% blocktranslate with percentage=evaluation|weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktranslate %} {% endif %}{% translate 'The results have not been published yet.' %}{% if evaluation.participates_in %} {% translate 'You will receive an email when the results are published.' %}{% endif %}">
                                                     {% include 'distribution_with_grade_disabled.html' with icon="fas fa-hourglass" weight_info=evaluation|weight_info %}
                                                 </div>
                                             {% endif %}

--- a/evap/student/templates/student_index_semester_evaluations_list.html
+++ b/evap/student/templates/student_index_semester_evaluations_list.html
@@ -161,7 +161,7 @@
                                             {% elif evaluation.state == evaluation.State.PUBLISHED %}
                                                 {% include 'evaluation_result_widget.html' with course_or_evaluation=evaluation %}
                                             {% elif not evaluation.participates_in or evaluation.voted_for and evaluation.State.IN_EVALUATION <= evaluation.state and evaluation.state <= evaluation.State.REVIEWED %}
-                                                <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% if evaluation|weight_info %}{% blocktrans with percentage=evaluation|weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktrans %} {% endif %}{% translate 'The results have not been published yet.' %}{% if evaluation.participates_in %} {% translate 'You will receive an email when the results are published.' %}{% endif %}">
+                                                <div class="d-flex" data-bs-toggle="tooltip" data-bs-placement="left" title="{% if evaluation|weight_info %}{% blocktranslate with percentage=evaluation|weight_info %}This evaluation contributes {{ percentage }} to the final grade of the course.{% endblocktrans %} {% endif %}{% translate 'The results have not been published yet.' %}{% if evaluation.participates_in %} {% translate 'You will receive an email when the results are published.' %}{% endif %}">
                                                     {% include 'distribution_with_grade_disabled.html' with icon="fas fa-hourglass" weight_info=evaluation|weight_info %}
                                                 </div>
                                             {% endif %}

--- a/evap/student/templates/student_index_unfinished_evaluations_list.html
+++ b/evap/student/templates/student_index_unfinished_evaluations_list.html
@@ -14,8 +14,8 @@
                         {% if not evaluation.course.semester.is_active %}({{ evaluation.course.semester.name }}){% endif %}
                     </div>
                     <span class="badge bg-secondary">{{ evaluation.course.type }}</span>
-                    {% if evaluation.is_midterm_evaluation %}<span class="badge bg-dark">{% trans 'Midterm evaluation' %}</span>{% endif %}
-                    <span class="badge bg-secondary-outline" data-bs-toggle="tooltip" data-bs-placement="right" title="{% trans 'Number of participants' %}">
+                    {% if evaluation.is_midterm_evaluation %}<span class="badge bg-dark">{% translate 'Midterm evaluation' %}</span>{% endif %}
+                    <span class="badge bg-secondary-outline" data-bs-toggle="tooltip" data-bs-placement="right" title="{% translate 'Number of participants' %}">
                         <span class="fas fa-user"></span> {{ evaluation.num_participants }}
                     </span>
                     <i class="small">{{ evaluation.course.responsibles_names }}</i>
@@ -25,7 +25,7 @@
                 </td>
                 <td style="width: 20%" class="text-end">
                     {% if evaluation.state == evaluation.State.IN_EVALUATION and not evaluation.voted_for and evaluation.is_in_evaluation_period  %}
-                        <a class="btn btn-sm btn-primary btn-row-hover" href="{% url 'student:vote' evaluation.id %}">{% trans 'Evaluate' %}</a>
+                        <a class="btn btn-sm btn-primary btn-row-hover" href="{% url 'student:vote' evaluation.id %}">{% translate 'Evaluate' %}</a>
                     {% endif %}
                 </td>
             </tr>

--- a/evap/student/templates/student_text_answer_warnings.html
+++ b/evap/student/templates/student_text_answer_warnings.html
@@ -1,6 +1,6 @@
 <span class="mt-2 warning-label d-none" data-warning="meaningless">
     <span class="fas fa-triangle-exclamation"></span>
-    {% trans "This answer will probably be filtered out. You can simply leave the textbox empty." %}
+    {% translate "This answer will probably be filtered out. You can simply leave the textbox empty." %}
 </span>
 {% for warning in text_answer_warnings %}
     <span class="mt-2 warning-label d-none" data-warning="trigger-string-{{ forloop.counter0 }}">

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -22,9 +22,9 @@
             <div class="d-flex align-items-center justify-content-between">
                 <div class="p-2">
                     {% if contributor_errors_exist %}
-                        {% blocktrans %}Please make sure to vote for all rating questions. You can also click on "I can't give feedback" to skip the questions about a single person.{% endblocktrans %}
+                        {% blocktranslate %}Please make sure to vote for all rating questions. You can also click on "I can't give feedback" to skip the questions about a single person.{% endblocktrans %}
                     {% else %}
-                        {% blocktrans %}Please make sure to vote for all rating questions.{% endblocktrans %}
+                        {% blocktranslate %}Please make sure to vote for all rating questions.{% endblocktrans %}
                     {% endif %}
                 </div>
                 <button id="btn-jump-unanswered-question" type="button" class="btn btn-light float-end" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Jump to the first unanswered question' %}">
@@ -47,7 +47,7 @@
         <div class="callout callout-info">
             <small>
                 <b>{% translate 'Questionnaire Preview' %}</b><br />
-                {% blocktrans %}This is a preview of the questionnaire for the evaluation. Participants will see the questions below.{% endblocktrans %}
+                {% blocktranslate %}This is a preview of the questionnaire for the evaluation. Participants will see the questions below.{% endblocktrans %}
             </small>
         </div>
     {% endif %}
@@ -61,10 +61,10 @@
                     <span class="fas fa-triangle-exclamation"></span> {% translate 'Small number of participants' %}
                 </div>
                 <div class="card-body tab-row">
-                    {% blocktrans %}Only a small number of people can take part in this evaluation. You should be aware that contributors might be able to guess who voted for a specific answer and who wrote a text answer. Results will only be published if two or more people participated in the evaluation.{% endblocktrans %}
+                    {% blocktranslate %}Only a small number of people can take part in this evaluation. You should be aware that contributors might be able to guess who voted for a specific answer and who wrote a text answer. Results will only be published if two or more people participated in the evaluation.{% endblocktrans %}
                     {% if evaluation.num_voters == 0 %}
                         <br />
-                        {% blocktrans %}You're the first person taking part in this evaluation. If you want your text answers to be shown to the contributors even if you remain the only person taking part, please check the box below. Otherwise your text answers will be deleted if no other person takes part in the evaluation.{% endblocktrans %}
+                        {% blocktranslate %}You're the first person taking part in this evaluation. If you want your text answers to be shown to the contributors even if you remain the only person taking part, please check the box below. Otherwise your text answers will be deleted if no other person takes part in the evaluation.{% endblocktrans %}
 
                         <div class="form-check mt-3">
                             <input class="form-check-input tab-selectable" id="text_results_publish_confirmation_top" type="checkbox"
@@ -96,7 +96,7 @@
                 <div class="card-body">
                     {% if not preview %}
                         <div class="callout callout-info">
-                            {% blocktrans %}Please vote for all contributors you worked with. Click on "I can't give feedback" to skip a person.{% endblocktrans %}
+                            {% blocktranslate %}Please vote for all contributors you worked with. Click on "I can't give feedback" to skip a person.{% endblocktrans %}
                         </div>
                     {% endif %}
 
@@ -137,7 +137,7 @@
                     <span class="fas fa-triangle-exclamation"></span> {% translate 'Small number of participants' %}
                 </div>
                 <div class="card-body tab-row">
-                    {% blocktrans %}You're the first person taking part in this evaluation. If you want your text answers to be shown to the contributors even if you remain the only person taking part, please check the box below. Otherwise your text answers will be deleted if no other person takes part in the evaluation.{% endblocktrans %}
+                    {% blocktranslate %}You're the first person taking part in this evaluation. If you want your text answers to be shown to the contributors even if you remain the only person taking part, please check the box below. Otherwise your text answers will be deleted if no other person takes part in the evaluation.{% endblocktrans %}
 
                     <div class="form-check mt-3">
                         <input class="form-check-input tab-selectable" id="text_results_publish_confirmation_bottom" type="checkbox"
@@ -162,7 +162,7 @@
                         <button id="vote-submit-btn" type="submit" class="btn btn-success tab-selectable">{% translate 'Submit questionnaire' %}</button>
                         <p id="submit-error-warning" style="display: none" class="text-danger">
                             <span class="fas fa-triangle-exclamation"></span>
-                            {% blocktrans %}The server can't be reached. Your answers have been stored in your browser and it's safe to leave the page. Please try again later to submit the questionnaire.{% endblocktrans %}
+                            {% blocktranslate %}The server can't be reached. Your answers have been stored in your browser and it's safe to leave the page. Please try again later to submit the questionnaire.{% endblocktrans %}
                         </p>
                     {% endif %}
                 </div>

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -4,7 +4,7 @@
 {% load evaluation_filters %}
 {% load student_filters %}
 
-{% block title %}{{ evaluation.full_name }} - {% trans 'Evaluation' %} - {{ block.super }}{% endblock %}
+{% block title %}{{ evaluation.full_name }} - {% translate 'Evaluation' %} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb_bar %}
     <div class="breadcrumb-bar">
@@ -27,26 +27,26 @@
                         {% blocktrans %}Please make sure to vote for all rating questions.{% endblocktrans %}
                     {% endif %}
                 </div>
-                <button id="btn-jump-unanswered-question" type="button" class="btn btn-light float-end" data-bs-toggle="tooltip" data-bs-placement="left" title="{% trans 'Jump to the first unanswered question' %}">
+                <button id="btn-jump-unanswered-question" type="button" class="btn btn-light float-end" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Jump to the first unanswered question' %}">
                     <i class="fas fa-arrow-down"></i>
                 </button>
             </div>
         </div>
     {% endif %}
     {% if evaluation.is_midterm_evaluation %}
-        <div class="callout callout-warning">{% trans 'The results of this evaluation will be published while the course is still running. This means that the contributors will receive this feedback before the final grades for the course have been published.' %}</div>
+        <div class="callout callout-warning">{% translate 'The results of this evaluation will be published while the course is still running. This means that the contributors will receive this feedback before the final grades for the course have been published.' %}</div>
     {% endif %}
     {% if evaluation.ends_soon %}
         <div class="callout callout-danger">
-            {% trans 'The evaluation period will end in' %}
+            {% translate 'The evaluation period will end in' %}
             {{ evaluation.vote_end_datetime|timeuntil }} ({{ evaluation.vote_end_datetime }}).
-            {% trans 'Your evaluation will only be accepted if you send the completed questionnaire before this deadline ends.' %}
+            {% translate 'Your evaluation will only be accepted if you send the completed questionnaire before this deadline ends.' %}
         </div>
     {% endif %}
     {% if preview and not for_rendering_in_modal %}
         <div class="callout callout-info">
             <small>
-                <b>{% trans 'Questionnaire Preview' %}</b><br />
+                <b>{% translate 'Questionnaire Preview' %}</b><br />
                 {% blocktrans %}This is a preview of the questionnaire for the evaluation. Participants will see the questions below.{% endblocktrans %}
             </small>
         </div>
@@ -58,7 +58,7 @@
         {% if small_evaluation_size_warning and not preview %}
             <div class="card card-outline-warning mb-3">
                 <div class="card-header">
-                    <span class="fas fa-triangle-exclamation"></span> {% trans 'Small number of participants' %}
+                    <span class="fas fa-triangle-exclamation"></span> {% translate 'Small number of participants' %}
                 </div>
                 <div class="card-body tab-row">
                     {% blocktrans %}Only a small number of people can take part in this evaluation. You should be aware that contributors might be able to guess who voted for a specific answer and who wrote a text answer. Results will only be published if two or more people participated in the evaluation.{% endblocktrans %}
@@ -70,7 +70,7 @@
                             <input class="form-check-input tab-selectable" id="text_results_publish_confirmation_top" type="checkbox"
                                 name="text_results_publish_confirmation_top" />
                             <label class="form-check-label" for="text_results_publish_confirmation_top">
-                                {% trans 'Show my text answers to the contributors even if I remain the only person who takes part in this evaluation.' %}
+                                {% translate 'Show my text answers to the contributors even if I remain the only person who takes part in this evaluation.' %}
                             </label>
                         </div>
                     {% endif %}
@@ -81,7 +81,7 @@
         {% if evaluation_form_group_top %}
             <div class="card card-outline-primary mb-3">
                 <div class="card-header">
-                    {% trans 'General questions' %}
+                    {% translate 'General questions' %}
                 </div>
                 <div class="card-body">
                     {% include 'student_vote_questionnaire_group.html' with questionnaire_group=evaluation_form_group_top textanswers_visible_to=general_contribution_textanswers_visible_to preview=preview %}
@@ -91,7 +91,7 @@
         {% if contributor_form_groups %}
             <div class="card card-outline-primary mb-3">
                 <div class="card-header">
-                    {% trans 'Questions about the contributors' %}
+                    {% translate 'Questions about the contributors' %}
                 </div>
                 <div class="card-body">
                     {% if not preview %}
@@ -124,7 +124,7 @@
         {% if evaluation_form_group_bottom %}
             <div class="card card-outline-primary mb-3">
                 <div class="card-header">
-                    {% trans "General questions" %}
+                    {% translate "General questions" %}
                 </div>
                 <div class="card-body">
                     {% include "student_vote_questionnaire_group.html" with questionnaire_group=evaluation_form_group_bottom textanswers_visible_to=general_contribution_textanswers_visible_to preview=preview %}
@@ -134,7 +134,7 @@
         {% if small_evaluation_size_warning and not preview and evaluation.num_voters == 0 %}
             <div class="card card-outline-warning mb-3" id="bottom_text_results_publish_confirmation_card">
                 <div class="card-header">
-                    <span class="fas fa-triangle-exclamation"></span> {% trans 'Small number of participants' %}
+                    <span class="fas fa-triangle-exclamation"></span> {% translate 'Small number of participants' %}
                 </div>
                 <div class="card-body tab-row">
                     {% blocktrans %}You're the first person taking part in this evaluation. If you want your text answers to be shown to the contributors even if you remain the only person taking part, please check the box below. Otherwise your text answers will be deleted if no other person takes part in the evaluation.{% endblocktrans %}
@@ -143,7 +143,7 @@
                         <input class="form-check-input tab-selectable" id="text_results_publish_confirmation_bottom" type="checkbox"
                             name="text_results_publish_confirmation_bottom" />
                         <label class="form-check-label" for="text_results_publish_confirmation_bottom">
-                            {% trans 'Show my text answers to the contributors even if I remain the only person who takes part in this evaluation.' %}
+                            {% translate 'Show my text answers to the contributors even if I remain the only person who takes part in this evaluation.' %}
                         </label>
                     </div>
                 </div>
@@ -153,13 +153,13 @@
             <div class="card card-submit-area{% if not preview %} card-submit-area-2{% endif %} text-center">
                 <div class="card-body tab-row">
                     {% if preview %}
-                        <a class="btn btn-secondary" href="{{ request.META.HTTP_REFERER }}">{% trans 'Back' %}</a>
+                        <a class="btn btn-secondary" href="{{ request.META.HTTP_REFERER }}">{% translate 'Back' %}</a>
                     {% else %}
                         <div class="pb-3 text-secondary">
                             <span id="last-saved"></span>
-                            <span class="fas fa-circle-info" data-bs-toggle="tooltip" title="{% trans 'The evaluation can be continued later using the same device and the same browser. But you have to submit it to send it to the server and make it count. After submitting, you can not edit the evaluation anymore.' %}"></span>
+                            <span class="fas fa-circle-info" data-bs-toggle="tooltip" title="{% translate 'The evaluation can be continued later using the same device and the same browser. But you have to submit it to send it to the server and make it count. After submitting, you can not edit the evaluation anymore.' %}"></span>
                         </div>
-                        <button id="vote-submit-btn" type="submit" class="btn btn-success tab-selectable">{% trans 'Submit questionnaire' %}</button>
+                        <button id="vote-submit-btn" type="submit" class="btn btn-success tab-selectable">{% translate 'Submit questionnaire' %}</button>
                         <p id="submit-error-warning" style="display: none" class="text-danger">
                             <span class="fas fa-triangle-exclamation"></span>
                             {% blocktrans %}The server can't be reached. Your answers have been stored in your browser and it's safe to leave the page. Please try again later to submit the questionnaire.{% endblocktrans %}
@@ -220,13 +220,13 @@
                     const relativeTimeFormat = new Intl.RelativeTimeFormat(languageCode);
                     let timeStamp;
                     if (delta < 3) {
-                        timeStamp = "{% trans 'just now' %}";
+                        timeStamp = "{% translate 'just now' %}";
                     } else if (delta < 10) {
-                        timeStamp = "{% trans 'less than 10 seconds ago' %}";
+                        timeStamp = "{% translate 'less than 10 seconds ago' %}";
                     } else if (delta < 30) {
-                        timeStamp = "{% trans 'less than 30 seconds ago' %}";
+                        timeStamp = "{% translate 'less than 30 seconds ago' %}";
                     } else if (delta < 60) {
-                        timeStamp = "{% trans 'less than 1 minute ago' %}";
+                        timeStamp = "{% translate 'less than 1 minute ago' %}";
                     } else if (delta < 60 * 30) {
                         timeStamp = relativeTimeFormat.format(-Math.round(delta / 60), 'minutes');
                     } else if (delta < 60 * 60 * 12) {
@@ -238,9 +238,9 @@
                         + padWithLeadingZeros(lastSavedDate.getHours()) + ":"
                         + padWithLeadingZeros(lastSavedDate.getMinutes());
                     }
-                    lastSavedLabel.innerText = "{% trans 'Last saved locally' %}: " + timeStamp;
+                    lastSavedLabel.innerText = "{% translate 'Last saved locally' %}: " + timeStamp;
                 } else {
-                    lastSavedLabel.innerText = "{% trans 'Could not save your information locally' %}";
+                    lastSavedLabel.innerText = "{% translate 'Could not save your information locally' %}";
                 }
             }
 
@@ -264,7 +264,7 @@
                 const submitButton = document.getElementById('vote-submit-btn');
                 const originalText = submitButton.innerText;
 
-                submitButton.innerText = "{% trans 'Submitting...' %}";
+                submitButton.innerText = "{% translate 'Submitting...' %}";
                 submitButton.disabled = true;
 
                 fetch(form.action, {

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -22,9 +22,9 @@
             <div class="d-flex align-items-center justify-content-between">
                 <div class="p-2">
                     {% if contributor_errors_exist %}
-                        {% blocktranslate %}Please make sure to vote for all rating questions. You can also click on "I can't give feedback" to skip the questions about a single person.{% endblocktrans %}
+                        {% blocktranslate %}Please make sure to vote for all rating questions. You can also click on "I can't give feedback" to skip the questions about a single person.{% endblocktranslate %}
                     {% else %}
-                        {% blocktranslate %}Please make sure to vote for all rating questions.{% endblocktrans %}
+                        {% blocktranslate %}Please make sure to vote for all rating questions.{% endblocktranslate %}
                     {% endif %}
                 </div>
                 <button id="btn-jump-unanswered-question" type="button" class="btn btn-light float-end" data-bs-toggle="tooltip" data-bs-placement="left" title="{% translate 'Jump to the first unanswered question' %}">
@@ -47,7 +47,7 @@
         <div class="callout callout-info">
             <small>
                 <b>{% translate 'Questionnaire Preview' %}</b><br />
-                {% blocktranslate %}This is a preview of the questionnaire for the evaluation. Participants will see the questions below.{% endblocktrans %}
+                {% blocktranslate %}This is a preview of the questionnaire for the evaluation. Participants will see the questions below.{% endblocktranslate %}
             </small>
         </div>
     {% endif %}
@@ -61,10 +61,10 @@
                     <span class="fas fa-triangle-exclamation"></span> {% translate 'Small number of participants' %}
                 </div>
                 <div class="card-body tab-row">
-                    {% blocktranslate %}Only a small number of people can take part in this evaluation. You should be aware that contributors might be able to guess who voted for a specific answer and who wrote a text answer. Results will only be published if two or more people participated in the evaluation.{% endblocktrans %}
+                    {% blocktranslate %}Only a small number of people can take part in this evaluation. You should be aware that contributors might be able to guess who voted for a specific answer and who wrote a text answer. Results will only be published if two or more people participated in the evaluation.{% endblocktranslate %}
                     {% if evaluation.num_voters == 0 %}
                         <br />
-                        {% blocktranslate %}You're the first person taking part in this evaluation. If you want your text answers to be shown to the contributors even if you remain the only person taking part, please check the box below. Otherwise your text answers will be deleted if no other person takes part in the evaluation.{% endblocktrans %}
+                        {% blocktranslate %}You're the first person taking part in this evaluation. If you want your text answers to be shown to the contributors even if you remain the only person taking part, please check the box below. Otherwise your text answers will be deleted if no other person takes part in the evaluation.{% endblocktranslate %}
 
                         <div class="form-check mt-3">
                             <input class="form-check-input tab-selectable" id="text_results_publish_confirmation_top" type="checkbox"
@@ -96,7 +96,7 @@
                 <div class="card-body">
                     {% if not preview %}
                         <div class="callout callout-info">
-                            {% blocktranslate %}Please vote for all contributors you worked with. Click on "I can't give feedback" to skip a person.{% endblocktrans %}
+                            {% blocktranslate %}Please vote for all contributors you worked with. Click on "I can't give feedback" to skip a person.{% endblocktranslate %}
                         </div>
                     {% endif %}
 
@@ -137,7 +137,7 @@
                     <span class="fas fa-triangle-exclamation"></span> {% translate 'Small number of participants' %}
                 </div>
                 <div class="card-body tab-row">
-                    {% blocktranslate %}You're the first person taking part in this evaluation. If you want your text answers to be shown to the contributors even if you remain the only person taking part, please check the box below. Otherwise your text answers will be deleted if no other person takes part in the evaluation.{% endblocktrans %}
+                    {% blocktranslate %}You're the first person taking part in this evaluation. If you want your text answers to be shown to the contributors even if you remain the only person taking part, please check the box below. Otherwise your text answers will be deleted if no other person takes part in the evaluation.{% endblocktranslate %}
 
                     <div class="form-check mt-3">
                         <input class="form-check-input tab-selectable" id="text_results_publish_confirmation_bottom" type="checkbox"
@@ -162,7 +162,7 @@
                         <button id="vote-submit-btn" type="submit" class="btn btn-success tab-selectable">{% translate 'Submit questionnaire' %}</button>
                         <p id="submit-error-warning" style="display: none" class="text-danger">
                             <span class="fas fa-triangle-exclamation"></span>
-                            {% blocktranslate %}The server can't be reached. Your answers have been stored in your browser and it's safe to leave the page. Please try again later to submit the questionnaire.{% endblocktrans %}
+                            {% blocktranslate %}The server can't be reached. Your answers have been stored in your browser and it's safe to leave the page. Please try again later to submit the questionnaire.{% endblocktranslate %}
                         </p>
                     {% endif %}
                 </div>

--- a/evap/student/templates/student_vote_questionnaire_group.html
+++ b/evap/student/templates/student_vote_questionnaire_group.html
@@ -11,7 +11,7 @@
                     data-mark-no-answers-for="{{ contributor.id }}"
                     {% if preview %}disabled{% endif %}
                 >
-                    {% blocktranslate %}I can't give feedback about this contributor{% endblocktrans %}
+                    {% blocktranslate %}I can't give feedback about this contributor{% endblocktranslate %}
                 </button>
             </div>
         {% endif%}
@@ -78,7 +78,7 @@
                                         <textarea id="{{ field.id_for_label }}" class="form-control tab-selectable" name="{{ field.name }}"{% if preview %} disabled{% endif %}>{{ field.value|default_if_none:"" }}</textarea>
                                     </div>
                                     <div>
-                                        {% blocktranslate asvar intro_text %}After publishing, this text answer can be seen by:{% endblocktrans %}
+                                        {% blocktranslate asvar intro_text %}After publishing, this text answer can be seen by:{% endblocktranslate %}
                                         {% include 'textanswer_visibility_info.html' with intro_text=intro_text visible_by_contribution=textanswers_visible_to.visible_by_contribution visible_by_delegation_count=textanswers_visible_to.visible_by_delegation_count %}
                                     </div>
                                 </div>

--- a/evap/student/templates/student_vote_questionnaire_group.html
+++ b/evap/student/templates/student_vote_questionnaire_group.html
@@ -37,12 +37,12 @@
                                 <span class="me-1">
 
                                     {% if field.field.widget.attrs.choices.is_inverted %}
-                                        <span class="fas fa-triangle-exclamation warning-label" data-bs-toggle="tooltip" data-bs-placement="top" title="{% trans 'The answer scale is inverted for this question.' %}"></span>
+                                        <span class="fas fa-triangle-exclamation warning-label" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'The answer scale is inverted for this question.' %}"></span>
                                     {% endif %}
                                     {{ field.label }}
                                 </span>
                                 {% if allows_textanswer %}
-                                    <span class="my-auto" data-bs-toggle="tooltip" data-container=".col-question" title="{% trans 'Add a text answer to this question' %}">
+                                    <span class="my-auto" data-bs-toggle="tooltip" data-container=".col-question" title="{% translate 'Add a text answer to this question' %}">
                                         <button type="button" class="btn btn-light btn-textanswer collapsed" data-bs-toggle="collapse" data-bs-target=".collapse-{{ field.name }}" tabindex="-1">
                                             <span class="far fa-comment"></span>
                                         </button>

--- a/evap/student/templates/student_vote_questionnaire_group.html
+++ b/evap/student/templates/student_vote_questionnaire_group.html
@@ -11,7 +11,7 @@
                     data-mark-no-answers-for="{{ contributor.id }}"
                     {% if preview %}disabled{% endif %}
                 >
-                    {% blocktrans %}I can't give feedback about this contributor{% endblocktrans %}
+                    {% blocktranslate %}I can't give feedback about this contributor{% endblocktrans %}
                 </button>
             </div>
         {% endif%}
@@ -78,7 +78,7 @@
                                         <textarea id="{{ field.id_for_label }}" class="form-control tab-selectable" name="{{ field.name }}"{% if preview %} disabled{% endif %}>{{ field.value|default_if_none:"" }}</textarea>
                                     </div>
                                     <div>
-                                        {% blocktrans asvar intro_text %}After publishing, this text answer can be seen by:{% endblocktrans %}
+                                        {% blocktranslate asvar intro_text %}After publishing, this text answer can be seen by:{% endblocktrans %}
                                         {% include 'textanswer_visibility_info.html' with intro_text=intro_text visible_by_contribution=textanswers_visible_to.visible_by_contribution visible_by_delegation_count=textanswers_visible_to.visible_by_delegation_count %}
                                     </div>
                                 </div>


### PR DESCRIPTION
They were [introduced in django3.1](https://docs.djangoproject.com/en/5.0/releases/3.1/#templates) and, while it says the old tags  are still supported, the documentation [does not mention them anymore](https://docs.djangoproject.com/en/5.0/topics/i18n/translation/#translate-template-tag).

Replacement was done using the commands in the commit messages. I quickly looked through the results and they seem meaningful to me. It should be easy to rebase/redo, so we can wait (e.g. for #1985)