### PR TITLE
reset evaluation after it started

### DIFF
--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -98,7 +98,7 @@ class TestContributorEvaluationView(WebTestWith200Check):
         cls.url = f"/contributor/evaluation/{cls.evaluation.pk}"
 
     def test_wrong_state(self):
-        self.evaluation.revert_to_new()
+        self.evaluation.reset_to_new()
         self.evaluation.save()
         self.app.get(self.url, user=self.responsible, status=403)
 
@@ -125,7 +125,7 @@ class TestContributorEvaluationPreviewView(WebTestWith200Check):
         cls.url = f"/contributor/evaluation/{cls.evaluation.pk}/preview"
 
     def test_wrong_state(self):
-        self.evaluation.revert_to_new()
+        self.evaluation.reset_to_new()
         self.evaluation.save()
         self.app.get(self.url, user=self.responsible, status=403)
 

--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -98,7 +98,7 @@ class TestContributorEvaluationView(WebTestWith200Check):
         cls.url = f"/contributor/evaluation/{cls.evaluation.pk}"
 
     def test_wrong_state(self):
-        self.evaluation.reset_to_new()
+        self.evaluation.reset_to_new(delete_previous_answers=False)
         self.evaluation.save()
         self.app.get(self.url, user=self.responsible, status=403)
 
@@ -125,7 +125,7 @@ class TestContributorEvaluationPreviewView(WebTestWith200Check):
         cls.url = f"/contributor/evaluation/{cls.evaluation.pk}/preview"
 
     def test_wrong_state(self):
-        self.evaluation.reset_to_new()
+        self.evaluation.reset_to_new(delete_previous_answers=False)
         self.evaluation.save()
         self.app.get(self.url, user=self.responsible, status=403)
 

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -711,9 +711,24 @@ class Evaluation(LoggedModel):
     def manager_approve(self):
         pass
 
-    @transition(field=state, source=[State.PREPARED, State.EDITOR_APPROVED, State.APPROVED], target=State.NEW)
-    def revert_to_new(self):
-        pass
+    @transition(
+        field=state,
+        source=[
+            State.PREPARED,
+            State.EDITOR_APPROVED,
+            State.APPROVED,
+            State.IN_EVALUATION,
+            State.EVALUATED,
+            State.REVIEWED,
+        ],
+        target=State.NEW,
+    )
+    def reset_to_new(self, delete_previous_answers: bool | None = False):
+        """Reset an Evaluation after it started (#1991)"""
+        if delete_previous_answers:
+            for answer_class in Answer.__subclasses__():
+                answer_class._default_manager.filter(contribution__evaluation_id=self.id).delete()
+            self.voters.clear()
 
     @transition(
         field=state,

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -617,6 +617,12 @@ class Evaluation(LoggedModel):
             return self.is_user_responsible_or_contributor_or_delegate(user)
         return self.can_be_seen_by(user)
 
+    def can_reset_to_new(self):
+        """Is it possible to execute .reset_to_new() for this evaluation?"""
+        return any(
+            state_transition.name == "reset_to_new" for state_transition in self.get_available_state_transitions()
+        )  # get_available_<fieldname>_transitions() is available for all fsm-fields on a class
+
     @property
     def can_be_edited_by_manager(self):
         return not self.participations_are_archived and self.state < Evaluation.State.PUBLISHED

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -617,6 +617,7 @@ class Evaluation(LoggedModel):
             return self.is_user_responsible_or_contributor_or_delegate(user)
         return self.can_be_seen_by(user)
 
+    @property
     def can_reset_to_new(self):
         allowed_sources = [
             Evaluation.State.PREPARED,

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -729,7 +729,7 @@ class Evaluation(LoggedModel):
         target=State.NEW,
         conditions=[lambda self: not self.is_single_result],
     )
-    def reset_to_new(self, *, delete_previous_answers: bool | None):
+    def reset_to_new(self, *, delete_previous_answers: bool):
         if delete_previous_answers:
             for answer_class in Answer.__subclasses__():
                 answer_class._default_manager.filter(contribution__evaluation_id=self.id).delete()

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -728,7 +728,7 @@ class Evaluation(LoggedModel):
         ],
         target=State.NEW,
     )
