### PR TITLE
remove get_by_natural_key implementation on UserProfileManager

### DIFF
--- a/evap/development/fixtures/test_data.json
+++ b/evap/development/fixtures/test_data.json
@@ -152737,7 +152737,7 @@
     "is_superuser": false,
     "password": "pbkdf2_sha256$12000$lRV0h1V7qLSK$pKzYyUhT7l65JxoIv7Du3btUHYzfGCZ81JFtbF9ymOY=",
     "last_login": "2014-03-24T10:25:43.302",
-    "email": "dot.carlisle@external.example.com",
+    "email": null,
     "title": "",
     "first_name_given": "Dot",
     "first_name_chosen": "",

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -1688,7 +1688,9 @@ class Infotext(models.Model):
         return not (self.title or self.content)
 
 
-class UserProfileManager(BaseUserManager):
+class UserProfileManager(models.Manager["UserProfile"]):
+    normalize_email = BaseUserManager.normalize_email
+
     def create_user(self, *, email, password=None, first_name_given=None, last_name=None):
         user = self.model(email=self.normalize_email(email), first_name_given=first_name_given, last_name=last_name)
         validate_password(password, user=user)


### PR DESCRIPTION
leftover from #2249.

You can see an effect, if using the "natural key notation" `[null]`" for a UserProfile fk:

WITHOUT `remove get_by_natural_key implementation on UserProfileManager`, loading the fixture below results in 
```py
django.core.serializers.base.DeserializationError: Problem installing fixture '/home/jonas/development/evap/breakage.json': get() returned more than one UserProfile -- it returned 2!: (evaluation.evaluation:pk=356000) field_value was '[None]'
```

while WITH the commit, the error is (correctly) 
```py
django.core.serializers.base.DeserializationError: Problem installing fixture '/home/jonas/development/evap/breakage.json': ['“[None]” value must be an integer.']: (evaluation.evaluation:pk=356000) field_value was '[None]'
```

json fixture to load:
```json
[{"model": "evaluation.evaluation","pk": 356000,"fields": {"state": 80,"course": 141,"name_de": "","name_en": "","weight": 1,"is_single_result": false,"is_rewarded": true,"is_midterm_evaluation": false,"can_publish_text_results": true,"_participant_count": 62,"_voter_count": 35,"vote_start_datetime": "2022-02-02T00:00:00","vote_end_date": "2022-02-12","allow_editors_to_edit": true,"wait_for_grade_upload_before_publishing": true,"participants": [[null]],"voters": []}}]
```

I cannot think of any test for this, but browsing the django code revealed no critical changes.