### PR TITLE
Downgrade django-fsm to 2.8.2 to fix deprecation warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django-extensions==3.2.3
-django-fsm==3.0.0
+django-fsm==2.8.2
 django~=5.0
 mozilla-django-oidc==4.0.1
 openpyxl==3.1.2


### PR DESCRIPTION
Version 3.0.0 [didn't have functional changes](https://github.com/viewflow/django-fsm/compare/2.8.2...master) except for the annoying deprecation warning