### PR TITLE
MacOS nix fixes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
       devShells = forAllSystems (system:
         let
           pkgs = pkgsFor.${system};
+          extras = if pkgs.stdenv.isDarwin then [ "psycopg-c" ] else [ "psycopg-binary" ];
         in
         rec {
           evap = pkgs.callPackage ./nix/shell.nix {
@@ -30,6 +31,7 @@
             poetry2nix = inputs.poetry2nix.lib.mkPoetry2Nix { inherit pkgs; };
             pyproject = ./pyproject.toml;
             poetrylock = ./poetry.lock;
+            inherit extras;
           };
           evap-dev = evap.override { poetry-groups = [ "dev" ]; };
           default = evap-dev;

--- a/nix/services.nix
+++ b/nix/services.nix
@@ -67,7 +67,7 @@
         fi
         set -x
         cp deployment/localsettings.template.py evap/localsettings.py
-        sed -i -e "s/\$SECRET_KEY/$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)/" evap/localsettings.py
+        sed -i -e "s/\$SECRET_KEY/$(head /dev/urandom | LC_ALL=C tr -dc A-Za-z0-9 | head -c 32)/" evap/localsettings.py
         git submodule update --init
         ./manage.py migrate --noinput
         ./manage.py collectstatic --noinput

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs, python3, poetry2nix, pyproject, poetrylock, poetry-groups ? [ ], extraPackages ? [ ], extraPythonPackages ? (ps: [ ]), ... }:
+{ pkgs, lib ? pkgs.lib, python3, poetry2nix, pyproject, poetrylock, extras ? [ ], poetry-groups ? [ ], extraPackages ? [ ], extraPythonPackages ? (ps: [ ]), ... }:
 
 let
   # When running a nix shell, XDG_DATA_DIRS will be populated so that bash_completion can (lazily) find this completion script
@@ -17,11 +17,22 @@ let
   poetry-env = poetry2nix.mkPoetryEnv {
     python = python3;
     # We pass these instead of `projectDir` to avoid adding the dependency on other files.
-    inherit pyproject poetrylock;
+    inherit pyproject poetrylock extras;
     preferWheels = true;
     overrides = poetry2nix.overrides.withDefaults (final: prev: {
       # https://github.com/nix-community/poetry2nix/issues/1499
       django-stubs-ext = prev.django-stubs-ext.override { preferWheel = false; };
+
+      psycopg = prev.psycopg.overridePythonAttrs (old: {
+        buildInputs = old.buildInputs or [ ]
+          ++ lib.optionals pkgs.stdenv.isDarwin [ pkgs.openssl ];
+        propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [ pkgs.postgresql ];
+      });
+
+      psycopg-c = prev.psycopg-c.overridePythonAttrs (old: {
+        nativeBuildInputs = old.nativeBuildInputs or [ ] ++ [ pkgs.postgresql ];
+        propagatedBuildInputs = old.propagatedBuildInputs or [ ] ++ [ final.setuptools ];
+      });
     });
     groups = poetry-groups;
     checkGroups = [ ]; # would otherwise always install dev-dependencies

--- a/poetry.lock
+++ b/poetry.lock
@@ -824,7 +824,6 @@ files = [
 ]
 
 [package.dependencies]
-psycopg-binary = {version = "3.2.3", optional = true, markers = "implementation_name != \"pypy\" and extra == \"binary\""}
 typing-extensions = {version = ">=4.6", markers = "python_version < \"3.13\""}
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
@@ -840,7 +839,7 @@ test = ["anyio (>=4.0)", "mypy (>=1.11)", "pproxy (>=2.7)", "pytest (>=6.2.5)", 
 name = "psycopg-binary"
 version = "3.2.3"
 description = "PostgreSQL database adapter for Python -- C optimisation distribution"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "psycopg_binary-3.2.3-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:965455eac8547f32b3181d5ec9ad8b9be500c10fe06193543efaaebe3e4ce70c"},
@@ -907,6 +906,16 @@ files = [
     {file = "psycopg_binary-3.2.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:f0b018e37608c3bfc6039a1dc4eb461e89334465a19916be0153c757a78ea426"},
     {file = "psycopg_binary-3.2.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2a29f5294b0b6360bfda69653697eff70aaf2908f58d1073b0acd6f6ab5b5a4f"},
     {file = "psycopg_binary-3.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:e56b1fd529e5dde2d1452a7d72907b37ed1b4f07fdced5d8fb1e963acfff6749"},
+]
+
+[[package]]
+name = "psycopg-c"
+version = "3.2.3"
+description = "PostgreSQL database adapter for Python -- C optimisation distribution"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "psycopg_c-3.2.3.tar.gz", hash = "sha256:06ae7db8eaec1a3845960fa7f997f4ccdb1a7a7ab8dc593a680bcc74e1359671"},
 ]
 
 [[package]]
@@ -1265,7 +1274,11 @@ files = [
     {file = "xlwt-1.3.0.tar.gz", hash = "sha256:c59912717a9b28f1a3c2a98fd60741014b06b043936dcecbc113eaaada156c88"},
 ]
 
+[extras]
+psycopg-binary = ["psycopg-binary"]
+psycopg-c = ["psycopg-c"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.0"
-content-hash = "9554e9cb984e6e02b5b1c80f139eda4b3a864ef09c30824d00633d1eadceeb3f"
+content-hash = "d800aac484055ba0b004eeac5f3130a35295ffb650fce69ac4576bbfe6bd107f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ django-fsm = "~2.8.2"
 Django = "~5.1.0"
 mozilla-django-oidc = "~4.0.1"
 openpyxl = "~3.1.5"
-psycopg = { version = "~3.2.3", extras = ["binary"] }
+psycopg = "~3.2.3"
+psycopg-c = { version = "~3.2.3", optional = true }
+psycopg-binary = { version = "~3.2.3", optional = true }
 redis = "~5.2.0"
 typing-extensions = "~4.12.2"
 xlwt = "~1.3.0"
@@ -33,6 +35,10 @@ ruff = "~0.7.0"
 tblib = "~3.0.0"
 xlrd = "~2.0.1"
 typeguard = "~4.4.0"
+
+[tool.poetry.extras]
+psycopg-c = ["psycopg-c"]
+psycopg-binary = ["psycopg-binary"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Mac users reported issues that boiled down to `psycopg[binary]` not having a matching wheel. I thought that using the "pure Python installation" (just `psycopg`) would work, but this breaks even on Linux as the libpq dynamic library cannot be found (even when adding postgres to the nix shell packages or the build inputs of the Python packages). There is also `psycopg[c]` which compiles the extension at installation time. This seems to work and the compilation time is not too long either (on a Surface from this decade it took ~1min to compile the extension, same in a Mac VM).

Should we just default to using `psycopg[c]` on Linux too, or stick to using the binary installation on Linux?
