### PR TITLE
Replace `do_not_call_in_templates = True` class variable in enums with instance property

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -469,12 +469,15 @@ class Evaluation(LoggedModel):
     )
 
     class TextAnswerReviewState(Enum):
-        do_not_call_in_templates = True  # pylint: disable=invalid-name
         NO_TEXTANSWERS = auto()
         NO_REVIEW_NEEDED = auto()
         REVIEW_NEEDED = auto()
         REVIEW_URGENT = auto()
         REVIEWED = auto()
+
+        @property
+        def do_not_call_in_templates(self):
+            return True
 
     class Meta:
         unique_together = [


### PR DESCRIPTION
The current pattern has the following misbehavior:
```python
class E(enum.Enum):
    do_not_call_in_templates = True
    FOO = 42
assert set(E.__members__) == {"FOO", "do_not_call_in_templates"}
```

The way Django fixes this in their `Choices` class is by using
```python
class E(enum.Enum):
    FOO = 42

    @property
    def do_not_call_in_templates(self):
        return True
```

This is technically not in line with the Django documentation, which instructs us to "set a do_not_call_in_templates attribute on the callable with the value True", but still works. This is because the Django code to check this is
```python
getattr(E, "do_not_call_in_templates", False)
```
which evaluates to a `<property object ...>` and is therefore truthy.

Starting with Python 3.11, we should use
```python
class E(enum.Enum):
    do_not_call_in_templates = enum.nonmember(True)`
```
which is also what Django's `Choices` uses if available.

- https://docs.djangoproject.com/en/5.1/ref/templates/api/
