### PR TITLE
ci: run backup process without dev dependencies

### DIFF
--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ hashFiles( 'requirements*.txt' ) }}
+        key: venv-${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ hashFiles( inputs.requirements-file ) }}
 
     - name: Install dependencies
       run: |

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -21,7 +21,8 @@ runs:
       uses: actions/cache@v4
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ hashFiles( inputs.requirements-file ) }}
+        # hashFiles( 'requirements*.txt' ) because -dev.txt includes requirements.txt
+        key: venv-${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ hashFiles( 'requirements*.txt' ) }}-${{ inputs.requirements-file }}
 
     - name: Install dependencies
       run: |

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -20,9 +20,8 @@ runs:
         install_dev: ${{ inputs.install-dev-requirements }}
       run: |
         if [[ $install_dev == 'true' ]]; then \
-          REQUIREMENTS_TXT='requirements-dev.txt' \
-        else REQUIREMENTS_TXT='requirements.txt' fi
-        
+          set REQUIREMENTS_TXT 'requirements-dev.txt' \
+        else set REQUIREMENTS_TXT 'requirements.txt' fi
         echo "requirements_txt=$REQUIREMENTS_TXT" >> $GITHUB_ENV
       shell: bash
 

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         if [[ $install_dev == 'true' ]]; then \
           set REQUIREMENTS_TXT 'requirements-dev.txt' \
-        else set REQUIREMENTS_TXT 'requirements.txt' fi
+        else set REQUIREMENTS_TXT 'requirements.txt'; fi
         echo "requirements_txt=$REQUIREMENTS_TXT" >> $GITHUB_ENV
       shell: bash
 

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -20,8 +20,9 @@ runs:
         install_dev: ${{ inputs.install-dev-requirements }}
       run: |
         if [[ $install_dev == 'true' ]]; then \
-          set REQUIREMENTS_TXT 'requirements-dev.txt' \
-        else set REQUIREMENTS_TXT 'requirements.txt'; fi
+          REQUIREMENTS_TXT='requirements-dev.txt' \
+        else REQUIREMENTS_TXT='requirements.txt'; fi
+
         echo "requirements_txt=$REQUIREMENTS_TXT" >> $GITHUB_ENV
       shell: bash
 

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -16,24 +16,40 @@ runs:
         python-version: "3.10"
 
     - name: Restore venv cache
-      uses: syphar/restore-virtualenv@v1
       id: cache-virtualenv
+      uses: actions/cache@v3
       with:
-        requirement_files: ${{ inputs.requirements-file }}
+        path: .venv
+        key: venv-${{ runner.os }}-${{ hashFiles( inputs.requirements-file ) }}-${{ inputs.requirements-file }}
+        restore-keys: venv-${{ runner.os }}-${{ hashFiles( inputs.requirements-file ) }}-${{ inputs.requirements-file }}
 
     - name: Restore pip download cache
-      uses: syphar/restore-pip-download-cache@v1
-      if: steps.cache-virtualenv.outputs.cache-hit != 'true'
+      uses: actions/cache@v3
       with:
-        requirement_files: ${{ inputs.requirements-file }}
+        path: ~/.cache/pip
+        key: pip-${{ runner.os }}-${{ hashFiles( inputs.requirements-file ) }}-${{ inputs.requirements-file }}
+        restore-keys: pip-${{ runner.os }}-${{ hashFiles( inputs.requirements-file ) }}-${{ inputs.requirements-file }}
+      if: steps.cache-virtualenv.outputs.cache-hit != 'true'
 
     - name: Install dependencies
       env:
         requirements_txt: ${{ inputs.requirements-file }}
-      run: pip install -r $requirements_txt
+      run: |
+        python -m venv .venv
+        source .venv/bin/activate
+        pip install -r $requirements_txt
       shell: bash
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
 
     - name: Add localsettings
       run: cp evap/settings_test.py evap/localsettings.py
+      shell: bash
+
+    - name: Activate venv
+      run: |
+        source .venv/bin/activate
+        echo $PATH >> $GITHUB_PATH
+        echo PATH=$PATH >> $GITHUB_ENV
+        echo VIRTUAL_ENV=$VIRTUAL_ENV >> $GITHUB_ENV
+        echo PYTHONHOME=$PYTHONHOME >> $GITHUB_ENV
       shell: bash

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -28,6 +28,8 @@ runs:
     - name: Restore venv cache
       uses: syphar/restore-virtualenv@v1
       id: cache-virtualenv
