### PR TITLE
Add python wrapper for IDEs

### DIFF
--- a/nix/nix-python
+++ b/nix/nix-python
@@ -1,3 +1,3 @@
 #!/bin/sh
-SCRIPTPATH="$( cd -- "$(dirname "$0")"/.. >/dev/null 2>&1 || exit 1 ; pwd -P )"
+SCRIPTPATH="$(realpath "$(dirname "$0")"/.. )"
 exec nix develop "$SCRIPTPATH" --command python "$@"

--- a/nix/nix-python
+++ b/nix/nix-python
@@ -1,0 +1,3 @@
+#!/bin/sh
+SCRIPTPATH="$( cd -- "$(dirname "$0")"/.. >/dev/null 2>&1 || exit 1 ; pwd -P )"
+exec nix develop "$SCRIPTPATH" --command python "$@"

--- a/nix/nix-python
+++ b/nix/nix-python
@@ -1,3 +1,4 @@
 #!/bin/sh
-SCRIPTPATH="$(realpath "$(dirname "$0")"/.. )"
-exec nix develop "$SCRIPTPATH" --command python "$@"
+SCRIPTPATH=$(dirname "$0")
+FLAKEPATH=$(realpath "$SCRIPTPATH/..")
+exec nix develop "$FLAKEPATH" --command python "$@"


### PR DESCRIPTION
This might come in handy for IDEs insisting on a single python executable path for setting the python interpreter. So far, tested with JetBrains' PyCharm on Windows and Linux.

For PyCharm, one can [select](https://www.jetbrains.com/help/pycharm/configuring-python-interpreter.html) this as an existing interpreter to get full python hightlighing, introspection and documentations. Just tested with PyCharm 2024.2.3 (#JBC-242.23339.19 on wsl 2.3.24.0). For VSCode, this might come in handy as well.
For PyCharm, one can set the "terminal shell path" (search for it) to `nix develop` to instantly start in a development shell. I expect there to be a similar config for VSCode.
Maybe this is worth a comment in the wiki? However, this just works around missing IDE features.

Adapted https://intellij-support.jetbrains.com/hc/en-us/community/posts/360008227939/comments/9528610214802 for `nix develop` and inlined the `PYTHONCMD` to prevent unexpected parameter unpacking.