### PR TITLE
Pin django to minor version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django-extensions==3.2.3
 django-fsm==2.8.2
-django~=5.0
+Django~=5.0.0
 mozilla-django-oidc==4.0.1
 openpyxl==3.1.5
 psycopg2-binary==2.9.9


### PR DESCRIPTION
Fixup for #2084, where dependabot (without asking) changed our pinning from "any patch" to "any minor version".

Should fix current CI failures.

The [official PyPI package](https://pypi.org/project/Django/) is named `Django` with a capital D, I also fixed the file to reflect that.