+      with:
+        requirement_files: ${{ env.requirements_txt }}
 
     - name: Restore pip download cache
       uses: syphar/restore-pip-download-cache@v1

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -2,10 +2,10 @@ name: "Setup Python"
 description: "Sets up Python for use in actions with caching and copy localsettings"
 
 inputs:
-  install-dev-requirements:
+  requirements-file:
     description: "if disabled this will only install runtime dependencies"
     required: false
-    default: "true"
+    default: requirements-dev.txt
 
 runs:
   using: "composite"
@@ -15,32 +15,21 @@ runs:
       with:
         python-version: "3.10"
 
-    - name: Deduce requirements file
-      env:
-        install_dev: ${{ inputs.install-dev-requirements }}
-      run: |
-        if [[ $install_dev == 'true' ]]; then \
-          REQUIREMENTS_TXT='requirements-dev.txt'; \
-        else REQUIREMENTS_TXT='requirements.txt'; fi
-
-        echo "requirements_txt=$REQUIREMENTS_TXT" >> $GITHUB_ENV
-      shell: bash
-
     - name: Restore venv cache
       uses: syphar/restore-virtualenv@v1
       id: cache-virtualenv
       with:
-        requirement_files: ${{ env.requirements_txt }}
+        requirement_files: ${{ inputs.requirements-file }}
 
     - name: Restore pip download cache
       uses: syphar/restore-pip-download-cache@v1
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
       with:
-        requirement_files: ${{ env.requirements_txt }}
+        requirement_files: ${{ inputs.requirements-file }}
 
     - name: Install dependencies
       env:
-        requirements_txt: ${{ env.requirements_txt }}
+        requirements_txt: ${{ inputs.requirements-file }}
       run: pip install -r $requirements_txt
       shell: bash
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -1,13 +1,19 @@
 name: "Setup Python"
 description: "Sets up Python for use in actions with caching and copy localsettings"
 
+inputs:
+  install-dev-requirements:
+    description: "if disabled this will only install runtime dependencies"
+    required: false
+    default: "true"
+
 runs:
   using: "composite"
   steps:
     - name: Setup python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: "3.10"
 
     - name: Restore venv cache
       uses: syphar/restore-virtualenv@v1
@@ -18,7 +24,12 @@ runs:
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
 
     - name: Install dependencies
-      run: pip install -r requirements-dev.txt
+      env:
+        install_dev: ${{ inputs.install-dev-requirements }}
+      run: |
+        if [[ $install_dev == 'true' ]]; then 
+          pip install -r requirements-dev.txt 
+        else pip install -r requirements.txt; fi
       shell: bash
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
 

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         if [[ $install_dev == 'true' ]]; then
           REQUIREMENTS_TXT='requirements-dev.txt'
-        else REQUIREMENTS_TXT='requirements.txt'
+        else REQUIREMENTS_TXT='requirements.txt' fi
         
         echo "requirements_txt=$REQUIREMENTS_TXT" >> $GITHUB_ENV
       shell: bash

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -2,14 +2,26 @@ name: "Setup Python"
 description: "Sets up Python for use in actions with caching and copy localsettings"
 
 inputs:
-  requirements-file:
+  install-dev-dependencies:
     description: "if disabled this will only install runtime dependencies"
     required: false
-    default: requirements-dev.txt
+    default: true
 
 runs:
   using: "composite"
   steps:
+    - name: Compute requirements files
+      run: |
+        cache_files="requirements.txt"
+        requirements_file="requirements.txt"
+        if [[ ${{ inputs.install-dev-dependencies }} == 'true' ]]; then
+          cache_files="requirements*.txt"
+          requirements_file="requirements-dev.txt"
+        fi
+        echo cache-files=$cache_files >> $GITHUB_ENV
+        echo requirements-file=$requirements_file >> $GITHUB_ENV
+      shell: bash
+
     - name: Setup python
       uses: actions/setup-python@v4
       with:
