### PR TITLE
Dependabot: Ignore non-major sass updates (due to constant deprecation warnings in bootstrap) (attempt 2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
       - dependency-name: "*puppeteer*"
         update-types: ["version-update:semver-minor"]
       - dependency-name: "sass"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-minor"]
     labels:
       - "[T] Dependencies"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Sorry, I messed up #2280, it should have been "ignore minor updates". Ignoring major updates doesn't help (at least that the I explanation I hope is correct to justify 2286)