### PR TITLE
Add export of all available reward points

### DIFF
--- a/evap/rewards/templates/rewards_reward_point_redemption_events.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_events.html
@@ -13,6 +13,7 @@
         </div>
         <div class="col text-end">
             {% translate 'Available reward points' %}: {{ total_points_available }}
+            <a href="{% url 'rewards:reward_points_export' %}" class="btn btn-dark btn-sm ms-2">{% translate 'Export reward points' %}</a>
         </div>
     </div>
 

--- a/evap/rewards/templates/rewards_reward_point_redemption_events.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_events.html
@@ -13,7 +13,7 @@
         </div>
         <div class="col text-end">
             {% translate 'Available reward points' %}: {{ total_points_available }}
-            <a href="{% url 'rewards:reward_points_export' %}" class="btn btn-dark btn-sm ms-2">{% translate 'Export reward points' %}</a>
+            <a href="{% url 'rewards:reward_points_export' %}" class="btn btn-light btn-sm ms-2">{% translate 'Export reward points' %}</a>
         </div>
     </div>
 

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -180,13 +180,37 @@ class TestEventEditView(WebTestStaffMode):
         self.assertEqual(RewardPointRedemptionEvent.objects.get(pk=self.event.pk).name, "new name")
 
 
-class TestExportView(WebTestStaffModeWith200Check):
+class TestEventExportView(WebTestStaffModeWith200Check):
     @classmethod
     def setUpTestData(cls):
         cls.test_users = [make_manager()]
         event = baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
         baker.make(RewardPointRedemption, value=1, event=event)
         cls.url = f"/rewards/reward_point_redemption_event/{event.pk}/export"