@@ -17,25 +29,16 @@ runs:
 
     - name: Restore venv cache
       id: cache-virtualenv
-      uses: actions/cache@v3
+      uses: actions/cache4@v3
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ hashFiles( inputs.requirements-file ) }}-${{ inputs.requirements-file }}
-        restore-keys: venv-${{ runner.os }}-${{ hashFiles( inputs.requirements-file ) }}-${{ inputs.requirements-file }}
-
-    - name: Restore pip download cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: pip-${{ runner.os }}-${{ hashFiles( inputs.requirements-file ) }}-${{ inputs.requirements-file }}
-        restore-keys: pip-${{ runner.os }}-${{ hashFiles( inputs.requirements-file ) }}-${{ inputs.requirements-file }}
-      if: steps.cache-virtualenv.outputs.cache-hit != 'true'
+        key: venv-${{ runner.os }}-${{ hashFiles( env.cache-files ) }}
 
     - name: Install dependencies
       run: |
         python -m venv .venv
         source .venv/bin/activate
-        pip install -r "${{ inputs.requirements-file }}"
+        pip install -r "${{ env.requirements-file }}"
       shell: bash
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
 

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -15,6 +15,17 @@ runs:
       with:
         python-version: "3.10"
 
+    - name: Deduce requirements file
+      env:
+        install_dev: ${{ inputs.install-dev-requirements }}
+      run: |
+        if [[ $install_dev == 'true' ]]; then
+          REQUIREMENTS_TXT='requirements-dev.txt'
+        else REQUIREMENTS_TXT='requirements.txt'
+        
+        echo "requirements_txt=$REQUIREMENTS_TXT" >> $GITHUB_ENV
+      shell: bash
+
     - name: Restore venv cache
       uses: syphar/restore-virtualenv@v1
       id: cache-virtualenv
@@ -22,14 +33,13 @@ runs:
     - name: Restore pip download cache
       uses: syphar/restore-pip-download-cache@v1
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
+      with:
+        requirement_files: ${{ env.requirements_txt }}
 
     - name: Install dependencies
       env:
-        install_dev: ${{ inputs.install-dev-requirements }}
-      run: |
-        if [[ $install_dev == 'true' ]]; then 
-          pip install -r requirements-dev.txt 
-        else pip install -r requirements.txt; fi
+        requirements_txt: ${{ env.requirements_txt }}
+      run: pip install -r $requirements_txt
       shell: bash
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
 

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: Restore venv cache
       id: cache-virtualenv
-      uses: actions/cache4@v3
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ hashFiles( env.cache-files ) }}

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -19,8 +19,8 @@ runs:
       env:
         install_dev: ${{ inputs.install-dev-requirements }}
       run: |
-        if [[ $install_dev == 'true' ]]; then
-          REQUIREMENTS_TXT='requirements-dev.txt'
+        if [[ $install_dev == 'true' ]]; then \
+          REQUIREMENTS_TXT='requirements-dev.txt' \
         else REQUIREMENTS_TXT='requirements.txt' fi
         
         echo "requirements_txt=$REQUIREMENTS_TXT" >> $GITHUB_ENV

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -2,26 +2,14 @@ name: "Setup Python"
 description: "Sets up Python for use in actions with caching and copy localsettings"
 
 inputs:
-  install-dev-dependencies:
+  requirements-file:
     description: "if disabled this will only install runtime dependencies"
     required: false
-    default: true
+    default: requirements-dev.txt
 
 runs:
   using: "composite"
   steps:
-    - name: Compute requirements files
-      run: |
-        cache_files="requirements.txt"
-        requirements_file="requirements.txt"
-        if [[ ${{ inputs.install-dev-dependencies }} == 'true' ]]; then
-          cache_files="requirements*.txt"
-          requirements_file="requirements-dev.txt"
-        fi
-        echo cache-files=$cache_files >> $GITHUB_ENV
-        echo requirements-file=$requirements_file >> $GITHUB_ENV
-      shell: bash
-
     - name: Setup python
       uses: actions/setup-python@v4
       with:
@@ -32,13 +20,13 @@ runs:
       uses: actions/cache@v4
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ hashFiles( env.cache-files ) }}
+        key: venv-${{ runner.os }}-${{ hashFiles( requirements*.txt ) }}
 
     - name: Install dependencies
       run: |
         python -m venv .venv
         source .venv/bin/activate
