### PR TITLE
only remount if REPO_FOLDER does not contain any items

### DIFF
--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -44,7 +44,8 @@ cp /etc/skel/.bashrc /home/$USER/
 OWNER=$(stat -c %u "$MOUNTPOINT/evap")
 apt-get -q install -y bindfs
 mkdir -p "$REPO_FOLDER"
-bindfs --map="$OWNER/1042:@$OWNER/@1042" "$MOUNTPOINT" "$REPO_FOLDER" || exit 1
+# remount if REPO_FOLDER does not contain any files (meaning it is not mounted)
+[[ -z $(ls -A "$REPO_FOLDER") ]] && bindfs --map="$OWNER/1042:@$OWNER/@1042" "$MOUNTPOINT" "$REPO_FOLDER" || exit 1
 echo "[[ -z \$(ls -A '$REPO_FOLDER') ]] && sudo bindfs --map='$OWNER/1042:@$OWNER/@1042' '$MOUNTPOINT' '$REPO_FOLDER'  #  remount iff folder empty" >> /home/$USER/.bashrc
 
 # allow ssh login

--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -45,7 +45,11 @@ OWNER=$(stat -c %u "$MOUNTPOINT/evap")
 apt-get -q install -y bindfs
 mkdir -p "$REPO_FOLDER"
 # remount if REPO_FOLDER does not contain any files (meaning it is not mounted)
-[[ -z $(ls -A "$REPO_FOLDER") ]] && bindfs --map="$OWNER/1042:@$OWNER/@1042" "$MOUNTPOINT" "$REPO_FOLDER" || exit 1
+if [[ -z $(ls -A "$REPO_FOLDER") ]]; then
+  bindfs --map="$OWNER/1042:@$OWNER/@1042" "$MOUNTPOINT" "$REPO_FOLDER" || exit 1
+else
+  echo "Skipped trying to mount $REPO_FOLDER - a mounted folder was already detected."
+fi
 echo "[[ -z \$(ls -A '$REPO_FOLDER') ]] && sudo bindfs --map='$OWNER/1042:@$OWNER/@1042' '$MOUNTPOINT' '$REPO_FOLDER'  #  remount iff folder empty" >> /home/$USER/.bashrc
 
 # allow ssh login


### PR DESCRIPTION
This allows users to rerun `vagrant provision` without a failure, if the folder is already mounted