### PR TITLE
Remove compiled files in clean-setup and don't collect static files in init

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             inherit (self.packages.${system}) python3;
             inherit (inputs) pyproject-nix uv2nix pyproject-build-systems;
             inherit dependency-groups;
+            our-packages = self.packages.${system};
             workspaceRoot = ./.;
           };
           evap-dev = evap.override (prev: { dependency-groups = (prev.dependency-groups or [ ]) ++ [ "dev" ]; });
@@ -106,6 +107,16 @@
                 ${python-dev}/bin/python ./manage.py scss --production
                 ${python-dev}/bin/python ./manage.py ts compile --fresh
                 ${python-build}/bin/python -m build
+              '';
+          };
+
+          clean-setup = pkgs.writeShellApplication {
+            name = "clean-setup";
+            runtimeInputs = with pkgs; [ git ];
+            text = ''
+                read -r -p "Delete node_modules/, data/, generated CSS and JS files in evap/static/, and evap/localsettings.py? [y/N] "
+                [[ "$REPLY" =~ ^[Yy]$ ]] || exit 1
+                git clean -f -X evap/static/ node_modules/ data/ evap/localsettings.py
               '';
           };
         });

--- a/nix/services.nix
+++ b/nix/services.nix
@@ -68,7 +68,6 @@
         cp deployment/localsettings.template.py evap/localsettings.py
         sed -i -e "s/\$SECRET_KEY/$(head /dev/urandom | LC_ALL=C tr -dc A-Za-z0-9 | head -c 32)/" evap/localsettings.py
         git submodule update --init
-        ./manage.py collectstatic --noinput
         ./manage.py compilemessages --locale de
         ./manage.py reload_testdata --noinput
       '';

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,17 +1,10 @@
-{ pkgs, lib ? pkgs.lib, python3, pyproject-nix, uv2nix, pyproject-build-systems, workspaceRoot, extraPackages ? [ ], dependency-groups ? [ ], ... }:
+{ pkgs, lib ? pkgs.lib, python3, pyproject-nix, uv2nix, pyproject-build-systems, workspaceRoot, extraPackages ? [ ], dependency-groups ? [ ], our-packages, ... }:
 
 let
   # When running a nix shell, XDG_DATA_DIRS will be populated so that bash_completion can (lazily) find this completion script
   evap-managepy-completion = pkgs.runCommand "evap-managepy-completion" { } ''
     mkdir -p "$out/share/bash-completion/completions"
     install ${../deployment/manage_autocompletion.sh} "$out/share/bash-completion/completions/manage.py.bash"
-  '';
-
-  clean-setup = pkgs.writeShellScriptBin "clean-setup" ''
-    read -p "Delete node_modules/, data/ and evap/localsettings.py? [y/N] "
-    [[ "$REPLY" =~ ^[Yy]$ ]] || exit 1
-    set -ex
-    rm -rf node_modules/ data/ evap/localsettings.py
   '';
 
   workspace = uv2nix.lib.workspace.loadWorkspace { inherit workspaceRoot; };
@@ -35,7 +28,7 @@ pkgs.mkShell {
     git
 
     venv
-    clean-setup
+    our-packages.clean-setup
     evap-managepy-completion
   ] ++ extraPackages;
 


### PR DESCRIPTION
We don't want to call `collectstatic` in startup as it's only necessary for production and not for development. Additionally, this MR also deletes generated JS and CSS files on clean-setup. clean-setup now also runs as `nix run .#clean-setup`.