### PR TITLE
Add dunder name check to manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,4 +2,5 @@
 
 import runpy
 
-runpy.run_module("evap", run_name="__main__")
+if __name__ == "__main__":
+    runpy.run_module("evap", run_name="__main__")


### PR DESCRIPTION
PyCharm's testing integration imports the `manage.py` script without a concrete reason. Without this check, the module is then executed unexpectedly, leading to an assertion error.

