### PR TITLE
Silence `createsuperuser` during tests

### DIFF
--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -44,6 +44,7 @@ class TestCreateUserCommand(TestCase):
             "Kuchenbuch",
             "--email",
             "tonykuchenbuch@example.com",
+            stdout=StringIO(),
         )
 
         user = UserProfile.objects.get(email="tonykuchenbuch@example.com")


### PR DESCRIPTION
We did not spot that in #2344.