### PR TITLE
Add step to rewards.rewardpointredemptionevent in testdata

### DIFF
--- a/evap/development/fixtures/test_data.json
+++ b/evap/development/fixtures/test_data.json
@@ -153476,7 +153476,8 @@
   "fields": {
     "name": "Big party",
     "date": "2099-12-31",
-    "redeem_end_date": "2099-12-30"
+    "redeem_end_date": "2099-12-30",
+    "step": 1
   }
 },
 {

--- a/evap/development/fixtures/test_data.json
+++ b/evap/development/fixtures/test_data.json
@@ -153477,7 +153477,7 @@
     "name": "Big party",
     "date": "2099-12-31",
     "redeem_end_date": "2099-12-30",
-    "step": 1
+    "step": 3
   }
 },
 {

--- a/evap/rewards/models.py
+++ b/evap/rewards/models.py
@@ -11,6 +11,7 @@ class RewardPointRedemptionEvent(models.Model):
     name = models.CharField(max_length=1024, verbose_name=_("event name"))
     date = models.DateField(verbose_name=_("event date"))
     redeem_end_date = models.DateField(verbose_name=_("redemption end date"))
+    # Note that we allow this value to change throughout the lifetime of the event.
     step = models.PositiveSmallIntegerField(
         verbose_name=_("redemption step"), help_text=_("Only multiples of this step can be redeemed."), default=1
     )


### PR DESCRIPTION
in #2264 the `step` field was added to `rewards.rewardpointredemptionevent` but not reflected in the `test_data.json`.

It is now added :)