### PR TITLE
always show placeholder text in fullwidth user selection fields

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -148,7 +148,7 @@
                     const baseOptions = {
                         createOnBlur: true,
                         placeholder: "{% translate 'Please select...' %}",
-                        hidePlaceholder: true,
+                        hidePlaceholder: element.hasAttribute("data-tomselect-fullwidth") ? false : true,
                         minimumInputLength,
                         render: {
                             option_create: (data, escape) => `<div class="create">${ escape(data.input) }</div>`,


### PR DESCRIPTION
Some editors didn't see that they could edit the participants field. Showing the placeholder text even when values are already selected should help.

`Please select...` is now always shown.
![image](https://github.com/e-valuation/EvaP/assets/1781719/576050e8-f6d5-4ec3-86f1-776b7471a076)