-    def reset_to_new(self, delete_previous_answers: bool):
+    def reset_to_new(self, *, delete_previous_answers: bool):
         if delete_previous_answers:
             for answer_class in Answer.__subclasses__():
                 answer_class._default_manager.filter(contribution__evaluation_id=self.id).delete()

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -728,7 +728,7 @@ class Evaluation(LoggedModel):
         ],
         target=State.NEW,
     )
-    def reset_to_new(self, *, delete_previous_answers: bool):
+    def reset_to_new(self, *, delete_previous_answers: bool | None):
         if delete_previous_answers:
             for answer_class in Answer.__subclasses__():
                 answer_class._default_manager.filter(contribution__evaluation_id=self.id).delete()

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -618,7 +618,6 @@ class Evaluation(LoggedModel):
         return self.can_be_seen_by(user)
 
     def can_reset_to_new(self):
-        """Is it possible to execute .reset_to_new() for this evaluation?"""
         return any(
             state_transition.name == "reset_to_new" for state_transition in self.get_available_state_transitions()
         )  # get_available_<fieldname>_transitions() is available for all fsm-fields on a class
@@ -729,8 +728,7 @@ class Evaluation(LoggedModel):
         ],
         target=State.NEW,
     )
-    def reset_to_new(self, delete_previous_answers: bool | None = False):
-        """Reset an Evaluation after it started (#1991)"""
+    def reset_to_new(self, delete_previous_answers: bool):
         if delete_previous_answers:
             for answer_class in Answer.__subclasses__():
                 answer_class._default_manager.filter(contribution__evaluation_id=self.id).delete()

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -619,15 +619,7 @@ class Evaluation(LoggedModel):
 
     @property
     def can_reset_to_new(self):
-        allowed_sources = [
-            Evaluation.State.PREPARED,
-            Evaluation.State.EDITOR_APPROVED,
-            Evaluation.State.APPROVED,
-            Evaluation.State.IN_EVALUATION,
-            Evaluation.State.EVALUATED,
-            Evaluation.State.REVIEWED,
-        ]
-        return self.state in allowed_sources and not self.is_single_result
+        return Evaluation.State.PREPARED <= self.state <= Evaluation.State.REVIEWED and not self.is_single_result
 
     @property
     def can_be_edited_by_manager(self):

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -727,6 +727,7 @@ class Evaluation(LoggedModel):
             State.REVIEWED,
         ],
         target=State.NEW,
+        conditions=[lambda self: not self.is_single_result],
     )
     def reset_to_new(self, *, delete_previous_answers: bool | None):
         if delete_previous_answers:

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -719,7 +719,7 @@ class Evaluation(LoggedModel):
     def reset_to_new(self, *, delete_previous_answers: bool):
         if delete_previous_answers:
             for answer_class in Answer.__subclasses__():
-                answer_class._default_manager.filter(contribution__evaluation_id=self.id).delete()
+                answer_class._default_manager.filter(contribution__evaluation=self).delete()
             self.voters.clear()
 
     @transition(

--- a/evap/evaluation/tests/test_views.py
+++ b/evap/evaluation/tests/test_views.py
@@ -279,6 +279,9 @@ class TestResetEvaluation(WebTestStaffMode):
             Evaluation.State.PREPARED,
             Evaluation.State.EDITOR_APPROVED,
             Evaluation.State.APPROVED,
+            Evaluation.State.IN_EVALUATION,
+            Evaluation.State.EVALUATED,
+            Evaluation.State.REVIEWED,
         ]
 
         for s in valid_start_states:

--- a/evap/evaluation/tests/test_views.py
+++ b/evap/evaluation/tests/test_views.py
@@ -257,7 +257,7 @@ class TestResetEvaluation(WebTestStaffMode):
         cls.semester = baker.make(Semester)
         cls.url = reverse("staff:semester_view", args=[cls.semester.pk])
 
-    def reset_from_x_to_new(self, x, success_expected: bool) -> None:
+    def reset_from_x_to_new(self, x: Evaluation.State, success_expected: bool) -> None:
         evaluation = baker.make(Evaluation, state=x, course__semester=self.semester)
 
         semester_overview_page = self.app.get(self.url, user=self.manager, status=200)

