### PR TITLE
Allow list of values for graded column in importer

### DIFF
--- a/evap/settings.py
+++ b/evap/settings.py
@@ -74,9 +74,9 @@ INSTITUTION_EMAIL_DOMAINS: list[str] = ["institution.example.com", "student.inst
 # e.g.: [("institution.example.com", "institution.com")]
 INSTITUTION_EMAIL_REPLACEMENTS: list[tuple[str, str]] = []
 
-# the importer accepts only these two strings in the 'graded' column
-IMPORTER_GRADED_YES = "yes"
-IMPORTER_GRADED_NO = "no"
+# the importer accepts only these strings in the 'graded' column
+IMPORTER_GRADED_YES = ["yes", "ja", "graded", "benotet"]
+IMPORTER_GRADED_NO = ["no", "nein", "ungraded", "unbenotet"]
 
 # the importer will warn if any participant has more enrollments than this number
 IMPORTER_MAX_ENROLLMENTS = 7

--- a/evap/staff/fixtures/excel_files_test_data.py
+++ b/evap/staff/fixtures/excel_files_test_data.py
@@ -96,8 +96,8 @@ invalid_enrollment_data_filedata = {
 test_enrollment_data_filedata = {
     'MA Belegungen': [
         ['Degree', 'Student last name', 'Student first name', 'Student email address', 'Course kind', 'Course is graded', 'Course name (de)', 'Course name (en)', 'Responsible title', 'Responsible last name', 'Responsible first name', 'Responsible email address'],
-        ['Master', 'Quid', 'Bastius', 'bastius.quid@external.example.com', 'Seminar', 'no', 'Bauen', 'Build', '', 'Sed', 'Diam', '345@external.example.com'],
-        ['Master', 'Quid', 'Bastius', 'bastius.quid@external.example.com', 'Seminar', 'no', 'Herbringen', 'Bring', 'Dr.', 'Nonumy', 'Eirmod', '456@external.example.com'],
+        ['Master', 'Quid', 'Bastius', 'bastius.quid@external.example.com', 'Seminar', 'ungraded', 'Bauen', 'Build', '', 'Sed', 'Diam', '345@external.example.com'],
+        ['Master', 'Quid', 'Bastius', 'bastius.quid@external.example.com', 'Seminar', 'nein', 'Herbringen', 'Bring', 'Dr.', 'Nonumy', 'Eirmod', '456@external.example.com'],
         ['Master', 'Quid', 'Bastius', 'bastius.quid@external.example.com', 'Seminar', 'no', 'Machen', 'Do', 'Dr.', 'Romano', 'Electram', '111@external.example.com'],
         ['Master', 'Quid', 'Bastius', 'bastius.quid@external.example.com', 'Seminar', 'no', 'Verhandeln', 'Deal', 'Prof. Dr.', 'Tempor', 'Invidunt', '789@external.example.com'],
         ['Master', 'Synephebos', 'Diam', 'diam.synephebos@institution.example.com', 'Seminar', 'no', 'Kaufen', 'Buy', 'Dr.', 'Romano', 'Electram', '111@external.example.com'],
@@ -120,7 +120,7 @@ test_enrollment_data_filedata = {
     ],
     'BA Belegungen': [
         ['Degree', 'Student last name', 'Student first name', 'Student email address', 'Course kind', 'Course is graded', 'Course name (de)', 'Course name (en)', 'Responsible title', 'Responsible last name', 'Responsible first name', 'Responsible email address'],
-        ['Bachelor', 'Manilium', 'Lucilia', 'lucilia.manilium@institution.example.com', 'Vorlesung', 'yes', 'Schütteln', 'Shake', 'Prof. Dr.', 'Prorsus', 'Christoph', '123@institution.example.com'],
+        ['Bachelor', 'Manilium', 'Lucilia', 'lucilia.manilium@institution.example.com', 'Vorlesung', 'benotet', 'Schütteln', 'Shake', 'Prof. Dr.', 'Prorsus', 'Christoph', '123@institution.example.com'],
         ['Bachelor', 'Manilium', 'Lucilia', 'lucilia.manilium@institution.example.com', 'Vorlesung', 'no', 'Singen', 'Sing', 'Dr.', 'Praeterea', 'Eadamque', '345@institution.example.com'],
         ['Bachelor', 'Manilium', 'Lucilia', 'lucilia.manilium@institution.example.com', 'Vorlesung', 'no', 'Sinken', 'Sink', 'Dr.', 'Itaque', 'Ferdi', '789@institution.example.com'],
         ['Bachelor', 'Manilium', 'Lucilia', 'lucilia.manilium@institution.example.com', 'Vorlesung', 'no', 'Sitzen', 'Sit', 'Prof. Dr.', 'Tempor', 'Invidunt', '789@external.example.com'],
@@ -128,7 +128,7 @@ test_enrollment_data_filedata = {
         ['Bachelor', 'Manilium', 'Lucilia', 'lucilia.manilium@institution.example.com', 'Vorlesung', 'no', 'Zeigen', 'Show', 'Dr.', 'Sed', 'Tam', '456@institution.example.com'],
         ['Bachelor', 'Metrodorus', 'Torquate', 'torquate.metrodorus@institution.example.com', 'Vorlesung', 'no', 'Scheinen', 'Shine', 'Prof. Dr.', 'Multi', 'Augendas', '567@institution.example.com'],
         ['Bachelor', 'Metrodorus', 'Torquate', 'torquate.metrodorus@institution.example.com', 'Vorlesung', 'yes', 'Schütteln', 'Shake', 'Prof. Dr.', 'Prorsus', 'Christoph', '123@institution.example.com'],
-        ['Bachelor', 'Metrodorus', 'Torquate', 'torquate.metrodorus@institution.example.com', 'Seminar', 'yes', 'Stehlen', 'Steal', 'Dr.', 'Nonumy', 'Eirmod', '456@external.example.com'],
+        ['Bachelor', 'Metrodorus', 'Torquate', 'torquate.metrodorus@institution.example.com', 'Seminar', 'ja', 'Stehlen', 'Steal', 'Dr.', 'Nonumy', 'Eirmod', '456@external.example.com'],
         ['Bachelor', 'Metrodorus', 'Torquate', 'torquate.metrodorus@institution.example.com', 'Vorlesung', 'yes', 'Sprechen', 'Speak', 'Prof.-Dr.', 'Honoris', 'Invitat', '111@institution.example.com'],
         ['Bachelor', 'Metrodorus', 'Torquate', 'torquate.metrodorus@institution.example.com', 'Vorlesung', 'no', 'Schlafen', 'Sleep', 'Prof. Dr. ', 'Takimata', 'Labore', '678@external.example.com'],
         ['Bachelor', 'Metrodorus', 'Torquate', 'torquate.metrodorus@institution.example.com', 'Vorlesung', 'no', 'Zeigen', 'Show', 'Dr.', 'Sed', 'Tam', '456@institution.example.com']

--- a/evap/staff/importers/enrollment.py
+++ b/evap/staff/importers/enrollment.py
@@ -145,9 +145,9 @@ class IsGradedImportMapper:
     @classmethod
     def is_graded_from_import_string(cls, is_graded: str) -> bool:
         is_graded = is_graded.strip()
-        if is_graded == settings.IMPORTER_GRADED_YES:
+        if is_graded in settings.IMPORTER_GRADED_YES:
             return True
-        if is_graded == settings.IMPORTER_GRADED_NO:
+        if is_graded in settings.IMPORTER_GRADED_NO:
             return False
 
         raise cls.InvalidIsGradedError(invalid_is_graded=is_graded)

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -463,7 +463,7 @@ class TestEnrollmentImport(ImporterTestCase):
             errors,
             [
                 'Sheet "MA Belegungen", row 2 and 1 other place: No course type is associated with the import name "jaminar". Please manually create it first.',
-                'Sheet "MA Belegungen", row 2 and 1 other place: "is_graded" is probably not, but must be {} or {}'.format(settings.IMPORTER_GRADED_YES, settings.IMPORTER_GRADED_NO),
+                f'Sheet "MA Belegungen", row 2 and 1 other place: "is_graded" is probably not, but must be {settings.IMPORTER_GRADED_YES} or {settings.IMPORTER_GRADED_NO}',
                 'Sheet "MA Belegungen", row 2: No degree is associated with the import name "Grandmaster". Please manually create it first.',
                 'Sheet "MA Belegungen", row 3: No degree is associated with the import name "Beginner". Please manually create it first.',
                 "Errors occurred while parsing the input data. No data was imported.",
@@ -571,7 +571,9 @@ class TestEnrollmentImport(ImporterTestCase):
         )
         self.assertEqual(
             [msg.message for msg in importer_log_test.errors_by_category()[ImporterLogEntry.Category.IS_GRADED]],
-            ['Sheet "MA Belegungen", row 5: "is_graded" is maybe, but must be {} or {}'.format(settings.IMPORTER_GRADED_YES, settings.IMPORTER_GRADED_NO)],
+            [
+                f'Sheet "MA Belegungen", row 5: "is_graded" is maybe, but must be {settings.IMPORTER_GRADED_YES} or {settings.IMPORTER_GRADED_NO}'
+            ],
         )
         self.assertEqual(
             [msg.message for msg in importer_log_test.errors_by_category()[ImporterLogEntry.Category.DEGREE]],

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from unittest.mock import patch
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms.models import model_to_dict
 from django.test import TestCase, override_settings
@@ -462,7 +463,7 @@ class TestEnrollmentImport(ImporterTestCase):
             errors,
             [
                 'Sheet "MA Belegungen", row 2 and 1 other place: No course type is associated with the import name "jaminar". Please manually create it first.',
-                'Sheet "MA Belegungen", row 2 and 1 other place: "is_graded" is probably not, but must be yes or no',
+                'Sheet "MA Belegungen", row 2 and 1 other place: "is_graded" is probably not, but must be {} or {}'.format(settings.IMPORTER_GRADED_YES, settings.IMPORTER_GRADED_NO),
                 'Sheet "MA Belegungen", row 2: No degree is associated with the import name "Grandmaster". Please manually create it first.',
                 'Sheet "MA Belegungen", row 3: No degree is associated with the import name "Beginner". Please manually create it first.',
                 "Errors occurred while parsing the input data. No data was imported.",
@@ -570,7 +571,7 @@ class TestEnrollmentImport(ImporterTestCase):
         )
         self.assertEqual(
             [msg.message for msg in importer_log_test.errors_by_category()[ImporterLogEntry.Category.IS_GRADED]],
-            ['Sheet "MA Belegungen", row 5: "is_graded" is maybe, but must be yes or no'],
+            ['Sheet "MA Belegungen", row 5: "is_graded" is maybe, but must be {} or {}'.format(settings.IMPORTER_GRADED_YES, settings.IMPORTER_GRADED_NO)],
         )
         self.assertEqual(
             [msg.message for msg in importer_log_test.errors_by_category()[ImporterLogEntry.Category.DEGREE]],

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1159,9 +1159,7 @@ class TestSemesterImportView(WebTestStaffMode):
             "Please manually create it first."
         )
         self.assertContains(reply, course_type_error)
-        is_graded_error = (
-            "Sheet &quot;MA Belegungen&quot;, row 5: &quot;is_graded&quot; is maybe, but must be "
-        )
+        is_graded_error = "Sheet &quot;MA Belegungen&quot;, row 5: &quot;is_graded&quot; is maybe, but must be "
         self.assertContains(reply, is_graded_error)
         user_error = (
             "Sheet &quot;MA Belegungen&quot;, row 3: The data of user"

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1160,7 +1160,7 @@ class TestSemesterImportView(WebTestStaffMode):
         )
         self.assertContains(reply, course_type_error)
         is_graded_error = (
-            "Sheet &quot;MA Belegungen&quot;, row 5: &quot;is_graded&quot; is maybe, but must be yes or no"
+            "Sheet &quot;MA Belegungen&quot;, row 5: &quot;is_graded&quot; is maybe, but must be "
         )
         self.assertContains(reply, is_graded_error)
         user_error = (


### PR DESCRIPTION
Currently only one value can be defined in the settings. Multiple values are used on production, the importer should accept all of them.