### PR TITLE
Fix infobox collapse

### DIFF
--- a/evap/static/ts/src/infobox.ts
+++ b/evap/static/ts/src/infobox.ts
@@ -17,6 +17,7 @@ export class InfoboxLogic {
         // close the infobox and save state
         this.closeButton.addEventListener("click", event => {
             this.infobox.classList.add("closing");
+            this.infobox.classList.remove("opening");
             setTimeout(() => {
                 this.infobox.classList.replace("closing", "closed");
             }, OPEN_CLOSE_TIMEOUT);

--- a/evap/static/ts/src/infobox.ts
+++ b/evap/static/ts/src/infobox.ts
@@ -6,6 +6,7 @@ export class InfoboxLogic {
     private readonly infobox: HTMLDivElement;
     private readonly closeButton: HTMLButtonElement;
     private readonly storageKey: string;
+    private timeout?: number;
 
     constructor(infobox_id: string) {
         this.infobox = selectOrError("#infobox-" + infobox_id);
@@ -18,6 +19,7 @@ export class InfoboxLogic {
         this.closeButton.addEventListener("click", event => {
             this.infobox.classList.add("closing");
             this.infobox.classList.remove("opening");
+            clearTimeout(this.timeout);
             setTimeout(() => {
                 this.infobox.classList.replace("closing", "closed");
             }, OPEN_CLOSE_TIMEOUT);
@@ -29,7 +31,7 @@ export class InfoboxLogic {
         this.infobox.addEventListener("click", _ => {
             if (this.infobox.className.includes("closed")) {
                 this.infobox.classList.replace("closed", "opening");
-                setTimeout(() => {
+                this.timeout = setTimeout(() => {
                     this.infobox.classList.remove("opening");
                 }, OPEN_CLOSE_TIMEOUT);
                 localStorage[this.storageKey] = "show";

--- a/evap/static/ts/tsconfig.compile.json
+++ b/evap/static/ts/tsconfig.compile.json
@@ -4,7 +4,12 @@
         "rootDir": "./src",
         "outDir": "../../static/js",
         "incremental": true,
-        "tsBuildInfoFile": ".tsbuildinfo.json"
+        "tsBuildInfoFile": ".tsbuildinfo.json",
+        "types": [
+            "bootstrap",
+            "jquery",
+            "sortablejs"
+        ]
     },
     "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
fixes a bug, when the info box is closed during opening of the infobox. Now, we hard abort the opening process and further clear the "opening" timeout to prevent the class to be removed unexpectedly.