### PR TITLE
Reset translation in test tearDown

### DIFF
--- a/evap/contributor/tests/test_forms.py
+++ b/evap/contributor/tests/test_forms.py
@@ -1,10 +1,9 @@
 from django.forms.models import inlineformset_factory
-from django.test import TestCase
 from model_bakery import baker
 
 from evap.contributor.forms import EditorContributionForm, EvaluationForm
 from evap.evaluation.models import Contribution, Evaluation, Program, Questionnaire, UserProfile
-from evap.evaluation.tests.tools import WebTest, get_form_data_from_instance
+from evap.evaluation.tests.tools import TestCase, WebTest, get_form_data_from_instance
 from evap.staff.forms import ContributionFormset
 
 

--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -1,11 +1,11 @@
 import xlrd
 from django.core import mail
 from django.urls import reverse
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import Contribution, Course, Evaluation, Questionnaire, UserProfile
 from evap.evaluation.tests.tools import (
+    WebTest,
     WebTestWith200Check,
     create_evaluation_with_responsible_and_editor,
     render_pages,

--- a/evap/development/tests/test_commands.py
+++ b/evap/development/tests/test_commands.py
@@ -4,7 +4,8 @@ from unittest.mock import call, patch
 
 from django.conf import settings
 from django.core import management
-from django.test import TestCase
+
+from evap.evaluation.tests.tools import TestCase
 
 
 class TestDumpTestDataCommand(TestCase):

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -11,7 +11,6 @@ from django.contrib.auth.hashers import make_password
 from django.core import mail, management
 from django.core.management import CommandError
 from django.db.models import Sum
-from django.test import TestCase
 from django.test.utils import override_settings
 from model_bakery import baker
 
@@ -29,7 +28,7 @@ from evap.evaluation.models import (
     TextAnswer,
     UserProfile,
 )
-from evap.evaluation.tests.tools import make_manager, make_rating_answer_counters
+from evap.evaluation.tests.tools import TestCase, make_manager, make_rating_answer_counters
 from evap.tools import MonthAndDay
 
 

--- a/evap/evaluation/tests/test_forms.py
+++ b/evap/evaluation/tests/test_forms.py
@@ -1,9 +1,8 @@
-from django.test import TestCase
 from model_bakery import baker
 
 from evap.evaluation.forms import NewKeyForm, ProfileForm
 from evap.evaluation.models import UserProfile
-from evap.evaluation.tests.tools import get_form_data_from_instance
+from evap.evaluation.tests.tools import TestCase, get_form_data_from_instance
 
 
 class TestNewKeyForm(TestCase):

--- a/evap/evaluation/tests/test_misc.py
+++ b/evap/evaluation/tests/test_misc.py
@@ -3,13 +3,12 @@ from io import StringIO
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from model_bakery import baker
 
 from evap.evaluation.models import CourseType, Program, Semester, UserProfile
-from evap.evaluation.tests.tools import make_manager, submit_with_modal
+from evap.evaluation.tests.tools import TestCase, make_manager, submit_with_modal
 from evap.staff.tests.utils import WebTestStaffMode
 
 

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -5,8 +5,7 @@ from django.contrib.auth.models import Group
 from django.core import mail
 from django.core.cache import caches
 from django.core.exceptions import ValidationError
-from django.test import TestCase, override_settings
-from django_webtest import WebTest
+from django.test import override_settings
 from model_bakery import baker
 
 from evap.evaluation.models import (
@@ -25,6 +24,8 @@ from evap.evaluation.models import (
     UserProfile,
 )
 from evap.evaluation.tests.tools import (
+    TestCase,
+    WebTest,
     let_user_vote_for_evaluation,
     make_contributor,
     make_editor,

--- a/evap/evaluation/tests/test_models_logging.py
+++ b/evap/evaluation/tests/test_models_logging.py
@@ -1,11 +1,11 @@
 from datetime import date, datetime, timedelta
 
-from django.test import TestCase
 from django.utils.formats import localize
 from model_bakery import baker
 
 from evap.evaluation.models import Contribution, Course, Evaluation, Questionnaire, UserProfile
 from evap.evaluation.models_logging import FieldAction, InstanceActionType
+from evap.evaluation.tests.tools import TestCase
 
 
 class TestLoggedModel(TestCase):

--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -5,12 +5,11 @@ from django.core import management
 from django.core.exceptions import SuspiciousOperation
 from django.db.models import Model, prefetch_related_objects
 from django.http import Http404
-from django.test.testcases import TestCase
 from django.utils import translation
 from model_bakery import baker
 
 from evap.evaluation.models import Contribution, Course, Evaluation, TextAnswer, UserProfile
-from evap.evaluation.tests.tools import WebTest
+from evap.evaluation.tests.tools import TestCase, WebTest
 from evap.evaluation.tools import (
     discard_cached_related_objects,
     get_object_from_dict_pk_entry_or_logged_40x,
@@ -36,8 +35,6 @@ class TestLanguageMiddleware(WebTest):
         user.refresh_from_db()
         self.assertEqual(user.language, "de")
         self.assertEqual(translation.get_language(), "de")
-
-        translation.activate("en")  # for following tests
 
 
 class SaboteurError(Exception):

--- a/evap/evaluation/tests/test_views.py
+++ b/evap/evaluation/tests/test_views.py
@@ -3,12 +3,11 @@ from django.contrib.auth.models import Group
 from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
-from django.utils import translation
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import Evaluation, Question, QuestionType, Semester, UserProfile
 from evap.evaluation.tests.tools import (
+    WebTest,
     WebTestWith200Check,
     create_evaluation_with_responsible_and_editor,
     make_manager,
@@ -159,8 +158,6 @@ class TestChangeLanguageView(WebTest):
 
         user.refresh_from_db()
         self.assertEqual(user.language, "en")
-
-        translation.activate("en")  # for following tests
 
 
 class TestProfileView(WebTest):

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -4,14 +4,15 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from datetime import timedelta
 
+import django.test
+import django_webtest
 import webtest
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.http.request import QueryDict
 from django.test.utils import CaptureQueriesContext
-from django.utils import timezone
-from django_webtest import WebTest
+from django.utils import timezone, translation
 from model_bakery import baker
 
 from evap.evaluation.models import (
@@ -26,6 +27,20 @@ from evap.evaluation.models import (
     TextAnswer,
     UserProfile,
 )
+
+
+class ResetLanguageOnTearDownMixin:
+    def tearDown(self):
+        translation.activate("en")  # Django by default does not "reset" this, causing test interdependency
+        super().tearDown()
+
+
+class TestCase(ResetLanguageOnTearDownMixin, django.test.TestCase):
+    pass
+
+
+class WebTest(ResetLanguageOnTearDownMixin, django_webtest.WebTest):
+    pass
 
 
 def to_querydict(dictionary):

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -3,11 +3,10 @@ from datetime import date, datetime, timedelta
 from django.contrib.auth.models import Group
 from django.core import mail
 from django.urls import reverse
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import Contribution, Course, Evaluation, Questionnaire, Semester, UserProfile
-from evap.evaluation.tests.tools import WebTestWith200Check
+from evap.evaluation.tests.tools import WebTest, WebTestWith200Check
 from evap.grades.models import GradeDocument
 
 

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -55,6 +55,7 @@ class GradeUploadTest(WebTest):
         for course in Course.objects.all():
             for grade_document in course.grade_documents.all():
                 grade_document.file.delete()
+        super().tearDown()
 
     def helper_upload_grades(self, course, final_grades):
         upload_files = [("file", "grades.txt", b"Some content")]

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -1,7 +1,6 @@
 from io import BytesIO
 
 import xlrd
-from django.test import TestCase
 from django.utils import translation
 from model_bakery import baker
 
@@ -19,7 +18,7 @@ from evap.evaluation.models import (
     TextAnswer,
     UserProfile,
 )
-from evap.evaluation.tests.tools import make_rating_answer_counters
+from evap.evaluation.tests.tools import TestCase, make_rating_answer_counters
 from evap.results.exporters import ResultsExporter, TextAnswerExporter
 from evap.results.tools import cache_results, get_results
 from evap.results.views import filter_text_answers

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from django.conf import settings
 from django.core.cache import caches
 from django.test import override_settings
-from django.test.testcases import TestCase
 from model_bakery import baker
 
 from evap.evaluation.models import (
@@ -17,7 +16,7 @@ from evap.evaluation.models import (
     TextAnswer,
     UserProfile,
 )
-from evap.evaluation.tests.tools import make_rating_answer_counters
+from evap.evaluation.tests.tools import TestCase, make_rating_answer_counters
 from evap.results.tools import (
     cache_results,
     calculate_average_course_distribution,

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -6,9 +6,7 @@ from django.core.cache import caches
 from django.core.management import call_command
 from django.db import connection
 from django.test import override_settings
-from django.test.testcases import TestCase
 from django.test.utils import CaptureQueriesContext
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import (
@@ -25,6 +23,8 @@ from evap.evaluation.models import (
     UserProfile,
 )
 from evap.evaluation.tests.tools import (
+    TestCase,
+    WebTest,
     let_user_vote_for_evaluation,
     make_manager,
     make_rating_answer_counters,

--- a/evap/rewards/tests/test_tools.py
+++ b/evap/rewards/tests/test_tools.py
@@ -1,9 +1,9 @@
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from django.urls import reverse
 from model_bakery import baker
 
 from evap.evaluation.models import NO_ANSWER, Course, Evaluation, Question, Questionnaire, QuestionType, UserProfile
-from evap.evaluation.tests.tools import WebTest
+from evap.evaluation.tests.tools import TestCase, WebTest
 from evap.rewards.models import RewardPointGranting, SemesterActivation
 from evap.rewards.tools import reward_points_of_user
 

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -2,11 +2,10 @@ from datetime import date, timedelta
 
 from django.test import override_settings
 from django.urls import reverse
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import Course, Evaluation, Semester, UserProfile
-from evap.evaluation.tests.tools import make_manager
+from evap.evaluation.tests.tools import WebTest, make_manager
 from evap.rewards.models import (
     RewardPointGranting,
     RewardPointRedemption,

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from django.forms.models import inlineformset_factory
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from model_bakery import baker
 
 from evap.contributor.forms import EvaluationForm as ContributorEvaluationForm
@@ -21,6 +21,7 @@ from evap.evaluation.models import (
     UserProfile,
 )
 from evap.evaluation.tests.tools import (
+    TestCase,
     create_evaluation_with_responsible_and_editor,
     get_form_data_from_instance,
     to_querydict,

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -6,12 +6,12 @@ from unittest.mock import patch
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms.models import model_to_dict
-from django.test import TestCase, override_settings
+from django.test import override_settings
 from model_bakery import baker
 
 import evap.staff.fixtures.excel_files_test_data as excel_data
 from evap.evaluation.models import Contribution, Course, CourseType, Evaluation, Program, Semester, UserProfile
-from evap.evaluation.tests.tools import assert_no_database_modifications
+from evap.evaluation.tests.tools import TestCase, assert_no_database_modifications
 from evap.staff.importers import (
     ImporterLog,
     ImporterLogEntry,

--- a/evap/staff/tests/test_tools.py
+++ b/evap/staff/tests/test_tools.py
@@ -3,14 +3,12 @@ from itertools import cycle, repeat
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import Group
-from django.test import TestCase
 from django.utils.html import escape
-from django_webtest import WebTest
 from model_bakery import baker
 from openpyxl import load_workbook
 
 from evap.evaluation.models import Contribution, Course, Evaluation, UserProfile
-from evap.evaluation.tests.tools import assert_no_database_modifications
+from evap.evaluation.tests.tools import TestCase, WebTest, assert_no_database_modifications
 from evap.rewards.models import RewardPointGranting, RewardPointRedemption
 from evap.staff.fixtures.excel_files_test_data import (
     create_memory_csv_file,

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -14,10 +14,8 @@ from django.core import mail
 from django.db.models import Model
 from django.http import HttpResponse
 from django.test import override_settings
-from django.test.testcases import TestCase
 from django.urls import reverse
 from django.utils import translation
-from django_webtest import WebTest
 from model_bakery import baker
 
 import evap.staff.fixtures.excel_files_test_data as excel_data
@@ -41,6 +39,8 @@ from evap.evaluation.models import (
 )
 from evap.evaluation.tests.tools import (
     FuzzyInt,
+    TestCase,
+    WebTest,
     assert_no_database_modifications,
     create_evaluation_with_responsible_and_editor,
     let_user_vote_for_evaluation,

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2379,6 +2379,7 @@ class TestEvaluationImportPersonsView(WebTestStaffMode):
     def tearDown(self):
         # delete the uploaded file again so other tests can start with no file guaranteed
         helper_delete_all_import_files(self.manager.id)
+        super().tearDown()
 
     def test_import_valid_participants_file(self):
         page = self.app.get(self.url, user=self.manager)

--- a/evap/staff/tests/utils.py
+++ b/evap/staff/tests/utils.py
@@ -2,9 +2,7 @@ import os
 import time
 from contextlib import contextmanager
 
-from django_webtest import WebTest
-
-from evap.evaluation.tests.tools import WebTestWith200Check
+from evap.evaluation.tests.tools import WebTest, WebTestWith200Check
 from evap.staff.tools import ImportType, generate_import_filename
 
 

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -3,7 +3,6 @@ from fractions import Fraction
 from functools import partial
 
 from django.test.utils import override_settings
-from django_webtest import WebTest
 from model_bakery import baker
 
 from evap.evaluation.models import (
@@ -19,7 +18,7 @@ from evap.evaluation.models import (
     UserProfile,
     VoteTimestamp,
 )
-from evap.evaluation.tests.tools import FuzzyInt, WebTestWith200Check, render_pages
+from evap.evaluation.tests.tools import FuzzyInt, WebTest, WebTestWith200Check, render_pages
 from evap.student.tools import answer_field_id
 from evap.student.views import SUCCESS_MAGIC_STRING
 


### PR DESCRIPTION
Fixes order-dependent tests (as caused failure in https://github.com/e-valuation/EvaP/actions/runs/11331145512/job/31510516990)