--- a/evap/evaluation/tests/test_views.py
+++ b/evap/evaluation/tests/test_views.py
@@ -250,7 +250,6 @@ class TestNotebookView(WebTest):
 
 
 class TestResetEvaluation(WebTestStaffMode):
-
     @classmethod
     def setUpTestData(cls) -> None:
         cls.manager = make_manager()

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -55,9 +55,53 @@
         {% endif %}
         <input type="hidden" name="target_state" value="{{ target_state }}" />
 
+        {% if show_delete_answers_checkbox %}
+            <div class="card mb-3">
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" name="delete-previous-answers"
+                                       id="delete-previous-answers" checked>
+                                <label class="form-check-label" for="delete-previous-answers">
+                                    {% trans "Delete previous answers" %}
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+
         <div class="card card-submit-area card-submit-area-2 text-center mb-3">
             <div class="card-body">
-                <button type="submit" class="btn btn-primary">{% translate 'Confirm' %}</button>
+                <confirmation-modal type="submit" form="evaluation-operation-form" id="confirmation-modal">
+                    <span slot="title">{% translate 'Reset Evaluation' %}</span>
+                    <span slot="action-text">{% translate 'Reset Evaluation' %}</span>
+                    <span slot="question">
+                        {% blocktranslate trimmed %}
+                            This will delete all previously received answers. Evaluation participants will have to
+                            resubmit their answers.
+                        {% endblocktranslate %}
+                        <span slot="show-button" class="d-none"></span>
+                    </span>
+                </confirmation-modal>
+                <button id="form-confirmation-btn" type="button"
+                        class="btn btn-primary">{% translate 'Confirm' %}</button>
+                <script>
+                    /** @type ConfirmationModal */
+                    const modal = document.getElementById("confirmation-modal");
+                    /** @type HTMLFormElement */
+                    const form = document.getElementById("evaluation-operation-form");
+
+                    document.getElementById("form-confirmation-btn").addEventListener("click", () => {
+                        if (document.getElementById("delete-previous-answers").checked) {
+                            modal.dialog.showModal();
+                        } else {
+                            form.requestSubmit();
+                        }
+                    });
+                </script>
                 <a href="{% url 'staff:semester_view' semester.id %}" class="btn btn-light">{% translate 'Cancel' %}</a>
             </div>
         </div>

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -6,7 +6,7 @@
     <form id="evaluation-operation-form" method="POST" class="form-horizontal">
         {% csrf_token %}
         {% for evaluation in evaluations %}
-            <input type="hidden" name="evaluation" value="{{ evaluation.id }}"/>
+            <input type="hidden" name="evaluation" value="{{ evaluation.id }}">
         {% endfor %}
 
         <div class="card mb-3">
@@ -14,15 +14,15 @@
                 <p>{{ confirmation_message }}</p>
                 <table class="table table-striped table-vertically-aligned">
                     <colgroup>
-                        <col style="width: 2.75em"/>
-                        <col style="width: 1.25em"/>
-                        <col style="width: 1.25em"/>
-                        <col style="width: 1.25em"/>
-                        <col style="width: 1.25em"/>
-                        <col style=""/>
-                        <col style="width: 12.25em"/>
-                        <col style="width: 12em"/>
-                        <col style="width: 9em"/>
+                        <col style="width: 2.75em">
+                        <col style="width: 1.25em">
+                        <col style="width: 1.25em">
+                        <col style="width: 1.25em">
+                        <col style="width: 1.25em">
+                        <col style="">
+                        <col style="width: 12.25em">
+                        <col style="width: 12em">
+                        <col style="width: 9em">
                     </colgroup>
                     <tbody>
                     {% for evaluation in evaluations %}
@@ -53,7 +53,7 @@
                 {% endif %}
             </div>
         {% endif %}
-        <input type="hidden" name="target_state" value="{{ target_state }}"/>
+        <input type="hidden" name="target_state" value="{{ target_state }}">
 
         {% if show_delete_answers_checkbox %}
             <div class="card mb-3">

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -61,8 +61,7 @@
                     <div class="row">
                         <div class="col">
                             <div class="form-check">
-                                <input class="form-check-input" type="checkbox" name="delete-previous-answers"
-                                       id="delete-previous-answers" checked>
+                                <input class="form-check-input" type="checkbox" name="delete-previous-answers" id="delete-previous-answers" checked>
                                 <label class="form-check-label" for="delete-previous-answers">
                                     {% trans "Delete previous answers" %}
                                 </label>
