### PR TITLE
Fix broken javascript id selector on evaluation operation page

### DIFF
--- a/evap/staff/templates/staff_email_preview_form.html
+++ b/evap/staff/templates/staff_email_preview_form.html
@@ -3,10 +3,10 @@
          {% if heading %}<h4 class="card-title">{{ heading }}</h4>{% endif %}
         <div class="form-check mb-2">
             <input class="form-check-input" id="send_email{{ id_suffix }}" type="checkbox" name="send_email{{ id_suffix }}"
-                checked onclick="document.getElementById('email_form').classList.toggle('d-none');" />
+                checked onclick="document.getElementById('email_form{{ id_suffix }}').classList.toggle('d-none');" />
             <label class="form-check-label" for="send_email{{ id_suffix }}">{% translate 'Send email notifications' %}</label>
         </div>
-        <div class="email-form" id="email_form{{ id_suffix}}">
+        <div class="email-form" id="email_form{{ id_suffix }}">
             <div class="mb-3 d-flex">
                 <div class="form-label pe-4">{% translate 'Email subject' %}</div>
                 <div class="form-field"><input class="form-control" name="email_subject{{ id_suffix }}" type="text" value="{{ email_template.subject }}" /></div>


### PR DESCRIPTION
Fixes #2126 -- I accidentally removed the id suffix on the javascript function in #2013 in https://github.com/e-valuation/EvaP/pull/2013/commits/414f78e79368c402e5d36539b7883c661ad900ae#diff-2aa77ac31391a590518c641000cf37d44ac9e72948731264bd1c427f69c3915cR6