### PR TITLE
Publish EvaP to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: EvaP Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - run: |
+          RUN_ID=$(gh run --repo ${{ github.repository }} list --commit ${{ github.sha }} --status success --workflow "EvaP Test Suite" --json databaseId --jq '.[].databaseId')
+          if [ -z "$RUN_ID" ]; then
+            echo "No run found"
+            exit 1
+          fi
+          gh run --repo ${{ github.repository }} download "$RUN_ID" --name wheel --dir dist
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - run: tar tvf dist/*.tar.gz
+      - run: unzip -l dist/*.whl
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evap"
 description = "EvaP"
-version = "0.0.0"
+version = "2025.04.0"
 readme = "README.md"
 requires-python = "~=3.11.0"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evap"
 description = "EvaP"
-version = "2025.04.0rc1"
+version = "2025.4.0rc1"
 readme = "README.md"
 requires-python = "~=3.11.0"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "evap"
 description = "EvaP"
-version = "2025.04.0"
+version = "2025.04.0rc1"
 readme = "README.md"
 requires-python = "~=3.11.0"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "evap"
-version = "2025.4.0"
+version = "2025.4.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "django" },

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "evap"
-version = "0.0.0"
+version = "2025.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Closes #2303 

Since we don't want to use nix in production (for example because security updates might take a long time to propagate through nixpkgs / through our github release cycle), `pip install .` or `pip install evap` seems to be the most canonical way. This allows us to install security patches via `pip install --upgrade evap`.

If we really need to override a dependency version beyond the allowed range in `pyproject.toml`, we can install EvaP from sources outside of PyPI. The script to build the release artifacts is available as `nix run .#build-dist`. It is possible to run this on a development machine and copy the `.whl` file over to the server.

The release wheel includes compiled TypeScript, SCSS and translation files, so there is no need to install NodeJS or gettext on the production server.

The new release workflow is:
1. Add translations and commit them.
2. Bump version in `pyproject.toml`, run `nix develop .#impure --command uv lock`, commit it, tag it, push it.
3. After the CI is done on main, dispatch a release workflow run to publish the wheel to PyPI.
4. Create Github Release.

The versioning scheme we agreed on is year-month-patch, for example "2024.11.0". I suppose we should take care that we don't necessarily push breaking changes like updating the Python version in a new patch. Following the Python Packaging User Guide, we don't include leading zeros in release versions like "2025.4.0".

Since upgrading to the next stable revision of EvaP is handled by pip, there is no need for the `release` branch anymore.

See
- https://packaging.python.org/en/latest/tutorials/packaging-projects/
- https://docs.pypi.org/trusted-publishers/using-a-publisher/
- https://packaging.python.org/en/latest/specifications/version-specifiers/