### PR TITLE
use log-level instead of loglevel prettier arg

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
         run: isort . --check --diff
       - run: ls -laR evap/static/ts
       - name: Check TypeScript formatting
-        run: npx prettier --list-different --loglevel debug 'evap/static/ts/**/*.ts'
+        run: npx prettier --list-different --log-level debug 'evap/static/ts/**/*.ts'
 
   backup-process:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
It turns out that `loglevel` has been deprecated and there has been a [warn] message in our logs for some time

See https://redirect.github.com/prettier/prettier/pull/13204