### PR TITLE
Add `typing-extensions` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ mozilla-django-oidc==4.0.1
 openpyxl==3.1.5
 psycopg2-binary==2.9.9
 redis==5.1.0
+typing-extensions==4.12.2
 xlwt==1.3.0


### PR DESCRIPTION
Although it is a transitive dependency already, we have been using it directly for some time now, so this seems appropriate.