-        pip install -r "${{ env.requirements-file }}"
+        pip install -r "${{ inputs.requirements-file }}"
       shell: bash
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
 

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -3,7 +3,7 @@ description: "Sets up Python for use in actions with caching and copy localsetti
 
 inputs:
   requirements-file:
-    description: "if disabled this will only install runtime dependencies"
+    description: "name of the requirements file to install"
     required: false
     default: requirements-dev.txt
 

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -37,8 +37,8 @@ runs:
     - name: Activate venv
       run: |
         source .venv/bin/activate
-        echo $PATH >> $GITHUB_PATH
-        echo PATH=$PATH >> $GITHUB_ENV
-        echo VIRTUAL_ENV=$VIRTUAL_ENV >> $GITHUB_ENV
-        echo PYTHONHOME=$PYTHONHOME >> $GITHUB_ENV
+        echo "$PATH" >> "$GITHUB_PATH"
+        echo PATH="$PATH" >> "$GITHUB_ENV"
+        echo VIRTUAL_ENV="$VIRTUAL_ENV" >> "$GITHUB_ENV"
+        echo PYTHONHOME="$PYTHONHOME" >> "$GITHUB_ENV"
       shell: bash

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -20,7 +20,7 @@ runs:
         install_dev: ${{ inputs.install-dev-requirements }}
       run: |
         if [[ $install_dev == 'true' ]]; then \
-          REQUIREMENTS_TXT='requirements-dev.txt' \
+          REQUIREMENTS_TXT='requirements-dev.txt'; \
         else REQUIREMENTS_TXT='requirements.txt'; fi
 
         echo "requirements_txt=$REQUIREMENTS_TXT" >> $GITHUB_ENV

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -11,6 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup python
+      id: python
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
@@ -20,7 +21,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ hashFiles( 'requirements*.txt' ) }}
+        key: venv-${{ runner.os }}-${{ steps.python.outputs.python-version }}-${{ hashFiles( 'requirements*.txt' ) }}
 
     - name: Install dependencies
       run: |

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -32,12 +32,10 @@ runs:
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
 
     - name: Install dependencies
-      env:
-        requirements_txt: ${{ inputs.requirements-file }}
       run: |
         python -m venv .venv
         source .venv/bin/activate
-        pip install -r $requirements_txt
+        pip install -r "${{ inputs.requirements-file }}"
       shell: bash
       if: steps.cache-virtualenv.outputs.cache-hit != 'true'
 

--- a/.github/setup_python/action.yml
+++ b/.github/setup_python/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ hashFiles( requirements*.txt ) }}
+        key: venv-${{ runner.os }}-${{ hashFiles( 'requirements*.txt' ) }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Setup python
         uses: ./.github/setup_python
         with:
-          install-dev-requirements: false
+          requirements-file: requirements-dev.txt
 
       - name: Setup nodejs
         uses: ./.github/setup_nodejs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Setup python
         uses: ./.github/setup_python
         with:
-          install-dev-dependencies: false
+          requirements-file: requirements.txt
 
       - name: Setup nodejs
         uses: ./.github/setup_nodejs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Setup python
         uses: ./.github/setup_python
         with:
-          requirements-file: requirements.txt
+          install-dev-dependencies: true
 
       - name: Setup nodejs
         uses: ./.github/setup_nodejs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,6 +145,8 @@ jobs:
 
       - name: Setup python
         uses: ./.github/setup_python
+        with:
+          install-dev-requirements: false
 
       - name: Setup nodejs
         uses: ./.github/setup_nodejs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Setup python
         uses: ./.github/setup_python
         with:
-          requirements-file: requirements-dev.txt
+          requirements-file: requirements.txt
 
       - name: Setup nodejs
         uses: ./.github/setup_nodejs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Setup python
         uses: ./.github/setup_python
         with:
-          install-dev-dependencies: true
+          install-dev-dependencies: false
 
       - name: Setup nodejs
         uses: ./.github/setup_nodejs


### PR DESCRIPTION
fix #2113

does not (yet?) remove dependency to external venv caching action.