@@ -90,8 +89,7 @@
                     {% endcomment %}
                     <span slot="show-button"></span>
                 </confirmation-modal>
-                <button id="form-confirmation-btn" type="button"
-                        class="btn btn-primary">{% translate 'Confirm' %}</button>
+                <button id="form-confirmation-btn" type="button" class="btn btn-primary">{% translate 'Confirm' %}</button>
                 <script>
                     /** @type ConfirmationModal */
                     const modal = document.getElementById("confirmation-modal");

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -70,10 +70,9 @@
 
         <div class="card card-submit-area card-submit-area-2 text-center mb-3">
             <div class="card-body">
-            {% if show_delete_answers_checkbox %}
-                <confirmation-modal type="submit" id="confirmation-modal">
+                <confirmation-modal type="submit" data-allow-answer-deletion>
                     <span slot="title">{% translate 'Reset Evaluation' %}</span>
-                    <button slot="submit-group" class="btn ms-2 btn-danger" data-event-type="confirm">
+                    <button slot="submit-group" class="btn ms-2 btn-danger" data-event-type="confirm" data-confirm-answer-deletion>
                         {% translate 'Reset Evaluation' %}
                     </button>
                     <span slot="question">
@@ -87,24 +86,16 @@
                     {% endcomment %}
                     <span slot="show-button"></span>
                 </confirmation-modal>
-                <button id="form-confirmation-btn" type="button" class="btn btn-primary">{% translate 'Confirm' %}</button>
+                <button type="submit" class="btn btn-primary">{% translate 'Confirm' %}</button>
                 <script>
