### PR TITLE
fix dependabot composite action update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
     labels:
       - "[T] Dependencies"
   - package-ecosystem: "github-actions"
-    directory: "/actions/setup_nodejs"
+    directory: "/.github/setup_nodejs"
     schedule:
       interval: "weekly"
     groups:
@@ -41,7 +41,7 @@ updates:
     labels:
       - "[T] Dependencies"
   - package-ecosystem: "github-actions"
-    directory: "/actions/setup_python"
+    directory: "/.github/setup_python"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
After it apparently does not worked, I dug a bit deeper. Looking at a concrete example at [ansible-community/github-docs-build](https://www.github.com/ansible-community/github-docs-build/blob/c87c4e381fe8ef464e9d0318043ca1284af66b01/.github/dependabot.yml#L13) this should now finally be it.