### PR TITLE
Dispatch a `click` event on an off-DOM `<a>` element when clicking on `.table-seamless-links` rows

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -183,7 +183,7 @@
             document.querySelectorAll(".table-seamless-links [data-url]").forEach(row => {
                 row.addEventListener("click", event => {
                     // We navigate via the <a> tag to enable browser behavior for Ctrl-Click. We cannot insert an actual
-                    // <a> tag, because there cannot be any non-table tags between the for example <tbody> and <tr>.
+                    // <a> tag, because there cannot be any non-table tags between for example <tbody> and <tr>.
                     const anchor = document.createElement("a");
                     anchor.href = row.dataset.url;
                     // As `event` is bound to `row`, we need to clone it.

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -182,10 +182,12 @@
             // activate clickable hover tables
             document.querySelectorAll(".table-seamless-links [data-url]").forEach(row => {
                 row.addEventListener("click", event => {
-                    // We navigate via the <a> tag to enable browser behavior for Ctrl-Click.
+                    // We navigate via the <a> tag to enable browser behavior for Ctrl-Click. We cannot insert an actual
+                    // <a> tag, because there cannot be any non-table tags between the for example <tbody> and <tr>.
                     const anchor = document.createElement("a");
                     anchor.href = row.dataset.url;
-                    anchor.dispatchEvent(new PointerEvent("click", event));
+                    // As `event` is bound to `row`, we need to clone it.
+                    anchor.dispatchEvent(new event.constructor(event.type, event));
                 });
             });
 

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -181,8 +181,11 @@
 
             // activate clickable hover tables
             document.querySelectorAll(".table-seamless-links [data-url]").forEach(row => {
-                row.addEventListener("click", () => {
-                    window.location.assign(row.dataset.url);
+                row.addEventListener("click", event => {
+                    // We navigate via the <a> tag to enable browser behavior for Ctrl-Click.
+                    const anchor = document.createElement("a");
+                    anchor.href = row.dataset.url;
+                    anchor.dispatchEvent(new PointerEvent("click", event));
                 });
             });
 

--- a/evap/static/scss/components/_tables.scss
+++ b/evap/static/scss/components/_tables.scss
@@ -35,8 +35,12 @@ $table-colors: (
     padding-bottom: 0.4rem;
 }
 
-.table-seamless-links td {
-    overflow: hidden;
+.table-seamless-links {
+  // Disable outline on cell after Ctrl-Click.
+  -moz-user-select: none;
+  td {
+      overflow: hidden;
+  }
 }
 
 // Hoverable rows


### PR DESCRIPTION
Closes #2292

This brings the interaction closer to clicking on an actual `a` tag and enables Ctrl-Click again. Having an `a` in there is still not feasible, because we cannot have any elements between `tr` and `td`.