-                    /** @type ConfirmationModal */
-                    const modal = document.getElementById("confirmation-modal");
-                    /** @type HTMLFormElement */
-                    const form = document.getElementById("evaluation-operation-form");
-
-                    document.getElementById("form-confirmation-btn").addEventListener("click", () => {
-                        if (document.getElementById("delete-previous-answers").checked) {
-                            modal.dialog.showModal();
-                        } else {
-                            form.requestSubmit();
+                    document.getElementById("evaluation-operation-form").addEventListener("submit", submitEvent => {
+                        const data = new FormData(submitEvent.target);
+                        if (data.get("delete-previous-answers") === "on" && !submitEvent.submitter?.hasAttribute("data-confirm-answer-deletion")) {
+                            submitEvent.preventDefault()
+                            submitEvent.target.querySelector("confirmation-modal[data-allow-answer-deletion]").dialog.showModal();
                         }
-                    });
+                    })
                 </script>
-            {% else %}
-                <button id="form-confirmation-btn" type="submit" class="btn btn-primary">{% translate 'Confirm' %}</button>
-            {% endif %}
                 <a href="{% url 'staff:semester_view' semester.id %}" class="btn btn-light">{% translate 'Cancel' %}</a>
             </div>
         </div>

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -59,8 +59,8 @@
             <div class="card mb-3">
                 <div class="card-body">
                     <div class="form-check">
-                        <input class="form-check-input" type="checkbox" name="delete-previous-answers" id="delete-previous-answers" checked>
-                        <label class="form-check-label" for="delete-previous-answers">
+                        <label class="form-check-label">
+                            <input class="form-check-input" type="checkbox" name="delete-previous-answers" checked>
                             {% trans "Delete previous answers" %}
                         </label>
                     </div>

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -6,7 +6,7 @@
     <form id="evaluation-operation-form" method="POST" class="form-horizontal">
         {% csrf_token %}
         {% for evaluation in evaluations %}
-            <input type="hidden" name="evaluation" value="{{ evaluation.id }}">
+            <input type="hidden" name="evaluation" value="{{ evaluation.id }}" />
         {% endfor %}
 
         <div class="card mb-3">
@@ -14,15 +14,15 @@
                 <p>{{ confirmation_message }}</p>
                 <table class="table table-striped table-vertically-aligned">
                     <colgroup>
-                        <col style="width: 2.75em">
-                        <col style="width: 1.25em">
-                        <col style="width: 1.25em">
-                        <col style="width: 1.25em">
-                        <col style="width: 1.25em">
-                        <col style="">
-                        <col style="width: 12.25em">
-                        <col style="width: 12em">
-                        <col style="width: 9em">
+                        <col style="width: 2.75em" />
+                        <col style="width: 1.25em" />
+                        <col style="width: 1.25em" />
+                        <col style="width: 1.25em" />
+                        <col style="width: 1.25em" />
+                        <col style="" />
+                        <col style="width: 12.25em" />
+                        <col style="width: 12em" />
+                        <col style="width: 9em" />
                     </colgroup>
                     <tbody>
                     {% for evaluation in evaluations %}
@@ -53,14 +53,14 @@
                 {% endif %}
             </div>
         {% endif %}
-        <input type="hidden" name="target_state" value="{{ target_state }}">
+        <input type="hidden" name="target_state" value="{{ target_state }}" />
 
         {% if show_delete_answers_checkbox %}
             <div class="card mb-3">
                 <div class="card-body">
                     <div class="form-check">
                         <label class="form-check-label">
-                            <input class="form-check-input" type="checkbox" name="delete-previous-answers" checked>
+                            <input class="form-check-input" type="checkbox" name="delete-previous-answers" checked />
                             {% trans "Delete previous answers" %}
                         </label>
                     </div>

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -58,15 +58,11 @@
         {% if show_delete_answers_checkbox %}
             <div class="card mb-3">
                 <div class="card-body">
-                    <div class="row">
-                        <div class="col">
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" name="delete-previous-answers" id="delete-previous-answers" checked>
-                                <label class="form-check-label" for="delete-previous-answers">
-                                    {% trans "Delete previous answers" %}
-                                </label>
-                            </div>
-                        </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" name="delete-previous-answers" id="delete-previous-answers" checked>
+                        <label class="form-check-label" for="delete-previous-answers">
+                            {% trans "Delete previous answers" %}
+                        </label>
                     </div>
                 </div>
             </div>

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -83,8 +83,10 @@
                             This will delete all previously received answers. Evaluation participants will have to
                             resubmit their answers.
                         {% endblocktranslate %}
-                        <span slot="show-button" class="d-none"></span>
                     </span>
+                    {# The modal needs an element in the slot, otherwise it throws an error.
+                       No button is needed, as the modal is conditionally shown via JS.     #}
+                    <span slot="show-button"></span>
                 </confirmation-modal>
                 <button id="form-confirmation-btn" type="button"
                         class="btn btn-primary">{% translate 'Confirm' %}</button>

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -75,8 +75,7 @@
                     <span slot="action-text">{% translate 'Reset Evaluation' %}</span>
                     <span slot="question">
                         {% blocktranslate trimmed %}
-                            This will delete all previously received answers. Evaluation participants will have to
-                            resubmit their answers.
+                            This will delete all previously received answers. Voters will have to resubmit the evaluation.
                         {% endblocktranslate %}
                     </span>
                     {% comment %}

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -6,7 +6,7 @@
     <form id="evaluation-operation-form" method="POST" class="form-horizontal">
         {% csrf_token %}
         {% for evaluation in evaluations %}
-            <input type="hidden" name="evaluation" value="{{ evaluation.id }}" />
+            <input type="hidden" name="evaluation" value="{{ evaluation.id }}"/>
         {% endfor %}
 
         <div class="card mb-3">
@@ -14,15 +14,15 @@
                 <p>{{ confirmation_message }}</p>
                 <table class="table table-striped table-vertically-aligned">
                     <colgroup>
-                        <col style="width: 2.75em" />
-                        <col style="width: 1.25em" />
-                        <col style="width: 1.25em" />
-                        <col style="width: 1.25em" />
-                        <col style="width: 1.25em" />
-                        <col style="" />
-                        <col style="width: 12.25em" />
-                        <col style="width: 12em" />
-                        <col style="width: 9em" />
+                        <col style="width: 2.75em"/>
+                        <col style="width: 1.25em"/>
+                        <col style="width: 1.25em"/>
+                        <col style="width: 1.25em"/>
+                        <col style="width: 1.25em"/>
+                        <col style=""/>
+                        <col style="width: 12.25em"/>
+                        <col style="width: 12em"/>
+                        <col style="width: 9em"/>
                     </colgroup>
                     <tbody>
                     {% for evaluation in evaluations %}
@@ -53,7 +53,7 @@
                 {% endif %}
             </div>
         {% endif %}
-        <input type="hidden" name="target_state" value="{{ target_state }}" />
+        <input type="hidden" name="target_state" value="{{ target_state }}"/>
 
         {% if show_delete_answers_checkbox %}
             <div class="card mb-3">
@@ -84,8 +84,10 @@
                             resubmit their answers.
                         {% endblocktranslate %}
                     </span>
-                    {# The modal needs an element in the slot, otherwise it throws an error.
-                       No button is needed, as the modal is conditionally shown via JS.     #}
+                    {% comment %}
+                        The modal needs an element in the slot, otherwise it throws an error.
+                        No button is needed, as the modal is conditionally shown via JS.
+                    {% endcomment %}
                     <span slot="show-button"></span>
                 </confirmation-modal>
                 <button id="form-confirmation-btn" type="button"

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -71,7 +71,7 @@
         <div class="card card-submit-area card-submit-area-2 text-center mb-3">
             <div class="card-body">
             {% if show_delete_answers_checkbox %}
-                <confirmation-modal type="submit" form="evaluation-operation-form" id="confirmation-modal">
+                <confirmation-modal type="submit" id="confirmation-modal">
                     <span slot="title">{% translate 'Reset Evaluation' %}</span>
                     <button slot="submit-group" class="btn ms-2 btn-danger" data-event-type="confirm">
                         {% translate 'Reset Evaluation' %}

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -70,6 +70,7 @@
 
         <div class="card card-submit-area card-submit-area-2 text-center mb-3">
             <div class="card-body">
+            {% if show_delete_answers_checkbox %}
                 <confirmation-modal type="submit" form="evaluation-operation-form" id="confirmation-modal">
                     <span slot="title">{% translate 'Reset Evaluation' %}</span>
                     <span slot="action-text">{% translate 'Reset Evaluation' %}</span>
@@ -99,6 +100,9 @@
                         }
                     });
                 </script>
