### PR TITLE
format before linting

### DIFF
--- a/evap/evaluation/management/commands/precommit.py
+++ b/evap/evaluation/management/commands/precommit.py
@@ -21,5 +21,5 @@ class Command(BaseCommand):
         # subprocess call so our sys.argv check in settings.py works
         subprocess.run(["./manage.py", "test"], check=False)  # nosec
 
-        call_command("lint")
         call_command("format")
+        call_command("lint")


### PR DESCRIPTION
ruff and black have some overlaps, such as detecting/fixing trailing whitespaces. So, it is more user friendly to format before linting, so that these kinds of trivial linting errors can be fixed beforehand.