### PR TITLE
Build wheel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,22 @@ jobs:
       - name: Run tests
         run: python manage.py test --shuffle
 
+  build_wheel:
+    name: Build wheel
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: DeterminateSystems/nix-installer-action@main
+      - run: nix run .#build-dist
+      - run: tar tvf dist/*.tar.gz
+      - run: unzip -l dist/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel
+          path: dist/
+
   mypy:
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,21 @@ jobs:
           name: wheel
           path: dist/
 
+  install_wheel:
+    name: Install wheel with system Python
+    needs: build_wheel
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheel
+      - run: pip install *.whl
+      - name: Check that "evaluation" section appears in help string
+        run: python -m evap --help | grep --fixed-strings "[evaluation]"
+
   mypy:
     runs-on: ubuntu-22.04
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ TAGS
 
 # python files
 *.py[cod]
+dist/
 
 # gettext binaries
 *.mo

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,24 @@
               done
             '';
           };
+
+          build-dist = pkgs.writeShellApplication {
+            name = "build-dist";
+            runtimeInputs = with pkgs; [ nodejs gettext git ];
+            text =
+              let
+                python-dev = self.devShells.${system}.evap-dev.passthru.venv;
+                python-build = self.packages.${system}.python3.withPackages (ps: [ ps.build ]);
+              in
+              ''
+                set -x
+                npm ci
+                ${python-dev}/bin/python ./manage.py compilemessages
+                ${python-dev}/bin/python ./manage.py scss --production
+                ${python-dev}/bin/python ./manage.py ts compile --fresh
+                ${python-build}/bin/python -m build
+              '';
+          };
         });
     };
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,13 +39,31 @@ dev = [
     "typeguard~=4.4.0",
 ]
 
+[tool.uv]
+no-binary-package = [
+    "psycopg-c",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.uv]
-no-binary-package = [
-    "psycopg-c",
+[tool.hatch.build]
+skip-excluded-dirs = false  # otherwise, the artifacts below will be skipped
+exclude = [
+    "evap/static/bootstrap",
+    "evap/static/font-awesome",
+]
+artifacts = [
+    "evap/static/css/evap.css",
+    "evap/static/css/evap.css.map",
+    "evap/static/js/*.js",
+    "evap/static/js/*.map",
+    "evap/static/bootstrap/dist/js/bootstrap.bundle.min.js",
+    "evap/static/bootstrap/dist/js/bootstrap.bundle.min.js.map",
+    "evap/static/font-awesome/webfonts/",
+
+    "evap/locale/*.mo",
 ]
 
 ##############################################


### PR DESCRIPTION
This is in preparation for #2328. The entire workflow is documented in the `build-dist` nix script, which can be run via `nix run .#build-dist`. In particular, the wheel intentionally contains the built JavaScript, CSS, and translations, so that these steps don't need to be run on production anymore. To test the process, I added a CI job that builds the wheel and another that installs it using a non-nix Python installation.