### PR TITLE
revert overflow-x-scroll on footer from #2054

### DIFF
--- a/evap/evaluation/templates/footer.html
+++ b/evap/evaluation/templates/footer.html
@@ -6,7 +6,7 @@
         <div class="vote-bg-orange" style="width: 6%;"></div>
         <div class="vote-bg-red" style="width: 3%;"></div>
     </div>
-    <nav class="navbar navbar-expand overflow-x-scroll">
+    <nav class="navbar navbar-expand">
         <div class="collapse navbar-collapse justify-content-between">
             <ul class="navbar-nav justify-content-start">
                 <li class="nav-item my-auto">


### PR DESCRIPTION
In #2054 `overflow-x-scroll` was added to the footer ("make footer horizontally scrollable on small screens; The previous behavior was the footer became wider than the screen and the entire page width was increased.")

This leads to a disabled scrollbar (only visible in some browsers on some systems, depending on the scrollbar rendering) in normal resolution, which is worse :)

![image](https://github.com/e-valuation/EvaP/assets/1781719/d64add4e-2d62-4b90-bf06-0f7c332962f9)

This PR reverts that change, but future commits are welcome. I won't open a new issue, though, because the effect only occurs on very small screens (works on my phone) and doesn't seem worth the effort.