### PR TITLE
Correct redeeming users count in RewardPointRedemptionEvents overview

### DIFF
--- a/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_event_list.html
@@ -19,7 +19,7 @@
                         <td>{{ event.date }}</td>
                         <td>{{ event.redeem_end_date }}</td>
                         <td>{{ event.name }}</td>
-                        <td><span class="fas fa-user"></span> {{ event.redemptions_by_user|length }}</td>
+                        <td><span class="fas fa-user"></span> {{ event.users_with_redeemed_points|length }}</td>
                         <td class="d-flex justify-content-end gap-1">
                             <a href="{% url 'rewards:reward_point_redemption_event_export' event.id %}" class="btn btn-sm btn-primary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Export Redemptions' %}"><span class="fas fa-download"></span></a>
                             <a href="{% url 'rewards:reward_point_redemption_event_edit' event.id %}" class="btn btn-sm btn-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate 'Edit' %}"><span class="fas fa-pencil"></span></a>

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -120,22 +120,25 @@ class TestEventsView(WebTestStaffModeWith200Check):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.test_users = [make_manager()]
+        cls.manager = make_manager()
+        cls.test_users = [cls.manager]
 
         cls.redemption_event1 = baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
         baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
 
     def test_redemption_event_list(self) -> None:
+        quantity = 2
         baker.make(
             RewardPointRedemption,
             event=self.redemption_event1,
             value=1,
-            _quantity=2,
+            _quantity=quantity,
         )
         response = self.app.get(self.url, user=self.test_users[0])
 
-        self.assertContains(response, self.redemption_event1.name)
-        self.assertInHTML('<td><span class="fas fa-user"></span>2</td>', response.text)
+        self.assertInHTML(
+            f'<td>{self.redemption_event1.name}</td><td><span class="fas fa-user"></span>{quantity}</td>', response.text
+        )
         self.assertContains(response, str(self.redemption_event1.redeem_end_date))
         self.assertContains(response, str(self.redemption_event1.date))
 

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -119,11 +119,27 @@ class TestEventsView(WebTestStaffModeWith200Check):
     url = reverse("rewards:reward_point_redemption_events")
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls) -> None:
         cls.test_users = [make_manager()]
 
+        cls.redemption_event1 = baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
         baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
-        baker.make(RewardPointRedemptionEvent, redeem_end_date=date.today() + timedelta(days=1))
+
+    def test_redemption_event_list(self) -> None:
+        baker.make(
+            RewardPointRedemption,
+            event=self.redemption_event1,
+            value=1,
+            _quantity=2,
+        )
+        response = self.app.get(self.url, user=self.test_users[0])
+
+        self.assertContains(response, self.redemption_event1.name)
+        self.assertInHTML('<td><span class="fas fa-user"></span>2</td>', response.text)
+        self.assertContains(response, str(self.redemption_event1.redeem_end_date))
+        self.assertContains(response, str(self.redemption_event1.date))
+
+        self.assertInHTML('<td><span class="fas fa-user"></span>0</td>', response.text)
 
 
 class TestEventCreateView(WebTestStaffMode):


### PR DESCRIPTION
close #2386.

also adds a test that checks the corresponding number of redeeming users are present in the html.