### PR TITLE
Don't restrict time of day in renovate PR schedule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended"],
-  schedule: ["* 19-21 1 * *"],
+  schedule: ["* * 1 * *"],
   nix: {
     enabled: true,
   },
@@ -32,7 +32,7 @@
       groupName: "nix flakes",
       groupSlug: "nix",
       matchManagers: ["nix"],
-      schedule: ["* 19-21 1 */3 *"],
+      schedule: ["* * 1 */3 *"],
     },
   ],
 }


### PR DESCRIPTION
fixup to #2392.

As described in the commit message, if renovate is not run in the specified schedule, no PRs will be created [[renovate docs]](https://docs.renovatebot.com/key-concepts/scheduling/#global-schedule-vs-specific-schedule).

We cannot control that though, this is determined by Mend.io. They say, it's every 4 hours and we were unlucky [[mend docs]](https://docs.renovatebot.com/mend-hosted/overview/#resources-and-scheduling).