+
+
+class TestPointsExportView(WebTestStaffModeWith200Check):
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_users = [make_manager()]
+        cls.url = "/rewards/reward_points_export"
+
+        cls.student = baker.make(UserProfile, email="student@institution.example.com")
+        cls.event = baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
+
+    def test_positive_points(self):
+        baker.make(RewardPointGranting, user_profile=self.student, value=5)
+        baker.make(RewardPointRedemption, user_profile=self.student, event=self.event, value=3)
+
+        response = self.app.get(self.url, user=self.test_users[0], status=200).content
+        self.assertTrue("student@institution.example.com;2" in str(response))
+
+    def test_zero_points(self):
+        baker.make(RewardPointGranting, user_profile=self.student, value=5)
+        baker.make(RewardPointRedemption, user_profile=self.student, event=self.event, value=5)
+
+        response = self.app.get(self.url, user=self.test_users[0], status=200).content
+        self.assertFalse("student@institution.example.com" in str(response))
 
 
 @override_settings(

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -193,7 +193,7 @@ class TestPointsExportView(WebTestStaffModeWith200Check):
     @classmethod
     def setUpTestData(cls):
         cls.test_users = [make_manager()]
-        cls.url = "/rewards/reward_points_export"
+        cls.url = reverse("rewards:reward_points_export")
 
         cls.student = baker.make(UserProfile, email="student@institution.example.com")
         cls.event = baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
@@ -202,15 +202,15 @@ class TestPointsExportView(WebTestStaffModeWith200Check):
         baker.make(RewardPointGranting, user_profile=self.student, value=5)
         baker.make(RewardPointRedemption, user_profile=self.student, event=self.event, value=3)
 
-        response = self.app.get(self.url, user=self.test_users[0], status=200).content
-        self.assertTrue("student@institution.example.com;2" in str(response))
+        response = self.app.get(self.url, user=self.test_users[0], status=200)
+        self.assertIn("student@institution.example.com;2", response)
 
     def test_zero_points(self):
         baker.make(RewardPointGranting, user_profile=self.student, value=5)
         baker.make(RewardPointRedemption, user_profile=self.student, event=self.event, value=5)
 
-        response = self.app.get(self.url, user=self.test_users[0], status=200).content
-        self.assertFalse("student@institution.example.com" in str(response))
+        response = self.app.get(self.url, user=self.test_users[0], status=200)
+        self.assertNotIn("student@institution.example.com", response)
 
 
 @override_settings(

--- a/evap/rewards/urls.py
+++ b/evap/rewards/urls.py
@@ -7,6 +7,7 @@ app_name = "rewards"
 urlpatterns = [
     path("", views.index, name="index"),
 
+    path("reward_points_export", views.reward_points_export, name="reward_points_export"),
     path("reward_point_redemption_events/", views.reward_point_redemption_events, name="reward_point_redemption_events"),
     path("reward_point_redemption_event/create", views.RewardPointRedemptionEventCreateView.as_view(), name="reward_point_redemption_event_create"),
     path("reward_point_redemption_event/<int:event_id>/edit", views.RewardPointRedemptionEventEditView.as_view(), name="reward_point_redemption_event_edit"),

--- a/evap/rewards/views.py
+++ b/evap/rewards/views.py
@@ -1,3 +1,4 @@
+import csv
 from datetime import datetime
 
 from django.contrib import messages
@@ -14,7 +15,7 @@ from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, UpdateView
 
 from evap.evaluation.auth import manager_required, reward_user_required
-from evap.evaluation.models import Semester
+from evap.evaluation.models import Semester, UserProfile
 from evap.evaluation.tools import AttachmentResponse, get_object_from_dict_pk_entry_or_logged_40x
 from evap.rewards.exporters import RewardsExporter
 from evap.rewards.forms import RewardPointRedemptionEventForm
@@ -157,6 +158,30 @@ def reward_point_redemption_event_export(request, event_id):
 
     return response
 
+
+@manager_required
+def reward_points_export(request):
+    filename = _("RewardPoints") + f"-{get_language()}.csv"
+    response = AttachmentResponse(filename, content_type="text/csv")
+
+    writer = csv.writer(response, delimiter=";", lineterminator="\n")
+    writer.writerow(
+        [
+            _("Email address"),
+            _("Number of points"),
+        ]
+    )
+    profiles_with_points = UserProfile.objects.annotate(points=Sum("reward_point_grantings__value", default=0) - Sum("reward_point_redemptions__value", default=0)).filter(points__gt=0).order_by("-points")
+
+    for profile in profiles_with_points.all():
+        writer.writerow(
+            [
+                profile.email,
+                profile.points,
+            ]
+        )
+
+    return response
 
 @require_POST
 @manager_required

--- a/evap/rewards/views.py
+++ b/evap/rewards/views.py
@@ -171,7 +171,13 @@ def reward_points_export(request):
             _("Number of points"),
         ]
     )
-    profiles_with_points = UserProfile.objects.annotate(points=Sum("reward_point_grantings__value", default=0) - Sum("reward_point_redemptions__value", default=0)).filter(points__gt=0).order_by("-points")
+    profiles_with_points = (
+        UserProfile.objects.annotate(
+            points=Sum("reward_point_grantings__value", default=0) - Sum("reward_point_redemptions__value", default=0)
+        )
+        .filter(points__gt=0)
+        .order_by("-points")
+    )
 
     for profile in profiles_with_points.all():
         writer.writerow(
@@ -182,6 +188,7 @@ def reward_points_export(request):
         )
 
     return response
+
 
 @require_POST
 @manager_required

--- a/evap/rewards/views.py
+++ b/evap/rewards/views.py
@@ -165,12 +165,7 @@ def reward_points_export(request):
     response = AttachmentResponse(filename, content_type="text/csv")
 
     writer = csv.writer(response, delimiter=";", lineterminator="\n")
-    writer.writerow(
-        [
-            _("Email address"),
-            _("Number of points"),
-        ]
-    )
+    writer.writerow([_("Email address"), _("Number of points")])
     profiles_with_points = (
         UserProfile.objects.annotate(
             points=Sum("reward_point_grantings__value", default=0) - Sum("reward_point_redemptions__value", default=0)


### PR DESCRIPTION
This resolves #2020, as it adds a button to export a simple CSV that is an overview over all available reward points grouped by user profile.

Feel free to suggest better path names, or a way to improve the placement and look of the button:
<img width="457" alt="grafik" src="https://github.com/e-valuation/EvaP/assets/2820802/aa2d9ff7-d0ca-42e9-b491-9ef57d24e134">
