### PR TITLE
Fix django stubs 5.0.0

### DIFF
--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -12,7 +12,7 @@ from evap.staff.forms import ContributionForm
 
 
 class EvaluationForm(forms.ModelForm):
-    general_questionnaires = forms.ModelMultipleChoiceField[Questionnaire](
+    general_questionnaires: "forms.ModelMultipleChoiceField[Questionnaire]" = forms.ModelMultipleChoiceField(
         queryset=None, required=False, widget=CheckboxSelectMultiple, label=_("General questionnaires")
     )
     course = forms.ModelChoiceField(Course.objects.all(), disabled=True, required=False, widget=forms.HiddenInput())

--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -12,7 +12,7 @@ from evap.staff.forms import ContributionForm
 
 
 class EvaluationForm(forms.ModelForm):
-    general_questionnaires = forms.ModelMultipleChoiceField(
+    general_questionnaires = forms.ModelMultipleChoiceField[Questionnaire](
         queryset=None, required=False, widget=CheckboxSelectMultiple, label=_("General questionnaires")
     )
     course = forms.ModelChoiceField(Course.objects.all(), disabled=True, required=False, widget=forms.HiddenInput())

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -67,7 +67,7 @@ TEXTANSWER_REVIEW_REMINDER_WEEKDAYS = [3]
 
 # email domains for the internal users of the hosting institution used to
 # figure out who is an internal user
-INSTITUTION_EMAIL_DOMAINS = ["institution.example.com", "student.institution.example.com"]
+INSTITUTION_EMAIL_DOMAINS: list[str] = ["institution.example.com", "student.institution.example.com"]
 
 # List of tuples defining email domains that should be replaced on saving UserProfiles.
 # Emails ending on the first value will have this part replaced by the second value.

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -354,7 +354,7 @@ class CourseCopyForm(CourseFormMixin, forms.ModelForm):  # type: ignore[misc]
 
 
 class EvaluationForm(forms.ModelForm):
-    general_questionnaires = forms.ModelMultipleChoiceField(
+    general_questionnaires = forms.ModelMultipleChoiceField[Questionnaire](
         Questionnaire.objects.general_questionnaires().exclude(visibility=Questionnaire.Visibility.HIDDEN),
         widget=CheckboxSelectMultiple,
         label=_("General questions"),
@@ -573,7 +573,7 @@ class ContributionForm(forms.ModelForm):
     evaluation = forms.ModelChoiceField(
         Evaluation.objects.all(), disabled=True, required=False, widget=forms.HiddenInput()
     )
-    questionnaires = forms.ModelMultipleChoiceField(
+    questionnaires = forms.ModelMultipleChoiceField[Questionnaire](
         Questionnaire.objects.contributor_questionnaires().exclude(visibility=Questionnaire.Visibility.HIDDEN),
         required=False,
         widget=CheckboxSelectMultiple,
@@ -934,7 +934,7 @@ class UserForm(forms.ModelForm):
     is_grade_publisher = forms.BooleanField(required=False, label=_("Grade publisher"))
     is_reviewer = forms.BooleanField(required=False, label=_("Reviewer"))
     is_inactive = forms.BooleanField(required=False, label=_("Inactive"))
-    evaluations_participating_in = forms.ModelMultipleChoiceField(
+    evaluations_participating_in = forms.ModelMultipleChoiceField[Questionnaire](
         None, required=False, label=_("Evaluations participating in (active semester)")
     )
 

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -354,7 +354,7 @@ class CourseCopyForm(CourseFormMixin, forms.ModelForm):  # type: ignore[misc]
 
 
 class EvaluationForm(forms.ModelForm):
-    general_questionnaires = forms.ModelMultipleChoiceField[Questionnaire](
+    general_questionnaires: "forms.ModelMultipleChoiceField[Questionnaire]" = forms.ModelMultipleChoiceField(
         Questionnaire.objects.general_questionnaires().exclude(visibility=Questionnaire.Visibility.HIDDEN),
         widget=CheckboxSelectMultiple,
         label=_("General questions"),
@@ -573,7 +573,7 @@ class ContributionForm(forms.ModelForm):
     evaluation = forms.ModelChoiceField(
         Evaluation.objects.all(), disabled=True, required=False, widget=forms.HiddenInput()
     )
-    questionnaires = forms.ModelMultipleChoiceField[Questionnaire](
+    questionnaires: "forms.ModelMultipleChoiceField[Questionnaire]" = forms.ModelMultipleChoiceField(
         Questionnaire.objects.contributor_questionnaires().exclude(visibility=Questionnaire.Visibility.HIDDEN),
         required=False,
         widget=CheckboxSelectMultiple,
@@ -934,7 +934,7 @@ class UserForm(forms.ModelForm):
     is_grade_publisher = forms.BooleanField(required=False, label=_("Grade publisher"))
     is_reviewer = forms.BooleanField(required=False, label=_("Reviewer"))
     is_inactive = forms.BooleanField(required=False, label=_("Inactive"))
-    evaluations_participating_in = forms.ModelMultipleChoiceField[Questionnaire](
+    evaluations_participating_in: "forms.ModelMultipleChoiceField[Questionnaire]" = forms.ModelMultipleChoiceField(
         None, required=False, label=_("Evaluations participating in (active semester)")
     )
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 black~=24.4.0
 coverage[toml]
 django-debug-toolbar~=4.0
-django-stubs==4.2.6
+django-stubs==5.0.0
 django-webtest~=1.9.10
 isort~=5.13.1
 model-bakery~=1.18.0


### PR DESCRIPTION
This would require us to add `django-stubs-ext` as a runtime requirement, in order to define an itemgetter for these generic classes via `monkeypatch`

The new annotations do not improve much actually, because `Form.fields` is de-facto untyped ([typeddjango/django-stubs#1514](https://www.github.com/typeddjango/django-stubs/issues/1514))