### PR TITLE
Semesters not ordered correctly in evaluation selection on person management page 

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -164,7 +164,7 @@
                         plugins: {},
                         hideSelected: false,
                     };
-                    if (element.hasAttribute("tomselect-no-sort") && element.getAttribute("tomselect-no-sort") == 'true') {
+                    if (element.hasAttribute("tomselect-no-sort")) {
                         baseOptions.sortField = [{field:'$order'},{field:'$score'}];
                     }
                     if(element.hasAttribute("data-tomselect-fullwidth")) {

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -164,6 +164,9 @@
                         plugins: {},
                         hideSelected: false,
                     };
+                    if (element.hasAttribute("tomselect-no-sort") && element.getAttribute("tomselect-no-sort") == 'true') {
+                        baseOptions.sortField = [{field:'$order'},{field:'$score'}];
+                    }
                     if(element.hasAttribute("data-tomselect-fullwidth")) {
                         // span needed to the "remove this icon" button is right-aligned
                         baseOptions.render.item = (data, escape) => `<div class="w-100"><span class="w-100">${ escape(data.text) }</span></div>`;

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -142,6 +142,7 @@ class EvaluationParticipantCopyForm(forms.Form):
                 choices += [(semester.name, evaluation_choices)]
 
         self.fields["evaluation"].choices = choices
+        self.fields["evaluation"].widget.attrs["tomselect-no-sort"] = "true"
 
     def clean(self):
         if self.evaluation_selection_required and self.cleaned_data.get("evaluation") is None:

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -142,7 +142,7 @@ class EvaluationParticipantCopyForm(forms.Form):
                 choices += [(semester.name, evaluation_choices)]
 
         self.fields["evaluation"].choices = choices
-        self.fields["evaluation"].widget.attrs["tomselect-no-sort"] = "true"
+        self.fields["evaluation"].widget.attrs["tomselect-no-sort"] = ""
 
     def clean(self):
         if self.evaluation_selection_required and self.cleaned_data.get("evaluation") is None:


### PR DESCRIPTION
fix #2361.
This could also apply to any other tomselects where we sort the results into semester groups and sort these semester groups.
This can (now) be done adding the HTML `tomselect-no-sort` attribute to the `select` element.