### PR TITLE
Add eslint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,10 +58,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/setup_evap
+        with:
+          npm-ci: 'true'
+
       - name: Run ruff
         run: ruff check .
       - name: Run pylint
         run: pylint evap tools
+      - name: Run ESLint
+        run: |
+          cd evap/static/ts
+          npx eslint --quiet
 
   formatter:
     runs-on: ubuntu-22.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Run ESLint
         run: |
           cd evap/static/ts
-          npx eslint --quiet
+          npx eslint
 
   formatter:
     runs-on: ubuntu-22.04

--- a/evap/evaluation/management/commands/lint.py
+++ b/evap/evaluation/management/commands/lint.py
@@ -9,7 +9,9 @@ class Command(BaseCommand):
     requires_migrations_checks = False
 
     def handle(self, *args, **options):
-        self.stdout.write("Executing ruff .")
+        self.stdout.write("Executing ruff check .")
         subprocess.run(["ruff", "check", "."], check=False)  # nosec
         self.stdout.write("Executing pylint evap")
         subprocess.run(["pylint", "evap", "tools"], check=False)  # nosec
+        self.stdout.write("Executing npx eslint --quiet")
+        subprocess.run(["npx", "eslint", "--quiet"], cwd="evap/static/ts", check=False)  # nosec

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -453,9 +453,10 @@ class TestLintCommand(TestCase):
     @patch("subprocess.run")
     def test_pylint_called(self, mock_subprocess_run: MagicMock):
         management.call_command("lint", stdout=StringIO())
-        self.assertEqual(mock_subprocess_run.call_count, 2)
+        self.assertEqual(mock_subprocess_run.call_count, 3)
         mock_subprocess_run.assert_any_call(["ruff", "check", "."], check=False)
         mock_subprocess_run.assert_any_call(["pylint", "evap", "tools"], check=False)
+        mock_subprocess_run.assert_any_call(["npx", "eslint", "--quiet"], cwd="evap/static/ts", check=False)
 
 
 class TestFormatCommand(TestCase):

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -49,7 +49,6 @@ export default tseslint.config(
                 },
             ],
             "@typescript-eslint/no-confusing-void-expression": "warn",
