### PR TITLE
Fix GitHub badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EvaP - Evaluation Platform
 
-[![Build Status](https://github.com/e-valuation/EvaP/workflows/EvaP%20Test%20Suite/badge.svg?branch=main)](https://github.com/e-valuation/EvaP/actions?query=workflow%3A%22EvaP+Test+Suite%22)
+[![Build Status](https://github.com/e-valuation/EvaP/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/e-valuation/EvaP/actions?query=workflow%3A%22EvaP+Test+Suite%22)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2cf538781fdc4680a7103bcf96417a9a)](https://app.codacy.com/gh/e-valuation/EvaP/dashboard)
 [![codecov](https://codecov.io/gh/e-valuation/EvaP/branch/main/graph/badge.svg)](https://codecov.io/gh/e-valuation/EvaP)
 


### PR DESCRIPTION
The existing link shows "no status". Others also reported problems with workflow names containing white-spaces. Using the workflow file name works though.

https://github.com/orgs/community/discussions/14980#discussioncomment-10165826

The linked discussion initially describes that the file reference did not work, but now it seem to work. 

Preview:

[![Build Status](https://github.com/e-valuation/EvaP/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/e-valuation/EvaP/actions?query=workflow%3A%22EvaP+Test+Suite%22)