### PR TITLE
Move `manage.py` content to `evap.__main__`

### DIFF
--- a/evap/__main__.py
+++ b/evap/__main__.py
@@ -8,6 +8,7 @@ from django.core.management import execute_from_command_line
 
 
 def main():
+    assert not settings.configured
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "evap.settings")
     settings.DATADIR.mkdir(exist_ok=True)
     execute_from_command_line(sys.argv)

--- a/evap/__main__.py
+++ b/evap/__main__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+from django.conf import settings
+from django.core.management import execute_from_command_line
+
+
+def main():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "evap.settings")
+    settings.DATADIR.mkdir(exist_ok=True)
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/manage.py
+++ b/manage.py
@@ -1,13 +1,5 @@
 #!/usr/bin/env python3
 
-import os
-import sys
+from evap.__main__ import main
 
-if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "evap.settings")
-
-    from django.conf import settings
-    from django.core.management import execute_from_command_line
-
-    settings.DATADIR.mkdir(exist_ok=True)
-    execute_from_command_line(sys.argv)
+main()

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
 
-from evap.__main__ import main
+import runpy
 
-main()
+runpy.run_module("evap", run_name="__main__")


### PR DESCRIPTION
This is in preparation for #2328, where we want to include the `manage.py` code, but cannot include the `manage.py` file because it is outside the `evap` module. Using `__main__` allows running management commands with `python -m evap` if evap is installed into the environment. Running `manage.py` still works, as it uses the builtin `runpy` module to simulate running `python -m evap`.