+            {% else %}
+                <button id="form-confirmation-btn" type="submit" class="btn btn-primary">{% translate 'Confirm' %}</button>
+            {% endif %}
                 <a href="{% url 'staff:semester_view' semester.id %}" class="btn btn-light">{% translate 'Cancel' %}</a>
             </div>
         </div>

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -70,7 +70,7 @@
 
         <div class="card card-submit-area card-submit-area-2 text-center mb-3">
             <div class="card-body">
-                <confirmation-modal type="submit" data-allow-answer-deletion>
+                <confirmation-modal type="submit">
                     <span slot="title">{% translate 'Reset Evaluation' %}</span>
                     <button slot="submit-group" class="btn ms-2 btn-danger" data-event-type="confirm" data-confirm-answer-deletion>
                         {% translate 'Reset Evaluation' %}
@@ -92,7 +92,7 @@
                         const data = new FormData(submitEvent.target);
                         if (data.get("delete-previous-answers") === "on" && !submitEvent.submitter?.hasAttribute("data-confirm-answer-deletion")) {
                             submitEvent.preventDefault()
-                            submitEvent.target.querySelector("confirmation-modal[data-allow-answer-deletion]").dialog.showModal();
+                            submitEvent.target.querySelector("confirmation-modal:has([data-confirm-answer-deletion])").dialog.showModal();
                         }
                     })
                 </script>

--- a/evap/staff/templates/staff_evaluation_operation.html
+++ b/evap/staff/templates/staff_evaluation_operation.html
@@ -73,7 +73,9 @@
             {% if show_delete_answers_checkbox %}
                 <confirmation-modal type="submit" form="evaluation-operation-form" id="confirmation-modal">
                     <span slot="title">{% translate 'Reset Evaluation' %}</span>
-                    <span slot="action-text">{% translate 'Reset Evaluation' %}</span>
+                    <button slot="submit-group" class="btn ms-2 btn-danger" data-event-type="confirm">
+                        {% translate 'Reset Evaluation' %}
+                    </button>
                     <span slot="question">
                         {% blocktranslate trimmed %}
                             This will delete all previously received answers. Voters will have to resubmit the evaluation.

