### PR TITLE
Don't sort course_evaluations in results_evaluation_detail.html again

### DIFF
--- a/evap/results/templates/results_evaluation_detail.html
+++ b/evap/results/templates/results_evaluation_detail.html
@@ -134,7 +134,7 @@
                 </div>
                 {% if course_evaluations %}
                     {% include 'results_index_course.html' with evaluations=course_evaluations %}
-                    {% for course_evaluation in course_evaluations|dictsort:"name" %}
+                    {% for course_evaluation in course_evaluations %}
                         {% if course_evaluation.pk == evaluation.pk %}
                             {# we cannot add a class to the actual row because it is cached globally. so we use a + selector in css to style the following row. #}
                             <div class="current-row-follows"></div>

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -567,6 +567,24 @@ class TestResultsSemesterEvaluationDetailView(WebTestStaffMode):
         self.app.get(self.url + "?contributor_id=asd", user=self.manager, status=400)
         self.app.get(self.url + "?contributor_id=1234", user=self.manager, status=404)
 
+    def test_evaluation_sorting(self):
+        names = ["EvaluationB", "EvaluationA", "EvaluationC"]
+        additional_evaluations = baker.make(
+            Evaluation,
+            state=Evaluation.State.PUBLISHED,
+            course=self.evaluation.course,
+            _quantity=3,
+            _bulk_create=True,
+            name_en=iter(names),
+            name_de=iter(names),
+        )
+
+        for evaluation in (self.evaluation, *additional_evaluations):
+            cache_results(evaluation)
+
+        body = self.app.get(self.url, user=self.manager).body.decode()
+        self.assertTrue(body.find("EvaluationA") < body.find("EvaluationB") < body.find("EvaluationC"))
+
 
 class TestResultsSemesterEvaluationDetailViewFewVoters(WebTest):
     @classmethod


### PR DESCRIPTION
It is already sorted in the view:
https://github.com/e-valuation/EvaP/blob/b57ee63d84c88d13664630f758312b10c141caa3/evap/results/views.py#L183