### PR TITLE
Update a single comment :^)

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1032,7 +1032,7 @@ def log_state_transition(instance, name, source, target, **_kwargs):
 
 
 class Contribution(LoggedModel):
-    """A contributor who is assigned to an evaluation and his questionnaires."""
+    """A contributor who is assigned to an evaluation and their questionnaires."""
 
     class TextAnswerVisibility(models.TextChoices):
         OWN_TEXTANSWERS = "OWN", _("Own")


### PR DESCRIPTION
Found this during review. It is possible that the initial intention was to highlight that the questionnaires belong to the person and not the evaluation - in that case, I would opt for adding punctuation like

> A contributor, who is assigned to an evaluation, and their questionnaires.