--- a/evap/staff/templates/staff_semester_view_evaluation.html
+++ b/evap/staff/templates/staff_semester_view_evaluation.html
@@ -5,9 +5,10 @@
 
 <td>
     {% if request.user.is_manager and not info_only and not semester.participations_are_archived %}
-        <!-- TODO: was this there for a reason? -->
-        <div class="form-check" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Select for evaluation operation' %}">
-            <input class="form-check-input" type="checkbox" name="evaluation" id="evaluation{{ evaluation.id }}" value="{{ evaluation.id }}" />
+        <div class="form-check" data-bs-toggle="tooltip" data-bs-placement="top"
+             title="{% translate 'Select for evaluation operation' %}">
+            <input class="form-check-input" type="checkbox" name="evaluation" id="evaluation{{ evaluation.id }}"
+                   value="{{ evaluation.id }}" />
             <label class="form-check-label" for="evaluation{{ evaluation.id }}"></label>
         </div>
     {% endif %}

--- a/evap/staff/templates/staff_semester_view_evaluation.html
+++ b/evap/staff/templates/staff_semester_view_evaluation.html
@@ -5,12 +5,11 @@
 
 <td>
     {% if request.user.is_manager and not info_only and not semester.participations_are_archived %}
-        {% if state <= evaluation.State.APPROVED or state >= evaluation.State.REVIEWED %}
-            <div class="form-check" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Select for evaluation operation' %}">
-                <input class="form-check-input" type="checkbox" name="evaluation" id="evaluation{{ evaluation.id }}" value="{{ evaluation.id }}" />
-                <label class="form-check-label" for="evaluation{{ evaluation.id }}"></label>
-            </div>
-        {% endif %}
+        <!-- TODO: was this there for a reason? -->
+        <div class="form-check" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Select for evaluation operation' %}">
+            <input class="form-check-input" type="checkbox" name="evaluation" id="evaluation{{ evaluation.id }}" value="{{ evaluation.id }}" />
+            <label class="form-check-label" for="evaluation{{ evaluation.id }}"></label>
+        </div>
     {% endif %}
 </td>
 

--- a/evap/staff/templates/staff_semester_view_evaluation.html
+++ b/evap/staff/templates/staff_semester_view_evaluation.html
@@ -5,10 +5,8 @@
 
 <td>
     {% if request.user.is_manager and not info_only and not semester.participations_are_archived %}
-        <div class="form-check" data-bs-toggle="tooltip" data-bs-placement="top"
-             title="{% translate 'Select for evaluation operation' %}">
-            <input class="form-check-input" type="checkbox" name="evaluation" id="evaluation{{ evaluation.id }}"
-                   value="{{ evaluation.id }}" />
+        <div class="form-check" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Select for evaluation operation' %}">
+            <input class="form-check-input" type="checkbox" name="evaluation" id="evaluation{{ evaluation.id }}" value="{{ evaluation.id }}"/>
             <label class="form-check-label" for="evaluation{{ evaluation.id }}"></label>
         </div>
     {% endif %}

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -298,8 +298,8 @@ class ResetToNewOperation(EvaluationOperation):
     @staticmethod
     def warning_for_inapplicables(amount):
         return ngettext(
-            "{} evaluation cannot be reset, because it is already published. It was removed from the selection",
-            "{} evaluations cannot be reset, because they were already published. They were removed from the selection.",
+            "{} evaluation cannot be reset, because it is already in preparation or published. It was removed from the selection",
+            "{} evaluations cannot be reset, because they were already in preparation or published. They were removed from the selection.",
             amount,
         ).format(amount)
 

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -316,7 +316,7 @@ class ResetToNewOperation(EvaluationOperation):
         assert email_template_participant is None
 
         for evaluation in evaluations:
