### PR TITLE
Reraise exceptions when debugging

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -2062,14 +2062,15 @@ class EmailTemplate(models.Model):
     def send_to_user(self, user, subject_params, body_params, use_cc, additional_cc_users=(), request=None):
         if not user.email:
             message = gettext_noop("{} has no email address defined. Could not send email.")
-            level = logging.ERROR
+            log_message = message.format(user.full_name_with_additional_info)
             # If this method is triggered by a cronjob changing evaluation states, the request is None.
             # In this case warnings should be sent to the admins via email (configured in the settings for logger.error).
             # If a request exists, the page is displayed in the browser and the message can be shown on the page (messages.warning).
             if request is not None:
-                level = logging.WARNING
+                logger.warning(log_message)
                 messages.warning(request, _(message).format(user.full_name_with_additional_info))
-            logger.log(level, message.format(user.full_name_with_additional_info))
+            else:
+                logger.error(log_message)
             return
 
         cc_users = set(additional_cc_users)

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -27,7 +27,8 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.safestring import SafeData
 from django.utils.timezone import now
-from django.utils.translation import gettext_lazy as _, gettext_noop
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_noop
 from django_fsm import FSMIntegerField, transition
 from django_fsm.signals import post_transition
 

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -958,6 +958,8 @@ class Evaluation(LoggedModel):
                             evaluation_results_evaluations.append(evaluation)
                     evaluation.save()
             except Exception:  # noqa: PERF203
+                if settings.DEBUG:
+                    raise
                 logger.exception(
                     'An error occured when updating the state of evaluation "%s" (id %d).', evaluation, evaluation.id
                 )
@@ -2109,6 +2111,8 @@ class EmailTemplate(models.Model):
             if send_separate_login_url:
                 self.send_login_url_to_user(user)
         except Exception:
+            if settings.DEBUG:
+                raise
             logger.exception(
                 'An exception occurred when sending the following email to user "%s":\n%s\n',
                 user.full_name_with_additional_info,

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -2061,17 +2061,17 @@ class EmailTemplate(models.Model):
 
     def send_to_user(self, user, subject_params, body_params, use_cc, additional_cc_users=(), request=None):
         if not user.email:
-            warning_message = (
-                f"{user.full_name_with_additional_info} has no email address defined. Could not send email."
+            message = _("{} has no email address defined. Could not send email.").format(
+                user.full_name_with_additional_info
             )
             # If this method is triggered by a cronjob changing evaluation states, the request is None.
             # In this case warnings should be sent to the admins via email (configured in the settings for logger.error).
             # If a request exists, the page is displayed in the browser and the message can be shown on the page (messages.warning).
             if request is not None:
-                logger.warning(warning_message)
-                messages.warning(request, _(warning_message))
+                logger.warning(message)
+                messages.warning(request, message)
             else:
-                logger.error(warning_message)
+                logger.error(message)
             return
 
         cc_users = set(additional_cc_users)

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -100,7 +100,7 @@ def find_matching_internal_user_for_email(request, email):
     return matching_users[0]
 
 
-def bulk_update_users(request, user_file_content, test_run):  # noqa: PLR0912
+def bulk_update_users(request, user_file_content, test_run):
     # pylint: disable=too-many-branches,too-many-locals
     # user_file must have one user per line in the format "{username},{email}"
     imported_emails = {clean_email(line.decode().split(",")[1]) for line in user_file_content.splitlines()}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ ignore = [
     "COM812",                # incompatible with formatter
     "N802",                  # not as mighty as pylint's invalid-name https://github.com/astral-sh/ruff/issues/7660
     "PLR0913",               # we can't determine a good limit for arguments. reviews should spot bad cases of this.
-    "PLR2004", "PLW2901", "PLR0912"
+    "PLR2004", "PLW2901",
+    "PLR0912",             # sevaral ruff bugs: https://www.github.com/astral-sh/ruff/issues/11313, https://www.github.com/astral-sh/ruff/issues/11205
 ]
 
 ignore-init-module-imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ ignore = [
     "COM812",                # incompatible with formatter
     "N802",                  # not as mighty as pylint's invalid-name https://github.com/astral-sh/ruff/issues/7660
     "PLR0913",               # we can't determine a good limit for arguments. reviews should spot bad cases of this.
-    "PLR2004", "PLW2901"
+    "PLR2004", "PLW2901", "PLR0912"
 ]
 
 ignore-init-module-imports = true


### PR DESCRIPTION
This was raised during debugging https://github.com/e-valuation/EvaP/pull/2136, concerning `update_evaluations`. There, errors due to typeguard were silenced in the tests because of the raw except clause leading to weird test failures.
This adds checks to reraise the exceptions when debugging.