### PR TITLE
ci: track github actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,13 @@ updates:
         update-types: ["version-update:semver-minor"]
     labels:
       - "[T] Dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels:
+      - "[T] Dependencies"
+      - "[C] Tests and CI"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,4 +31,3 @@ updates:
         patterns: ["*"]
     labels:
       - "[T] Dependencies"
-      - "[C] Tests and CI"


### PR DESCRIPTION
Just saw some warnings in the [latest](https://github.com/e-valuation/EvaP/actions/runs/8790652276) ci runs, github [is deprecating](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) another node version. I never actually saw any practical incompatibilities of actions, so I told dependabot to group all ci PRs for less noise.