### PR TITLE
Use click handlers instead of inserting anchor tags in `.table-seamless-links`

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -179,12 +179,9 @@
 
             // activate clickable hover tables
             document.querySelectorAll(".table-seamless-links [data-url]").forEach(row => {
-                for(const table_data of row.children) {
-                    const wrapping_anchor = document.createElement("a");
-                    wrapping_anchor.href = row.dataset["url"];
-                    wrapping_anchor.append(...table_data.childNodes);
-                    table_data.replaceChildren(wrapping_anchor);
-                }
+                row.addEventListener("click", () => {
+                    window.location.assign(row.dataset.url);
+                });
             });
 
             document.querySelectorAll(".hover-row").forEach(row => {

--- a/evap/static/scss/components/_tables.scss
+++ b/evap/static/scss/components/_tables.scss
@@ -35,19 +35,8 @@ $table-colors: (
     padding-bottom: 0.4rem;
 }
 
-// Seamless links in tables
-//
-// -1- Expand links to fill the cell
 .table-seamless-links td {
     overflow: hidden;
-
-    a:not(.btn) {
-        color: $black;
-        text-decoration: none;
-        display: block; // -1-
-        margin: -10em;  // -1-
-        padding: 10em;  // -1-
-    }
 }
 
 // Hoverable rows


### PR DESCRIPTION
This way we don't need to think about the DOM elements being moved around and we can stop click events in nested elements.

This came up in #1985 