### PR TITLE
manually del weakref functions to make sure they are disconnected

### DIFF
--- a/evap/rewards/tools.py
+++ b/evap/rewards/tools.py
@@ -153,6 +153,7 @@ def grant_reward_points_after_delete(instance, action, reverse, pk_set, **_kwarg
             for semester in Semester.objects.filter(courses__evaluations__pk__in=pk_set):
                 granting, __ = grant_reward_points_if_eligible(user, semester)
                 if granting:
+                    assert not grantings
                     grantings = [granting]
         else:
             # a participant got removed from an evaluation

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1323,6 +1323,7 @@ def helper_evaluation_edit(request, evaluation):
         "editable": editable,
         "questionnaires_with_answers_per_contributor": questionnaires_with_answers_per_contributor,
     }
+    del notify_reward_points  # cleanup receiver
     return render(request, "staff_evaluation_form.html", template_data)
 
 
@@ -2228,7 +2229,7 @@ def user_edit(request, user_id):
         for message in form.remove_messages:
             messages.warning(request, message)
         return redirect("staff:user_index")
-
+    del notify_reward_points  # cleanup receiver
     return render(
         request,
         "staff_user_form.html",


### PR DESCRIPTION
fix https://github.com/e-valuation/EvaP/issues/2189

tested by reverting commit, adding `gc.disable()` and testing with `--shuffle=1116753744`