### PR TITLE
Fix underline text-decorations on results pages

### DIFF
--- a/evap/static/scss/components/_grid.scss
+++ b/evap/static/scss/components/_grid.scss
@@ -70,7 +70,9 @@
 
     @at-root a#{&} {
         color: $black;
-        text-decoration: none;
+        &:hover {
+            text-decoration: none;
+        }
     }
 
     @include media-breakpoint-up(lg) {


### PR DESCRIPTION
fixes #2115

As described in the issue, both the bootstrap selector that adds `text-decoration: underline` and our selector that removes it are equally selective.

The current code fixes this by also making our selector require `:hover`, thus making it more selective. Possibly downside: We don't set `text-decoration: none` for not hovered anchors anymore (but that isn't a problem with firefox and chrome in my tests?)

As an alternative, we could also use `!important` -- I was just hesitant about this.
Maybe we instead want to have `text-decoration: none` for both selectors, with and without `:hover`. I couldn't get scss to generate that, though (I have no idea what I'm doing)