### PR TITLE
Update to bootstrap 5.3.3

### DIFF
--- a/evap/static/scss/_variables.scss
+++ b/evap/static/scss/_variables.scss
@@ -65,6 +65,7 @@ $dropdown-item-padding-x: 1rem;
 $navbar-toggler-padding-y: 0;
 $navbar-toggler-padding-x: 0;
 $navbar-light-color: $light-gray;
+$navbar-light-active-color: $white;
 $navbar-light-hover-color: $white;
 
 $tooltip-max-width: 260px;

--- a/evap/static/scss/components/_tables.scss
+++ b/evap/static/scss/components/_tables.scss
@@ -47,6 +47,10 @@ $table-colors: (
         background-color: rgba(0, 0, 0, 0.075);
         cursor: pointer;
 
+        td {
+            background-color: inherit;  // workaround for bootstrap setting color in ".table > :not(caption) > * > *"
+        }
+
         &.hover-row-info {
             background-color: $evap-light-blue;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "packages": {
         "": {
             "devDependencies": {
-                "@types/bootstrap": "^5.2.6",
+                "@types/bootstrap": "^5.2.10",
                 "@types/jest": "^29.5.12",
                 "@types/jest-environment-puppeteer": "^5.0.3",
                 "@types/jquery": "^3.5.16",
@@ -1153,10 +1153,11 @@
             }
         },
         "node_modules/@types/bootstrap": {
-            "version": "5.2.6",
-            "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.2.6.tgz",
-            "integrity": "sha512-BlAc3YATdasbHoxMoBWODrSF6qwQO/E9X8wVxCCSa6rWjnaZfpkr2N6pUMCY6jj2+wf0muUtLySbvU9etX6YqA==",
+            "version": "5.2.10",
+            "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.2.10.tgz",
+            "integrity": "sha512-F2X+cd6551tep0MvVZ6nM8v7XgGN/twpdNDjqS1TUM7YFNEtQYWk+dKAnH+T1gr6QgCoGMPl487xw/9hXooa2g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@popperjs/core": "^2.9.2"
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "@types/bootstrap": "^5.2.6",
+        "@types/bootstrap": "^5.2.10",
         "@types/jest": "^29.5.12",
         "@types/jest-environment-puppeteer": "^5.0.3",
         "@types/jquery": "^3.5.16",


### PR DESCRIPTION
fixes the deprecation warning we're currently getting with sass

The "current" version of [@types/bootstrap](https://www.npmjs.com/package/@types/bootstrap) is 5.2.10, so cannot (yet) put "^5.3.0" there.