-            evaluation.reset_to_new(delete_previous_answers)
+            evaluation.reset_to_new(delete_previous_answers=delete_previous_answers)
             evaluation.save()
         messages.success(
             request,

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -293,7 +293,7 @@ class ResetToNewOperation(EvaluationOperation):
 
     @staticmethod
     def applicable_to(evaluation: Evaluation):
-        return evaluation.can_reset_to_new()
+        return evaluation.can_reset_to_new
 
     @staticmethod
     def warning_for_inapplicables(amount: int):

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -288,8 +288,7 @@ class ResetToNewOperation(EvaluationOperation):
 
     @staticmethod
     def applicable_to(evaluation: Evaluation):
-        # TODO: maybe move this into a helper function?
-        return any(t.name == 'reset_to_new' for t in evaluation.get_available_state_transitions())
+        return evaluation.can_reset_to_new()
 
     @staticmethod
     def warning_for_inapplicables(amount):

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -283,18 +283,19 @@ class EvaluationOperation:
         raise NotImplementedError
 
 
-class RevertToNewOperation(EvaluationOperation):
-    confirmation_message = gettext_lazy("Do you want to revert the following evaluations to preparation?")
+class ResetToNewOperation(EvaluationOperation):
+    confirmation_message = gettext_lazy("Do you want to reset the following evaluations to preparation?")
 
     @staticmethod
-    def applicable_to(evaluation):
-        return Evaluation.State.PREPARED <= evaluation.state <= Evaluation.State.APPROVED
+    def applicable_to(evaluation: Evaluation):
+        # TODO: maybe move this into a helper function?
+        return any(t.name == 'reset_to_new' for t in evaluation.get_available_state_transitions())
 
     @staticmethod
     def warning_for_inapplicables(amount):
         return ngettext(
-            "{} evaluation cannot be reverted, because it already started. It was removed from the selection.",
-            "{} evaluations cannot be reverted, because they already started. They were removed from the selection.",
+            "{} evaluation cannot be reset, because it is already published. It was removed from the selection",
+            "{} evaluations cannot be reset, because they were already published. They were removed from the selection.",
             amount,
         ).format(amount)
 
@@ -306,13 +307,13 @@ class RevertToNewOperation(EvaluationOperation):
         assert email_template_participant is None
 
         for evaluation in evaluations:
-            evaluation.revert_to_new()
+            evaluation.reset_to_new()
             evaluation.save()
         messages.success(
             request,
             ngettext(
-                "Successfully reverted {} evaluation to in preparation.",
-                "Successfully reverted {} evaluations to in preparation.",
+                "Successfully reset {} evaluation to in preparation.",
+                "Successfully reset {} evaluations to in preparation.",
                 len(evaluations),
             ).format(len(evaluations)),
         )
@@ -486,7 +487,7 @@ class PublishOperation(EvaluationOperation):
 
 
 EVALUATION_OPERATIONS = {
-    Evaluation.State.NEW: RevertToNewOperation,
+    Evaluation.State.NEW: ResetToNewOperation,
     Evaluation.State.PREPARED: ReadyForEditorsOperation,
     Evaluation.State.IN_EVALUATION: BeginEvaluationOperation,
     Evaluation.State.REVIEWED: UnpublishOperation,

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -316,7 +316,7 @@ class ResetToNewOperation(EvaluationOperation):
         assert email_template_participant is None
 
         for evaluation in evaluations:
-            evaluation.reset_to_new(delete_previous_answers=delete_previous_answers)
+            evaluation.reset_to_new(delete_previous_answers=bool(delete_previous_answers))
             evaluation.save()
         messages.success(
             request,

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -296,10 +296,10 @@ class ResetToNewOperation(EvaluationOperation):
         return evaluation.can_reset_to_new()
 
     @staticmethod
-    def warning_for_inapplicables(amount):
+    def warning_for_inapplicables(amount: int):
         return ngettext(
-            "{} evaluation cannot be reset, because it is already in preparation or published. It was removed from the selection",
-            "{} evaluations cannot be reset, because they were already in preparation or published. They were removed from the selection.",
+            "{} evaluation cannot be reset, because it is already in preparation, published, or a single result. It was removed from the selection",
+            "{} evaluations cannot be reset, because they were already in preparation, published, or a single result. They were removed from the selection.",
             amount,
         ).format(amount)
 


### PR DESCRIPTION
Closes #1991 
Replaces the `revert_to_new` evaluation operation with `reset_to_new`. It now allows resetting from any State except `NEW` and `PUBLISHED`. It also allows deleting all previously received answers.

Also, it makes `Evaluation.State` an `IntEnum`.


- [x] Only show confirmation modal when deleting previous answers
- [x] Finish Unit-Tests
- [x] Cleanup leftover TODO's