### PR TITLE
Remove duplicate bootstrap import

### DIFF
--- a/evap/static/scss/components/_buttons.scss
+++ b/evap/static/scss/components/_buttons.scss
@@ -1,5 +1,3 @@
-@import "../bootstrap";
-
 .btn.fas {
     font-weight: 900;
 }


### PR DESCRIPTION
Closes #2362

This decreases the size of `evap.css` generated by `./manage.py scss --production` from 585k to 357k.
