### PR TITLE
track all composite actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,21 @@ updates:
         patterns: ["*"]
     labels:
       - "[T] Dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/actions/setup_nodejs"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels:
+      - "[T] Dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/actions/setup_python"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels:
+      - "[T] Dependencies"


### PR DESCRIPTION
There are still actions which are not covered by dependabot... As it turns out, these need to be mentioned explicitly [dependabot/dependabot-core#4178 (comment)](https://www.github.com/dependabot/dependabot-core/issues/4178#issuecomment-1118492006) as long as there is still no wildcard support [dependabot/dependabot-core#2178](https://github.com/dependabot/dependabot-core/issues/2178). Meh