-            "@typescript-eslint/no-floating-promises": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
         },

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -56,7 +56,6 @@ export default tseslint.config(
             "@typescript-eslint/no-unnecessary-type-arguments": "warn",
             "@typescript-eslint/no-unnecessary-type-assertion": "warn",
             "@typescript-eslint/no-inferrable-types": "warn",
-            "prefer-const": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
         },

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -60,7 +60,6 @@ export default tseslint.config(
             "@typescript-eslint/no-unnecessary-condition": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
-            "@typescript-eslint/prefer-optional-chain": "warn",
         },
     },
 );

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -51,7 +51,6 @@ export default tseslint.config(
             "@typescript-eslint/no-confusing-void-expression": "warn",
             "@typescript-eslint/await-thenable": "warn",
             "@typescript-eslint/no-floating-promises": "warn",
-            "@typescript-eslint/no-deprecated": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
         },

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -58,7 +58,6 @@ export default tseslint.config(
             "prefer-const": "warn",
             "@typescript-eslint/no-unnecessary-condition": "warn",
             "@typescript-eslint/non-nullable-type-assertion-style": "warn",
-            "@typescript-eslint/array-type": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
             "@typescript-eslint/prefer-optional-chain": "warn",

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -59,7 +59,6 @@ export default tseslint.config(
             "@typescript-eslint/no-unnecessary-condition": "warn",
             "@typescript-eslint/non-nullable-type-assertion-style": "warn",
             "@typescript-eslint/array-type": "warn",
-            "@typescript-eslint/no-unsafe-enum-comparison": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
             "@typescript-eslint/prefer-optional-chain": "warn",

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -53,8 +53,6 @@ export default tseslint.config(
             "@typescript-eslint/no-floating-promises": "warn",
             "@typescript-eslint/no-deprecated": "warn",
             "@typescript-eslint/consistent-generic-constructors": "warn",
-            "@typescript-eslint/no-unnecessary-type-arguments": "warn",
-            "@typescript-eslint/no-unnecessary-type-assertion": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
         },

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -57,7 +57,6 @@ export default tseslint.config(
             "@typescript-eslint/no-unnecessary-type-assertion": "warn",
             "@typescript-eslint/no-inferrable-types": "warn",
             "prefer-const": "warn",
-            "@typescript-eslint/no-unnecessary-condition": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
         },

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -57,7 +57,6 @@ export default tseslint.config(
             "@typescript-eslint/no-inferrable-types": "warn",
             "prefer-const": "warn",
             "@typescript-eslint/no-unnecessary-condition": "warn",
-            "@typescript-eslint/non-nullable-type-assertion-style": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
             "@typescript-eslint/prefer-optional-chain": "warn",

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -1,0 +1,69 @@
+// @ts-check
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+    eslint.configs.recommended,
+    ...tseslint.configs.strictTypeChecked,
+    ...tseslint.configs.stylisticTypeChecked,
+    {
+        ignores: ["rendered/", "eslint.config.js"],
+    },
+    {
+        languageOptions: {
+            ecmaVersion: 5,
+            parserOptions: {
+                project: ["tsconfig.json", "tsconfig.compile.json"],
+            },
+            sourceType: "module",
+        },
+    },
+    // ignore @typescript-eslint/no-misused-promises
+    {
+        rules: {
+            "@typescript-eslint/restrict-template-expressions": ["error", { allowNumber: true }],
+            // not fixed in this PR
+            "@typescript-eslint/no-misused-promises": "off",
+            "@typescript-eslint/no-namespace": "off",
+            "@typescript-eslint/no-non-null-assertion": "off",
+            "@typescript-eslint/no-unsafe-call": "off",
+            "@typescript-eslint/no-unsafe-member-access": "off",
+            "@typescript-eslint/no-unsafe-argument": "off",
+            "@typescript-eslint/no-unsafe-assignment": "off",
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-empty-function": "off",
+            "@typescript-eslint/no-unnecessary-type-parameters": "off",
+            // fixed in this PR
+            "@typescript-eslint/no-unused-vars": [
+                "warn",
+                {
+                    args: "all",
+                    argsIgnorePattern: "^_",
+                    caughtErrors: "all",
+                    caughtErrorsIgnorePattern: "^_",
+                    destructuredArrayIgnorePattern: "^_",
+                    varsIgnorePattern: "^_",
+                    ignoreRestSiblings: true,
+                },
+            ],
+            "@typescript-eslint/no-confusing-void-expression": "warn",
+            "@typescript-eslint/await-thenable": "warn",
+            "@typescript-eslint/no-floating-promises": "warn",
+            "@typescript-eslint/no-deprecated": "warn",
+            "@typescript-eslint/consistent-generic-constructors": "warn",
+            "@typescript-eslint/no-unnecessary-type-arguments": "warn",
+            "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+            "@typescript-eslint/no-inferrable-types": "warn",
+            "prefer-const": "warn",
+            "@typescript-eslint/no-unnecessary-condition": "warn",
+            "@typescript-eslint/non-nullable-type-assertion-style": "warn",
+            "@typescript-eslint/array-type": "warn",
+            "@typescript-eslint/no-unsafe-enum-comparison": "warn",
+            "@typescript-eslint/use-unknown-in-catch-callback-variable": "warn",
+            "@typescript-eslint/no-unsafe-return": "warn",
+            "@typescript-eslint/no-redundant-type-constituents": "warn",
+            "@typescript-eslint/prefer-optional-chain": "warn",
+        },
+    },
+);

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -60,7 +60,6 @@ export default tseslint.config(
             "@typescript-eslint/non-nullable-type-assertion-style": "warn",
             "@typescript-eslint/array-type": "warn",
             "@typescript-eslint/no-unsafe-enum-comparison": "warn",
-            "@typescript-eslint/use-unknown-in-catch-callback-variable": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
             "@typescript-eslint/prefer-optional-chain": "warn",

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -49,7 +49,6 @@ export default tseslint.config(
                 },
             ],
             "@typescript-eslint/no-confusing-void-expression": "warn",
-            "@typescript-eslint/await-thenable": "warn",
             "@typescript-eslint/no-floating-promises": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -23,6 +23,7 @@ export default tseslint.config(
     {
         rules: {
             "@typescript-eslint/restrict-template-expressions": ["error", { allowNumber: true }],
+            "no-else-return": "error",
             // not fixed in this PR
             "@typescript-eslint/no-misused-promises": "off",
             "@typescript-eslint/no-namespace": "off",

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -55,7 +55,6 @@ export default tseslint.config(
             "@typescript-eslint/consistent-generic-constructors": "warn",
             "@typescript-eslint/no-unnecessary-type-arguments": "warn",
             "@typescript-eslint/no-unnecessary-type-assertion": "warn",
-            "@typescript-eslint/no-inferrable-types": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
         },

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -52,7 +52,6 @@ export default tseslint.config(
             "@typescript-eslint/await-thenable": "warn",
             "@typescript-eslint/no-floating-promises": "warn",
             "@typescript-eslint/no-deprecated": "warn",
-            "@typescript-eslint/consistent-generic-constructors": "warn",
             "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
         },

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -19,7 +19,6 @@ export default tseslint.config(
             sourceType: "module",
         },
     },
-    // ignore @typescript-eslint/no-misused-promises
     {
         rules: {
             "@typescript-eslint/restrict-template-expressions": ["error", { allowNumber: true }],

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -25,6 +25,7 @@ export default tseslint.config(
             "@typescript-eslint/restrict-template-expressions": ["error", { allowNumber: true }],
             "@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
             "no-else-return": "error",
+            "arrow-body-style": ["error", "as-needed"],
             "@typescript-eslint/no-unused-vars": [
                 "warn",
                 {

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -25,18 +25,6 @@ export default tseslint.config(
             "@typescript-eslint/restrict-template-expressions": ["error", { allowNumber: true }],
             "@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
             "no-else-return": "error",
-            // not fixed in this PR
-            "@typescript-eslint/no-misused-promises": "off",
-            "@typescript-eslint/no-namespace": "off",
-            "@typescript-eslint/no-non-null-assertion": "off",
-            "@typescript-eslint/no-unsafe-call": "off",
-            "@typescript-eslint/no-unsafe-member-access": "off",
-            "@typescript-eslint/no-unsafe-argument": "off",
-            "@typescript-eslint/no-unsafe-assignment": "off",
-            "@typescript-eslint/no-explicit-any": "off",
-            "@typescript-eslint/no-empty-function": "off",
-            "@typescript-eslint/no-unnecessary-type-parameters": "off",
-            // fixed in this PR
             "@typescript-eslint/no-unused-vars": [
                 "warn",
                 {
@@ -49,6 +37,17 @@ export default tseslint.config(
                     ignoreRestSiblings: true,
                 },
             ],
+            "@typescript-eslint/no-empty-function": "off",
+            "@typescript-eslint/no-explicit-any": "off",
+            "@typescript-eslint/no-unnecessary-type-parameters": "off",
+            "@typescript-eslint/no-unnecessary-condition": "warn",
+            "@typescript-eslint/no-misused-promises": "warn",
+            "@typescript-eslint/no-namespace": "warn",
+            "@typescript-eslint/no-non-null-assertion": "warn",
+            "@typescript-eslint/no-unsafe-call": "warn",
+            "@typescript-eslint/no-unsafe-member-access": "warn",
+            "@typescript-eslint/no-unsafe-argument": "warn",
+            "@typescript-eslint/no-unsafe-assignment": "warn",
         },
     },
 );

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -23,6 +23,7 @@ export default tseslint.config(
     {
         rules: {
             "@typescript-eslint/restrict-template-expressions": ["error", { allowNumber: true }],
+            "@typescript-eslint/no-confusing-void-expression": ["error", { ignoreArrowShorthand: true }],
             "no-else-return": "error",
             // not fixed in this PR
             "@typescript-eslint/no-misused-promises": "off",

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -49,8 +49,6 @@ export default tseslint.config(
                     ignoreRestSiblings: true,
                 },
             ],
-            "@typescript-eslint/no-confusing-void-expression": "warn",
-            "@typescript-eslint/no-unsafe-return": "warn",
             "@typescript-eslint/no-redundant-type-constituents": "warn",
         },
     },

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -49,7 +49,6 @@ export default tseslint.config(
                     ignoreRestSiblings: true,
                 },
             ],
-            "@typescript-eslint/no-redundant-type-constituents": "warn",
         },
     },
 );

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -12,7 +12,7 @@ export default tseslint.config(
     },
     {
         languageOptions: {
-            ecmaVersion: 5,
+            ecmaVersion: 2019,
             parserOptions: {
                 project: ["tsconfig.json", "tsconfig.compile.json"],
             },

--- a/evap/static/ts/src/base-template.ts
+++ b/evap/static/ts/src/base-template.ts
@@ -4,7 +4,7 @@
 document.addEventListener("shown.bs.modal", e => {
     if (!e.target) return;
     const modalEl = e.target as HTMLElement;
-    const autofocusEl = modalEl.querySelector("[autofocus]") as HTMLElement;
+    const autofocusEl = modalEl.querySelector<HTMLElement>("[autofocus]");
     if (autofocusEl) {
         autofocusEl.focus();
     }

--- a/evap/static/ts/src/confirmation-modal.ts
+++ b/evap/static/ts/src/confirmation-modal.ts
@@ -46,7 +46,7 @@ export class ConfirmationModal extends HTMLElement {
     onDialogFormSubmit = (event: SubmitEvent) => {
         event.preventDefault();
 
-        const isConfirm = event.submitter?.dataset?.eventType === "confirm";
+        const isConfirm = event.submitter?.dataset.eventType === "confirm";
 
         if (isConfirm && this.internals.form && !this.internals.form.reportValidity()) {
             return;

--- a/evap/static/ts/src/contact_modal.ts
+++ b/evap/static/ts/src/contact_modal.ts
@@ -10,7 +10,7 @@ export class ContactModalLogic {
     private readonly successMessageModal: bootstrap.Modal;
     private readonly actionButtonElement: HTMLButtonElement;
     private readonly messageTextElement: HTMLInputElement;
-    private readonly showButtonElements: Array<HTMLElement>;
+    private readonly showButtonElements: HTMLElement[];
     private readonly title: string;
 
     // may be null if anonymous feedback is not enabled

--- a/evap/static/ts/src/contact_modal.ts
+++ b/evap/static/ts/src/contact_modal.ts
@@ -39,7 +39,7 @@ export class ContactModalLogic {
             try {
                 const response = await fetch("/contact", {
                     body: new URLSearchParams({
-                        anonymous: String(this.anonymousRadioElement !== null && this.anonymousRadioElement.checked),
+                        anonymous: String(this.anonymousRadioElement?.checked),
                         message,
                         title: this.title,
                     }),

--- a/evap/static/ts/src/copy-to-clipboard.ts
+++ b/evap/static/ts/src/copy-to-clipboard.ts
@@ -5,7 +5,8 @@ function copyToClipboard(text: string) {
     document.body.appendChild(el);
     const selected = selection.rangeCount > 0 ? selection.getRangeAt(0) : false;
     el.select();
-    document.execCommand("copy");
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    document.execCommand("copy"); // required by puppeteer tests
     el.remove();
     if (selected) {
         selection.removeAllRanges();

--- a/evap/static/ts/src/custom-success-form.ts
+++ b/evap/static/ts/src/custom-success-form.ts
@@ -15,7 +15,7 @@ const overrideSuccessfulSubmit = (
                 assert(response.ok);
                 onSuccess({ body, response });
             })
-            .catch(error => {
+            .catch((error: unknown) => {
                 console.error(error);
                 window.alert(window.gettext("The server is not responding."));
             });

--- a/evap/static/ts/src/datagrid.ts
+++ b/evap/static/ts/src/datagrid.ts
@@ -264,9 +264,8 @@ export class TableGrid extends DataGrid {
         if (this.sortableHeaders.size > 0) {
             const [firstColumn] = this.sortableHeaders.keys();
             return [[firstColumn, "asc"]];
-        } else {
-            return [];
         }
+        return [];
     }
 }
 

--- a/evap/static/ts/src/datagrid.ts
+++ b/evap/static/ts/src/datagrid.ts
@@ -87,7 +87,7 @@ abstract class DataGrid {
     private static NUMBER_REGEX = /^[+-]?\d+(?:[.,]\d*)?$/;
 
     private fetchRows(): Row[] {
-        let rows = [...this.container.children]
+        const rows = [...this.container.children]
             .map(row => row as HTMLElement)
             .map(row => {
                 const searchWords = this.findSearchableCells(row).flatMap(element =>
@@ -118,7 +118,7 @@ abstract class DataGrid {
     protected abstract fetchRowFilterValues(row: HTMLElement): Map<string, string[]>;
 
     private fetchRowOrderValues(row: HTMLElement): Map<string, string> {
-        let orderValues = new Map();
+        const orderValues = new Map();
         for (const column of this.sortableHeaders.keys()) {
             const cell = row.querySelector<HTMLElement>(`[data-col=${column}]`)!;
             if (cell.matches("[data-order]")) {
@@ -476,7 +476,7 @@ export class ResultGrid extends DataGrid {
     }
 
     protected fetchRowFilterValues(row: HTMLElement): Map<string, string[]> {
-        let filterValues = new Map<string, string[]>();
+        const filterValues = new Map<string, string[]>();
         for (const [name, { selector, checkboxes }] of this.filterCheckboxes.entries()) {
             // To store filter values independent of the language, use the corresponding id from the checkbox
             const values = [...row.querySelectorAll(selector)]

--- a/evap/static/ts/src/datagrid.ts
+++ b/evap/static/ts/src/datagrid.ts
@@ -34,7 +34,7 @@ abstract class DataGrid {
     protected container: HTMLElement;
     private searchInput: HTMLInputElement;
     protected rows: Row[] = [];
-    private delayTimer: any | null;
+    private delayTimer: number | undefined;
     protected state: State;
 
     protected constructor({ storageKey, head, container, searchInput }: DataGridParameters) {
@@ -59,7 +59,7 @@ abstract class DataGrid {
     }
 
     protected bindEvents() {
-        this.delayTimer = null;
+        this.delayTimer = undefined;
         this.searchInput.addEventListener("input", () => {
             clearTimeout(this.delayTimer);
             this.delayTimer = setTimeout(() => {

--- a/evap/static/ts/src/datagrid.ts
+++ b/evap/static/ts/src/datagrid.ts
@@ -362,7 +362,7 @@ export class QuestionnaireGrid extends TableGrid {
                     body: new URLSearchParams(
                         this.rows.map((row, index) => [row.element.dataset.id!, index.toString()]),
                     ),
-                }).catch(error => {
+                }).catch((error: unknown) => {
                     console.error(error);
                     window.alert(window.gettext("The server is not responding."));
                 });

--- a/evap/static/ts/src/datagrid.ts
+++ b/evap/static/ts/src/datagrid.ts
@@ -118,11 +118,11 @@ abstract class DataGrid {
     protected abstract fetchRowFilterValues(row: HTMLElement): Map<string, string[]>;
 
     private fetchRowOrderValues(row: HTMLElement): Map<string, string> {
-        const orderValues = new Map();
+        const orderValues = new Map<string, string>();
         for (const column of this.sortableHeaders.keys()) {
             const cell = row.querySelector<HTMLElement>(`[data-col=${column}]`)!;
             if (cell.matches("[data-order]")) {
-                orderValues.set(column, cell.dataset.order);
+                orderValues.set(column, cell.dataset.order!);
             } else {
                 orderValues.set(column, cell.innerHTML.trim());
             }

--- a/evap/static/ts/src/datagrid.ts
+++ b/evap/static/ts/src/datagrid.ts
@@ -138,20 +138,20 @@ abstract class DataGrid {
     protected filterRows() {
         const searchWords = DataGrid.searchWordsOf(this.state.search);
         for (const row of this.rows) {
-            const isDisplayedBySearch = searchWords.every(searchWord => {
-                return row.searchWords.some(rowWord => rowWord.includes(searchWord));
-            });
-            const isDisplayedByFilters = [...this.state.equalityFilter].every(([name, filterValues]) => {
-                return filterValues.some(filterValue => {
-                    return row.filterValues.get(name)?.some(rowValue => rowValue === filterValue);
-                });
-            });
-            const isDisplayedByRangeFilters = [...this.state.rangeFilter].every(([name, bound]) => {
-                return row.filterValues
+            const isDisplayedBySearch = searchWords.every(searchWord =>
+                row.searchWords.some(rowWord => rowWord.includes(searchWord)),
+            );
+            const isDisplayedByFilters = [...this.state.equalityFilter].every(([name, filterValues]) =>
+                filterValues.some(filterValue =>
+                    row.filterValues.get(name)?.some(rowValue => rowValue === filterValue),
+                ),
+            );
+            const isDisplayedByRangeFilters = [...this.state.rangeFilter].every(([name, bound]) =>
+                row.filterValues
                     .get(name)
                     ?.map(rawValue => parseFloat(rawValue))
-                    .some(rowValue => rowValue >= bound.low && rowValue <= bound.high);
-            });
+                    .some(rowValue => rowValue >= bound.low && rowValue <= bound.high),
+            );
             row.isDisplayed = isDisplayedBySearch && isDisplayedByFilters && isDisplayedByRangeFilters;
         }
     }
@@ -284,9 +284,9 @@ export class EvaluationGrid extends TableGrid {
     public bindEvents() {
         super.bindEvents();
         this.filterButtons.forEach(button => {
-            const count = this.rows.filter(row => {
-                return row.filterValues.get("evaluationState")!.includes(button.dataset.filter!);
-            }).length;
+            const count = this.rows.filter(row =>
+                row.filterValues.get("evaluationState")!.includes(button.dataset.filter!),
+            ).length;
             button.append(EvaluationGrid.createBadgePill(count));
 
             button.addEventListener("click", () => {
@@ -508,9 +508,7 @@ export class ResultGrid extends DataGrid {
             checkboxes.forEach(checkbox => {
                 let isActive;
                 if (this.state.equalityFilter.has(name)) {
-                    isActive = this.state.equalityFilter.get(name)!.some(filterValue => {
-                        return filterValue === checkbox.value;
-                    });
+                    isActive = this.state.equalityFilter.get(name)!.some(filterValue => filterValue === checkbox.value);
                 } else {
                     isActive = false;
                 }

--- a/evap/static/ts/src/quick-review-slider.ts
+++ b/evap/static/ts/src/quick-review-slider.ts
@@ -239,7 +239,7 @@ export class QuickReviewSlider {
     };
 
     private isWrongSubmit = (submitter: SubmitterElement) => {
-        return submitter.value === Action.MakePrivate && !("contribution" in this.selectedSlide.dataset);
+        return (submitter.value as Action) === Action.MakePrivate && !("contribution" in this.selectedSlide.dataset);
     };
 
     private transitionHandler = (item: HTMLElement) => () => {
@@ -421,7 +421,7 @@ export class QuickReviewSlider {
             last.classList.add(`to-${reversed}`);
         }
 
-        if (layer > 0) {
+        if (layer > Layer.Questionnaire) {
             let activeInParentLayer;
             if (nextActiveElement && !this.isShowingEndslide()) {
                 activeInParentLayer =

--- a/evap/static/ts/src/quick-review-slider.ts
+++ b/evap/static/ts/src/quick-review-slider.ts
@@ -55,8 +55,8 @@ export class QuickReviewSlider {
     private readonly slider: HTMLElement;
     private readonly reviewDecisionForm: HTMLFormElement;
     private readonly flagForm: HTMLFormElement;
-    private readonly sliderItems: Array<HTMLElement>;
-    private answerSlides: Array<HTMLElement> = [];
+    private readonly sliderItems: HTMLElement[];
+    private answerSlides: HTMLElement[] = [];
     private selectedSlideIndex = 0;
 
     private readonly alertSlide: HTMLElement;
@@ -66,7 +66,7 @@ export class QuickReviewSlider {
     private nextEvaluationIndex = 0;
 
     private readonly startOverTriggers: { undecided: HTMLElement; all: HTMLElement };
-    private readonly slideTriggers: Array<HTMLElement>;
+    private readonly slideTriggers: HTMLElement[];
     private readonly navigationButtons: { left: NavigationButtonWithCounters; right: NavigationButtonWithCounters };
 
     constructor(

--- a/evap/static/ts/src/quick-review-slider.ts
+++ b/evap/static/ts/src/quick-review-slider.ts
@@ -114,6 +114,7 @@ export class QuickReviewSlider {
         assert(!this.isShowingEndslide(), "No answer slide is selected!");
         return this.answerSlides[this.selectedSlideIndex];
     }
+
     public isShowingEndslide = () => this.selectedSlideIndex === this.answerSlides.length;
 
     //
@@ -238,9 +239,8 @@ export class QuickReviewSlider {
         }
     };
 
-    private isWrongSubmit = (submitter: SubmitterElement) => {
-        return (submitter.value as Action) === Action.MakePrivate && !("contribution" in this.selectedSlide.dataset);
-    };
+    private isWrongSubmit = (submitter: SubmitterElement) =>
+        (submitter.value as Action) === Action.MakePrivate && !("contribution" in this.selectedSlide.dataset);
 
     private transitionHandler = (item: HTMLElement) => () => {
         this.updateButtons();

--- a/evap/static/ts/src/student-vote.ts
+++ b/evap/static/ts/src/student-vote.ts
@@ -24,7 +24,7 @@ function selectByNumberKey(row: HTMLElement, num: number) {
     nextElement.click();
 }
 
-const studentForm = document.getElementById("student-vote-form") as HTMLElement;
+const studentForm = document.getElementById("student-vote-form")!;
 const selectables: NodeListOf<HTMLElement> = studentForm.querySelectorAll(".tab-selectable");
 const rows = Array.from(studentForm.getElementsByClassName("tab-row")) as HTMLElement[];
 const letterRegex = new RegExp("^[A-Za-zÄÖÜäöü.*+-]$");
@@ -141,7 +141,7 @@ studentForm.addEventListener("keydown", (e: KeyboardEvent) => {
 });
 
 function findCorrectInputInRow(row: HTMLElement) {
-    const alreadySelectedElement: HTMLElement = row.querySelector(".tab-selectable:checked")!;
+    const alreadySelectedElement = row.querySelector<HTMLElement>(".tab-selectable:checked");
 
     if (alreadySelectedElement) {
         return alreadySelectedElement;
@@ -171,7 +171,7 @@ document.querySelector("#btn-jump-unanswered-question")?.addEventListener("click
 
 function scrollToFirstChoiceError() {
     const firstErrorRow = document.querySelector(".row .choice-error");
-    const tabRow = firstErrorRow?.closest(".row")?.querySelector(".tab-row") as HTMLElement;
+    const tabRow = firstErrorRow?.closest(".row")?.querySelector<HTMLElement>(".tab-row");
     if (tabRow) {
         fancyFocus(findCorrectInputInRow(tabRow));
     }

--- a/evap/static/ts/src/student-vote.ts
+++ b/evap/static/ts/src/student-vote.ts
@@ -145,18 +145,16 @@ function findCorrectInputInRow(row: HTMLElement) {
 
     if (alreadySelectedElement) {
         return alreadySelectedElement;
-    } else {
-        const possibleTargets: NodeListOf<HTMLElement> = row.querySelectorAll(".tab-selectable");
-        if (possibleTargets.length === 3) {
-            // Yes-No / No-Yes question, should focus first element
-            return possibleTargets[0];
-        } else {
-            // Everything else: The middle of all the answers excluding "no answer"
-            // This also handles all the single possibility cases
-            const index = Math.floor((possibleTargets.length - 1) / 2);
-            return possibleTargets[index];
-        }
     }
+    const possibleTargets: NodeListOf<HTMLElement> = row.querySelectorAll(".tab-selectable");
+    if (possibleTargets.length === 3) {
+        // Yes-No / No-Yes question, should focus first element
+        return possibleTargets[0];
+    }
+    // Everything else: The middle of all the answers excluding "no answer"
+    // This also handles all the single possibility cases
+    const index = Math.floor((possibleTargets.length - 1) / 2);
+    return possibleTargets[index];
 }
 
 function fancyFocus(element: HTMLElement) {

--- a/evap/static/ts/src/student-vote.ts
+++ b/evap/static/ts/src/student-vote.ts
@@ -26,7 +26,7 @@ function selectByNumberKey(row: HTMLElement, num: number) {
 
 const studentForm = document.getElementById("student-vote-form") as HTMLElement;
 const selectables: NodeListOf<HTMLElement> = studentForm.querySelectorAll(".tab-selectable");
-const rows = Array.from(studentForm.getElementsByClassName("tab-row")) as Array<HTMLElement>;
+const rows = Array.from(studentForm.getElementsByClassName("tab-row")) as HTMLElement[];
 const letterRegex = new RegExp("^[A-Za-zÄÖÜäöü.*+-]$");
 
 // Sometimes we just want the browser to do its thing.

--- a/evap/static/ts/src/text-answer-warnings.ts
+++ b/evap/static/ts/src/text-answer-warnings.ts
@@ -13,7 +13,7 @@ function doesTextContainTriggerString(text: string, triggerStrings: string[]): b
 function updateTextareaWarning(textarea: HTMLTextAreaElement, textAnswerWarnings: string[][]) {
     const text = normalize(textarea.value);
 
-    let matchingWarnings = [];
+    const matchingWarnings = [];
     if (isTextMeaningless(text)) {
         matchingWarnings.push("meaningless");
     }

--- a/evap/static/ts/src/utils.ts
+++ b/evap/static/ts/src/utils.ts
@@ -4,7 +4,7 @@ export const selectOrError = <T extends Element>(selector: string, root: ParentN
     return elem;
 };
 
-export function assert(condition: unknown, message: string = "Assertion Failed"): asserts condition {
+export function assert(condition: unknown, message = "Assertion Failed"): asserts condition {
     if (!condition) throw new Error(message);
 }
 

--- a/evap/static/ts/src/utils.ts
+++ b/evap/static/ts/src/utils.ts
@@ -13,9 +13,7 @@ export function assertDefined<T>(val: T): asserts val is NonNullable<T> {
     assert(val !== null);
 }
 
-export const sleep = (ms?: number): Promise<number> => {
-    return new Promise(resolve => window.setTimeout(resolve, ms));
-};
+export const sleep = (ms?: number): Promise<number> => new Promise(resolve => window.setTimeout(resolve, ms));
 
 export const clamp = (val: number, lowest: number, highest: number) => Math.min(highest, Math.max(lowest, val));
 

--- a/evap/static/ts/tests/frontend/results-index.ts
+++ b/evap/static/ts/tests/frontend/results-index.ts
@@ -90,7 +90,7 @@ test(
 
         await page.click("[data-reset=filter]");
 
-        expect(await searchInput.evaluate(searchInput => (searchInput as HTMLInputElement).value)).toBe("");
+        expect(await searchInput.evaluate(searchInput => searchInput.value)).toBe("");
         await expect(programCheckbox).not.toBeChecked();
         await expect(courseTypeCheckbox).not.toBeChecked();
         await expect(semesterCheckbox).not.toBeChecked();

--- a/evap/static/ts/tests/frontend/results-index.ts
+++ b/evap/static/ts/tests/frontend/results-index.ts
@@ -4,13 +4,11 @@ import { pageHandler } from "../utils/page";
 import "../utils/matchers";
 
 async function fetchVisibleRows(page: Page): Promise<string[][]> {
-    return await page.$$eval(".heading-row", rows => {
-        return rows.map(row => {
+    return await page.$$eval(".heading-row", rows => rows.map(row => {
             const evaluationName = row.querySelector(".evaluation-name")!.textContent!.trim();
             const semester = row.querySelector(".semester-short-name")!.textContent!.trim();
             return [evaluationName, semester];
-        });
-    });
+        }));
 }
 
 test(

--- a/evap/static/ts/tests/frontend/results-index.ts
+++ b/evap/static/ts/tests/frontend/results-index.ts
@@ -4,11 +4,13 @@ import { pageHandler } from "../utils/page";
 import "../utils/matchers";
 
 async function fetchVisibleRows(page: Page): Promise<string[][]> {
-    return await page.$$eval(".heading-row", rows => rows.map(row => {
+    return await page.$$eval(".heading-row", rows =>
+        rows.map(row => {
             const evaluationName = row.querySelector(".evaluation-name")!.textContent!.trim();
             const semester = row.querySelector(".semester-short-name")!.textContent!.trim();
             return [evaluationName, semester];
-        }));
+        }),
+    );
 }
 
 test(

--- a/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
+++ b/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
@@ -25,8 +25,8 @@ test(
             throw new Error("Button group buttons not found.");
         }
 
-        await (editorLabels[0] as ElementHandle<Element>).click();
-        await (ownAndGeneralLabels[0] as ElementHandle<Element>).click();
+        await editorLabels[0].click();
+        await ownAndGeneralLabels[0].click();
 
         const formData = await page.evaluate(() => {
             return Object.fromEntries(new FormData(document.getElementById("evaluation-form") as HTMLFormElement));

--- a/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
+++ b/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
@@ -28,9 +28,7 @@ test(
         await editorLabels[0].click();
         await ownAndGeneralLabels[0].click();
 
-        const formData = await page.evaluate(() => {
-            return Object.fromEntries(new FormData(document.getElementById("evaluation-form") as HTMLFormElement));
-        });
+        const formData = await page.evaluate(() => Object.fromEntries(new FormData(document.getElementById("evaluation-form") as HTMLFormElement)));
 
         expect(formData["contributions-0-contributor"]).toBe(managerId);
         expect(formData["contributions-0-order"]).toBe("0");

--- a/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
+++ b/evap/static/ts/tests/frontend/staff-evaluation-edit.ts
@@ -28,7 +28,9 @@ test(
         await editorLabels[0].click();
         await ownAndGeneralLabels[0].click();
 
-        const formData = await page.evaluate(() => Object.fromEntries(new FormData(document.getElementById("evaluation-form") as HTMLFormElement)));
+        const formData = await page.evaluate(() =>
+            Object.fromEntries(new FormData(document.getElementById("evaluation-form") as HTMLFormElement)),
+        );
 
         expect(formData["contributions-0-contributor"]).toBe(managerId);
         expect(formData["contributions-0-order"]).toBe("0");

--- a/evap/static/ts/tests/frontend/staff-user-import.ts
+++ b/evap/static/ts/tests/frontend/staff-user-import.ts
@@ -6,9 +6,7 @@ test(
     "copies header",
     pageHandler("staff/user/import/normal.html", async page => {
         await page.click(".btn-link");
-        const copiedText = await page.evaluate(() => {
-            return navigator.clipboard.readText();
-        });
+        const copiedText = await page.evaluate(() => navigator.clipboard.readText());
         expect(copiedText).toBe("Title\tFirst name\tLast name\tEmail");
     }),
 );

--- a/evap/static/ts/tests/frontend/student-vote.ts
+++ b/evap/static/ts/tests/frontend/student-vote.ts
@@ -19,9 +19,7 @@ async function query(page: Page): Promise<TextResultsPublishConfirmationElements
 
 async function queryClosest(element: ElementHandle, selector: string): Promise<ElementHandle<Node>> {
     return element
-        .evaluateHandle((element, selector) => {
-            return element.closest(selector);
-        }, selector)
+        .evaluateHandle((element, selector) => element.closest(selector), selector)
         .then(handle => handle.asElement()!);
 }
 

--- a/evap/static/ts/tests/utils/matchers.ts
+++ b/evap/static/ts/tests/utils/matchers.ts
@@ -5,6 +5,7 @@ declare global {
     namespace jest {
         interface Matchers<R> {
             toBeChecked(): Promise<R>;
+
             toHaveClass(className: string): Promise<R>;
         }
     }
@@ -45,17 +46,13 @@ async function createElementMessage(
 
 expect.extend({
     async toBeChecked(received: ElementHandle): Promise<jest.CustomMatcherResult> {
-        const pass = await received.evaluate(element => {
-            return (element as HTMLInputElement).checked;
-        });
+        const pass = await received.evaluate(element => (element as HTMLInputElement).checked);
         const message = await createElementMessage.call(this, "toBeChecked", "be checked", received);
         return { message, pass };
     },
 
     async toHaveClass(received: ElementHandle, className: string): Promise<jest.CustomMatcherResult> {
-        const classList = await received.evaluate(element => {
-            return [...element.classList];
-        });
+        const classList = await received.evaluate(element => [...element.classList]);
         const pass = classList.includes(className);
         const message = await createElementMessage.call(
             this,

--- a/evap/static/ts/tests/utils/page.ts
+++ b/evap/static/ts/tests/utils/page.ts
@@ -4,7 +4,7 @@ import { Browser, Page } from "puppeteer";
 import { Global } from "@jest/types/";
 import DoneFn = Global.DoneFn;
 
-const contentTypeByExtension: Map<string, string> = new Map([
+const contentTypeByExtension = new Map<string, string>([
     [".css", "text/css"],
     [".js", "application/javascript"],
     [".png", "image/png"],

--- a/evap/static/ts/tests/utils/page.ts
+++ b/evap/static/ts/tests/utils/page.ts
@@ -16,17 +16,17 @@ async function createPage(browser: Browser): Promise<Page> {
 
     const page = await browser.newPage();
     await page.setRequestInterception(true);
-    page.on("request", request => {
+    page.on("request", async request => {
         const extension = path.extname(request.url());
         const pathname = new URL(request.url()).pathname;
         if (extension === ".html") {
             // requests like /evap/evap/static/ts/rendered/results/student.html
-            request.continue();
+            await request.continue();
         } else if (pathname.startsWith(staticPrefix)) {
             // requests like /static/css/tom-select.bootstrap5.min.css
             const asset = pathname.substring(staticPrefix.length);
             const body = fs.readFileSync(path.join(__dirname, "..", "..", "..", asset));
-            request.respond({
+            await request.respond({
                 contentType: contentTypeByExtension.get(extension),
                 body,
             });
@@ -36,12 +36,12 @@ async function createPage(browser: Browser): Promise<Page> {
             // rendered in RenderJsTranslationCatalog
             const absolute_fs_path = path.join(__dirname, "..", "..", "..", "ts", "rendered", "catalog.js");
             const body = fs.readFileSync(absolute_fs_path);
-            request.respond({
+            await request.respond({
                 contentType: contentTypeByExtension.get(extension),
                 body,
             });
         } else {
-            request.abort();
+            await request.abort();
         }
     });
     return page;

--- a/evap/static/ts/tests/utils/page.ts
+++ b/evap/static/ts/tests/utils/page.ts
@@ -24,7 +24,7 @@ async function createPage(browser: Browser): Promise<Page> {
             request.continue();
         } else if (pathname.startsWith(staticPrefix)) {
             // requests like /static/css/tom-select.bootstrap5.min.css
-            const asset = pathname.substr(staticPrefix.length);
+            const asset = pathname.substring(staticPrefix.length);
             const body = fs.readFileSync(path.join(__dirname, "..", "..", "..", asset));
             request.respond({
                 contentType: contentTypeByExtension.get(extension),

--- a/evap/static/ts/tests/utils/page.ts
+++ b/evap/static/ts/tests/utils/page.ts
@@ -47,7 +47,7 @@ async function createPage(browser: Browser): Promise<Page> {
     return page;
 }
 
-export function pageHandler(fileName: string, fn: (page: Page) => void): (done?: DoneFn) => void {
+export function pageHandler(fileName: string, fn: (page: Page) => Promise<void>): (done?: DoneFn) => Promise<void> {
     return async done => {
         let finished = false;
         // This wrapper ensures that done() is only called once
@@ -62,7 +62,7 @@ export function pageHandler(fileName: string, fn: (page: Page) => void): (done?:
             }
         }
 
-        const context = await browser.defaultBrowserContext();
+        const context = browser.defaultBrowserContext();
         await context.overridePermissions("file:", ["clipboard-read"]);
 
         const page = await createPage(browser);

--- a/evap/static/ts/tsconfig.json
+++ b/evap/static/ts/tsconfig.json
@@ -6,5 +6,5 @@
         "esModuleInterop": true,
         "moduleResolution": "node"
     },
-    "include": ["**/*.ts"]
+    "include": ["**/*.ts", "eslint.config.js"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "packages": {
         "": {
             "devDependencies": {
+                "@eslint/js": "^9.10.0",
                 "@types/bootstrap": "^5.2.10",
                 "@types/jest": "^29.5.12",
                 "@types/jest-environment-puppeteer": "^5.0.3",
@@ -19,7 +20,8 @@
                 "puppeteer": "^23.1.1",
                 "sass": "1.77.1",
                 "ts-jest": "^29.2.0",
-                "typescript": "^5.7.2"
+                "typescript": "^5.7.2",
+                "typescript-eslint": "^8.6.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -587,6 +589,171 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "node_modules/@eslint-community/eslint-utils": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+            "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.4.3"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+            }
+        },
+        "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint-community/regexpp": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@eslint/config-array": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
+            "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.4",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
+            "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+            "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ajv": "^6.12.4",
+                "debug": "^4.3.2",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.1.0",
+                "minimatch": "^3.1.2",
+                "strip-json-comments": "^3.1.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0",
+            "peer": true
+        },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "9.16.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
+            "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+            "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+            "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
         "node_modules/@hapi/hoek": {
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -602,6 +769,77 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@hapi/hoek": "^9.0.0"
+            }
+        },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.6",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@humanfs/core": "^0.19.1",
+                "@humanwhocodes/retry": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@humanwhocodes/module-importer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=12.22"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+            "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -1004,6 +1242,44 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@nodelib/fs.scandir": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "2.0.5",
+                "run-parallel": "^1.1.9"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.stat": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/@nodelib/fs.walk": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.scandir": "2.1.5",
+                "fastq": "^1.6.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@popperjs/core": {
             "version": "2.11.7",
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
@@ -1162,6 +1438,14 @@
                 "@popperjs/core": "^2.9.2"
             }
         },
+        "node_modules/@types/estree": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.6",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -1261,6 +1545,14 @@
                 "parse5": "^7.0.0"
             }
         },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@types/node": {
             "version": "18.15.11",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
@@ -1325,6 +1617,243 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.16.0.tgz",
+            "integrity": "sha512-5YTHKV8MYlyMI6BaEG7crQ9BhSc8RxzshOReKwZwRWN0+XvvTOm+L/UYLCYxFpfwYuAAqhxiq4yae0CMFwbL7Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "8.16.0",
+                "@typescript-eslint/type-utils": "8.16.0",
+                "@typescript-eslint/utils": "8.16.0",
+                "@typescript-eslint/visitor-keys": "8.16.0",
+                "graphemer": "^1.4.0",
+                "ignore": "^5.3.1",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+                "eslint": "^8.57.0 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.16.0.tgz",
+            "integrity": "sha512-D7DbgGFtsqIPIFMPJwCad9Gfi/hC0PWErRRHFnaCWoEDYi5tQUDiJCTmGUbBiLzjqAck4KcXt9Ayj0CNlIrF+w==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.16.0",
+                "@typescript-eslint/types": "8.16.0",
+                "@typescript-eslint/typescript-estree": "8.16.0",
+                "@typescript-eslint/visitor-keys": "8.16.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.16.0.tgz",
+            "integrity": "sha512-mwsZWubQvBki2t5565uxF0EYvG+FwdFb8bMtDuGQLdCCnGPrDEDvm1gtfynuKlnpzeBRqdFCkMf9jg1fnAK8sg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.16.0",
+                "@typescript-eslint/visitor-keys": "8.16.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.16.0.tgz",
+            "integrity": "sha512-IqZHGG+g1XCWX9NyqnI/0CX5LL8/18awQqmkZSl2ynn8F76j579dByc0jhfVSnSnhf7zv76mKBQv9HQFKvDCgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "8.16.0",
+                "@typescript-eslint/utils": "8.16.0",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/types": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.16.0.tgz",
+            "integrity": "sha512-NzrHj6thBAOSE4d9bsuRNMvk+BvaQvmY4dDglgkgGC0EW/tB3Kelnp3tAKH87GEwzoxgeQn9fNGRyFJM/xd+GQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.16.0.tgz",
+            "integrity": "sha512-E2+9IzzXMc1iaBy9zmo+UYvluE3TW7bCGWSF41hVWUE01o8nzr1rvOQYSxelxr6StUvRcTMe633eY8mXASMaNw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@typescript-eslint/types": "8.16.0",
+                "@typescript-eslint/visitor-keys": "8.16.0",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^1.3.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.16.0.tgz",
+            "integrity": "sha512-C1zRy/mOL8Pj157GiX4kaw7iyRLKfJXBR3L82hk5kS/GyHcOFmy4YUq/zfZti72I9wnuQtA/+xzft4wCC8PJdA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@typescript-eslint/scope-manager": "8.16.0",
+                "@typescript-eslint/types": "8.16.0",
+                "@typescript-eslint/typescript-estree": "8.16.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.16.0.tgz",
+            "integrity": "sha512-pq19gbaMOmFE3CbL0ZB8J8BFCo2ckfHBfaIsaOZgBIF4EoISJIdLX5xRhd0FGB0LlHReNRuzoJoMGpTjq8F2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.16.0",
+                "eslint-visitor-keys": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
         "node_modules/abab": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -1332,10 +1861,11 @@
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.8.2",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1351,6 +1881,17 @@
             "dependencies": {
                 "acorn": "^8.1.0",
                 "acorn-walk": "^8.0.2"
+            }
+        },
+        "node_modules/acorn-jsx": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "peerDependencies": {
+                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/acorn-walk": {
@@ -1372,6 +1913,24 @@
             },
             "engines": {
                 "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/ansi-escapes": {
@@ -2039,10 +2598,11 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -2149,6 +2709,14 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/deep-is": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -2320,6 +2888,197 @@
                 "source-map": "~0.6.1"
             }
         },
+        "node_modules/eslint": {
+            "version": "9.16.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.16.0.tgz",
+            "integrity": "sha512-whp8mSQI4C8VXd+fLgSM0lh3UlmcFtVwUQjyKCFfsp+2ItAIYhlq/hqGahGqHE6cv9unM41VlqKk2VtKYR2TaA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.19.0",
+                "@eslint/core": "^0.9.0",
+                "@eslint/eslintrc": "^3.2.0",
+                "@eslint/js": "9.16.0",
+                "@eslint/plugin-kit": "^0.2.3",
+                "@humanfs/node": "^0.16.6",
+                "@humanwhocodes/module-importer": "^1.0.1",
+                "@humanwhocodes/retry": "^0.4.1",
+                "@types/estree": "^1.0.6",
+                "@types/json-schema": "^7.0.15",
+                "ajv": "^6.12.4",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.5",
+                "debug": "^4.3.2",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^8.2.0",
+                "eslint-visitor-keys": "^4.2.0",
+                "espree": "^10.3.0",
+                "esquery": "^1.5.0",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^8.0.0",
+                "find-up": "^5.0.0",
+                "glob-parent": "^6.0.2",
+                "ignore": "^5.2.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.1.2",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.3"
+            },
+            "bin": {
+                "eslint": "bin/eslint.js"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/eslint-scope": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+            "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint-visitor-keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "is-glob": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/eslint/node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint/node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/espree": {
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+            "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "acorn": "^8.14.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2331,6 +3090,34 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/esquery": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
+            "dependencies": {
+                "estraverse": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "estraverse": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=4.0"
             }
         },
         "node_modules/estraverse": {
@@ -2447,17 +3234,60 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/fast-fifo": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
             "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
             "dev": true
         },
+        "node_modules/fast-glob": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
+        },
+        "node_modules/fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/fastq": {
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "reusify": "^1.0.4"
+            }
         },
         "node_modules/fb-watchman": {
             "version": "2.0.2",
@@ -2475,6 +3305,20 @@
             "dev": true,
             "dependencies": {
                 "pend": "~1.2.0"
+            }
+        },
+        "node_modules/file-entry-cache": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "flat-cache": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/fill-range": {
@@ -2543,6 +3387,29 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/flat-cache": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "flatted": "^3.2.9",
+                "keyv": "^4.5.4"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/flatted": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+            "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/follow-redirects": {
             "version": "1.15.6",
@@ -2782,6 +3649,13 @@
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
+        "node_modules/graphemer": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2901,6 +3775,16 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/ignore": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
         },
         "node_modules/immutable": {
             "version": "4.3.0",
@@ -4215,11 +5099,35 @@
                 "node": ">=4"
             }
         },
+        "node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -4254,6 +5162,17 @@
                 "node": ">= 10.0.0"
             }
         },
+        "node_modules/keyv": {
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
         "node_modules/kleur": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4270,6 +5189,21 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/levn": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/lines-and-columns": {
@@ -4302,6 +5236,14 @@
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
             "dev": true
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -4380,6 +5322,16 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true
+        },
+        "node_modules/merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/micromatch": {
             "version": "4.0.5",
@@ -4534,6 +5486,25 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/optionator": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/os-homedir": {
@@ -4806,6 +5777,17 @@
                 "node": ">=8"
             }
         },
+        "node_modules/prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/prettier": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
@@ -5026,6 +6008,27 @@
             "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
             "dev": true
         },
+        "node_modules/queue-microtask": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/queue-tick": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
@@ -5124,6 +6127,41 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "iojs": ">=1.0.0",
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-parallel": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "queue-microtask": "^1.2.2"
             }
         },
         "node_modules/rxjs": {
@@ -5575,6 +6613,19 @@
                 "tree-kill": "cli.js"
             }
         },
+        "node_modules/ts-api-utils": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.2.0"
+            }
+        },
         "node_modules/ts-jest": {
             "version": "29.2.0",
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.0.tgz",
@@ -5640,6 +6691,20 @@
             "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
             "dev": true
         },
+        "node_modules/type-check": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "prelude-ls": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5678,6 +6743,33 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-eslint": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.16.0.tgz",
+            "integrity": "sha512-wDkVmlY6O2do4V+lZd0GtRfbtXbeD0q9WygwXXSJnC1xorE8eqyC2L1tJimqpSeFrOzRlYtWnUp/uzgHQOgfBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.16.0",
+                "@typescript-eslint/parser": "8.16.0",
+                "@typescript-eslint/utils": "8.16.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/unbzip2-stream": {
@@ -5727,6 +6819,17 @@
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "punycode": "^2.1.0"
             }
         },
         "node_modules/url-parse": {
@@ -5856,6 +6959,17 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
         "@types/jest-environment-puppeteer": "^5.0.3",
         "@types/jquery": "^3.5.16",
         "@types/sortablejs": "^1.3.32",
+        "@eslint/js": "^9.10.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-environment-puppeteer": "^10.1.0",
@@ -14,7 +15,8 @@
         "puppeteer": "^23.1.1",
         "sass": "1.77.1",
         "ts-jest": "^29.2.0",
-        "typescript": "^5.7.2"
+        "typescript": "^5.7.2",
+        "typescript-eslint": "^8.6.0"
     },
     "jest": {
         "testRunner": "jest-jasmine2",
@@ -34,5 +36,6 @@
         "globalTeardown": "jest-environment-puppeteer/teardown",
         "testEnvironment": "jest-environment-puppeteer",
         "resolver": "jest-ts-webcompat-resolver"
-    }
+    },
+    "type": "module"
 }


### PR DESCRIPTION
Enables just recommended configs from eslint, strict typecheck and stylistic configs from tseslint.

This will not run in ci because it would just fail. Intended for local checks and Codacy: Codacy should pick this up and only check the diff