### PR TITLE
Suppress python callstacks on lint/ts/scss command failure

### DIFF
--- a/evap/evaluation/management/commands/precommit.py
+++ b/evap/evaluation/management/commands/precommit.py
@@ -1,9 +1,10 @@
 import os.path
-import subprocess  # nosec
 import sys
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
+
+from evap.evaluation.management.commands.tools import subprocess_run_or_exit
 
 
 class Command(BaseCommand):
@@ -19,7 +20,7 @@ class Command(BaseCommand):
         call_command("typecheck")
 
         # subprocess call so our sys.argv check in settings.py works
-        subprocess.run(["./manage.py", "test"], check=False)  # nosec
+        subprocess_run_or_exit(["./manage.py", "test"])
 
         call_command("format")
         call_command("lint")

--- a/evap/evaluation/management/commands/precommit.py
+++ b/evap/evaluation/management/commands/precommit.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         call_command("typecheck")
 
         # subprocess call so our sys.argv check in settings.py works
-        subprocess_run_or_exit(["./manage.py", "test"])
+        subprocess_run_or_exit(["./manage.py", "test"], self.stdout)
 
         call_command("format")
         call_command("lint")

--- a/evap/evaluation/management/commands/scss.py
+++ b/evap/evaluation/management/commands/scss.py
@@ -1,7 +1,7 @@
-import subprocess  # nosec
-
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+
+from evap.evaluation.management.commands.tools import subprocess_run_or_exit
 
 
 class Command(BaseCommand):
@@ -34,7 +34,7 @@ class Command(BaseCommand):
             command += ["--style", "compressed", "--no-source-map"]
 
         try:
-            subprocess.run(command, check=True)  # nosec
+            subprocess_run_or_exit(command)
         except FileNotFoundError as e:
             raise CommandError("Could not find sass command") from e
         except KeyboardInterrupt:

--- a/evap/evaluation/management/commands/scss.py
+++ b/evap/evaluation/management/commands/scss.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
             command += ["--style", "compressed", "--no-source-map"]
 
         try:
-            subprocess_run_or_exit(command)
+            subprocess_run_or_exit(command, self.stdout)
         except FileNotFoundError as e:
             raise CommandError("Could not find sass command") from e
         except KeyboardInterrupt:

--- a/evap/evaluation/management/commands/tools.py
+++ b/evap/evaluation/management/commands/tools.py
@@ -50,7 +50,10 @@ def logged_call_command(stdout, *args, **kwargs):
     call_command(*args, **kwargs)
 
 
-def subprocess_run_or_exit(command: list) -> None:
+def subprocess_run_or_exit(command: list, stdout=None) -> None:
+    if stdout is not None:
+        stdout.write(f"Executing {' '.join(str(el) for el in command)}")
+
     exit_code = subprocess.run(command, check=False).returncode
     if exit_code != 0:
         sys.exit(exit_code)

--- a/evap/evaluation/management/commands/tools.py
+++ b/evap/evaluation/management/commands/tools.py
@@ -1,4 +1,5 @@
 import logging
+import subprocess
 import sys
 
 from django.conf import settings
@@ -47,3 +48,10 @@ def logged_call_command(stdout, *args, **kwargs):
     """Log execution of management command with all args."""
     stdout.write("Executing python manage.py " + " ".join(list(args) + [f"{a}={b}" for a, b in kwargs.items()]))
     call_command(*args, **kwargs)
+
+
+def subprocess_run_or_exit(command: list) -> None:
+    exit_code = subprocess.run(command, check=False).returncode
+    if exit_code != 0:
+        sys.exit(exit_code)
+    # don't sys.exit() on return code 0 so that precommit.py can chain commands

--- a/evap/evaluation/management/commands/ts.py
+++ b/evap/evaluation/management/commands/ts.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
 
     def run_command(self, command):
         try:
-            subprocess_run_or_exit(command)
+            subprocess_run_or_exit(command, self.stdout)
         except FileNotFoundError as e:
             raise CommandError(f"Could not find {command[0]} command") from e
         except KeyboardInterrupt:

--- a/evap/evaluation/management/commands/ts.py
+++ b/evap/evaluation/management/commands/ts.py
@@ -1,9 +1,10 @@
 import argparse
-import subprocess  # nosec
 
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
+
+from evap.evaluation.management.commands.tools import subprocess_run_or_exit
 
 
 class Command(BaseCommand):
@@ -36,13 +37,11 @@ class Command(BaseCommand):
 
     def run_command(self, command):
         try:
-            subprocess.run(command, check=True)  # nosec
+            subprocess_run_or_exit(command)
         except FileNotFoundError as e:
             raise CommandError(f"Could not find {command[0]} command") from e
         except KeyboardInterrupt:
             pass
-        except subprocess.CalledProcessError as e:
-            raise CommandError("Error during command execution", returncode=e.returncode) from e
 
     def compile(self, watch=False, fresh=False, **_options):
         static_directory = settings.STATICFILES_DIRS[0]

--- a/evap/evaluation/management/commands/typecheck.py
+++ b/evap/evaluation/management/commands/typecheck.py
@@ -1,6 +1,6 @@
-import subprocess  # nosec
-
 from django.core.management.base import BaseCommand
+
+from evap.evaluation.management.commands.tools import subprocess_run_or_exit
 
 
 class Command(BaseCommand):
@@ -9,4 +9,4 @@ class Command(BaseCommand):
     requires_migrations_checks = False
 
     def handle(self, *args, **options):
-        subprocess.run(["mypy"], check=True)  # nosec
+        subprocess_run_or_exit(["mypy"])

--- a/evap/evaluation/management/commands/typecheck.py
+++ b/evap/evaluation/management/commands/typecheck.py
@@ -9,4 +9,4 @@ class Command(BaseCommand):
     requires_migrations_checks = False
 
     def handle(self, *args, **options):
-        subprocess_run_or_exit(["mypy"])
+        subprocess_run_or_exit(["mypy"], self.stdout)

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -31,6 +31,10 @@ from evap.evaluation.tests.tools import TestCase, make_manager, make_rating_answ
 from evap.tools import MonthAndDay
 
 
+class FakeSubprocessRunResult:
+    returncode = 0
+
+
 class TestCreateUserCommand(TestCase):
     # Regression test for #2204 - createsuperuser failing due to misconfigured REQUIRED_FIELDS
     def test_create_super_user(self):
@@ -206,16 +210,16 @@ class TestScssCommand(TestCase):
         self.scss_path = settings.STATICFILES_DIRS[0] / "scss" / "evap.scss"
         self.css_path = settings.STATICFILES_DIRS[0] / "css" / "evap.css"
 
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_scss_called(self, mock_subprocess_run):
         management.call_command("scss")
 
         mock_subprocess_run.assert_called_once_with(
             ["npx", "sass", self.scss_path, self.css_path],
-            check=True,
+            check=False,
         )
 
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_scss_watch_called(self, mock_subprocess_run):
         mock_subprocess_run.side_effect = KeyboardInterrupt
 
@@ -223,19 +227,19 @@ class TestScssCommand(TestCase):
 
         mock_subprocess_run.assert_called_once_with(
             ["npx", "sass", self.scss_path, self.css_path, "--watch", "--poll"],
-            check=True,
+            check=False,
         )
 
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_scss_production_called(self, mock_subprocess_run):
         management.call_command("scss", "--production")
 
         mock_subprocess_run.assert_called_once_with(
             ["npx", "sass", self.scss_path, self.css_path, "--style", "compressed", "--no-source-map"],
-            check=True,
+            check=False,
         )
 
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_scss_called_with_no_sass_installed(self, mock_subprocess_run):
         mock_subprocess_run.side_effect = FileNotFoundError()
 
@@ -247,16 +251,16 @@ class TestTsCommand(TestCase):
     def setUp(self):
         self.ts_path = settings.STATICFILES_DIRS[0] / "ts"
 
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_ts_compile(self, mock_subprocess_run):
         management.call_command("ts", "compile")
 
         mock_subprocess_run.assert_called_once_with(
             ["npx", "tsc", "--project", self.ts_path / "tsconfig.compile.json"],
-            check=True,
+            check=False,
         )
 
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_ts_compile_with_watch(self, mock_subprocess_run):
         mock_subprocess_run.side_effect = KeyboardInterrupt
 
@@ -264,10 +268,10 @@ class TestTsCommand(TestCase):
 
         mock_subprocess_run.assert_called_once_with(
             ["npx", "tsc", "--project", self.ts_path / "tsconfig.compile.json", "--watch"],
-            check=True,
+            check=False,
         )
 
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     @patch("evap.evaluation.management.commands.ts.call_command")
     def test_ts_test(self, mock_call_command, mock_subprocess_run):
         management.call_command("ts", "test")
@@ -278,13 +282,13 @@ class TestTsCommand(TestCase):
             [
                 call(
                     ["npx", "tsc", "--project", self.ts_path / "tsconfig.compile.json"],
-                    check=True,
+                    check=False,
                 ),
-                call(["npx", "jest"], check=True),
+                call(["npx", "jest"], check=False),
             ]
         )
 
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_ts_called_with_no_npm_installed(self, mock_subprocess_run):
         mock_subprocess_run.side_effect = FileNotFoundError()
 
@@ -467,7 +471,7 @@ class TestSendRemindersCommand(TestCase):
 
 
 class TestLintCommand(TestCase):
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_pylint_called(self, mock_subprocess_run: MagicMock):
         management.call_command("lint", stdout=StringIO())
         self.assertEqual(mock_subprocess_run.call_count, 3)
@@ -477,7 +481,7 @@ class TestLintCommand(TestCase):
 
 
 class TestFormatCommand(TestCase):
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_formatters_called(self, mock_subprocess_run):
         management.call_command("format")
         self.assertEqual(len(mock_subprocess_run.mock_calls), 3)
@@ -491,15 +495,15 @@ class TestFormatCommand(TestCase):
 
 
 class TestTypecheckCommand(TestCase):
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_mypy_called(self, mock_subprocess_run):
         management.call_command("typecheck")
         self.assertEqual(len(mock_subprocess_run.mock_calls), 1)
-        mock_subprocess_run.assert_has_calls([call(["mypy"], check=True)])
+        mock_subprocess_run.assert_has_calls([call(["mypy"], check=False)])
 
 
 class TestPrecommitCommand(TestCase):
-    @patch("subprocess.run")
+    @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     @patch("evap.evaluation.management.commands.precommit.call_command")
     def test_subcommands_called(self, mock_call_command, mock_subprocess_run):
         management.call_command("precommit")

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -212,7 +212,7 @@ class TestScssCommand(TestCase):
 
     @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_scss_called(self, mock_subprocess_run):
-        management.call_command("scss")
+        management.call_command("scss", stdout=StringIO())
 
         mock_subprocess_run.assert_called_once_with(
             ["npx", "sass", self.scss_path, self.css_path],
@@ -223,7 +223,7 @@ class TestScssCommand(TestCase):
     def test_scss_watch_called(self, mock_subprocess_run):
         mock_subprocess_run.side_effect = KeyboardInterrupt
 
-        management.call_command("scss", "--watch")
+        management.call_command("scss", "--watch", stdout=StringIO())
 
         mock_subprocess_run.assert_called_once_with(
             ["npx", "sass", self.scss_path, self.css_path, "--watch", "--poll"],
@@ -232,7 +232,7 @@ class TestScssCommand(TestCase):
 
     @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_scss_production_called(self, mock_subprocess_run):
-        management.call_command("scss", "--production")
+        management.call_command("scss", "--production", stdout=StringIO())
 
         mock_subprocess_run.assert_called_once_with(
             ["npx", "sass", self.scss_path, self.css_path, "--style", "compressed", "--no-source-map"],
@@ -244,7 +244,7 @@ class TestScssCommand(TestCase):
         mock_subprocess_run.side_effect = FileNotFoundError()
 
         with self.assertRaisesMessage(CommandError, "Could not find sass command"):
-            management.call_command("scss")
+            management.call_command("scss", stdout=StringIO())
 
 
 class TestTsCommand(TestCase):
@@ -253,7 +253,7 @@ class TestTsCommand(TestCase):
 
     @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_ts_compile(self, mock_subprocess_run):
-        management.call_command("ts", "compile")
+        management.call_command("ts", "compile", stdout=StringIO())
 
         mock_subprocess_run.assert_called_once_with(
             ["npx", "tsc", "--project", self.ts_path / "tsconfig.compile.json"],
@@ -264,7 +264,7 @@ class TestTsCommand(TestCase):
     def test_ts_compile_with_watch(self, mock_subprocess_run):
         mock_subprocess_run.side_effect = KeyboardInterrupt
 
-        management.call_command("ts", "compile", "--watch")
+        management.call_command("ts", "compile", "--watch", stdout=StringIO())
 
         mock_subprocess_run.assert_called_once_with(
             ["npx", "tsc", "--project", self.ts_path / "tsconfig.compile.json", "--watch"],
@@ -274,7 +274,7 @@ class TestTsCommand(TestCase):
     @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     @patch("evap.evaluation.management.commands.ts.call_command")
     def test_ts_test(self, mock_call_command, mock_subprocess_run):
-        management.call_command("ts", "test")
+        management.call_command("ts", "test", stdout=StringIO())
 
         # Mock render pages to prevent a second call into the test framework
         mock_call_command.assert_called_once_with("scss")
@@ -293,13 +293,13 @@ class TestTsCommand(TestCase):
         mock_subprocess_run.side_effect = FileNotFoundError()
 
         with self.assertRaisesMessage(CommandError, "Could not find npx command"):
-            management.call_command("ts", "compile")
+            management.call_command("ts", "compile", stdout=StringIO())
 
 
 class TestUpdateEvaluationStatesCommand(TestCase):
     def test_update_evaluations_called(self):
         with patch("evap.evaluation.models.Evaluation.update_evaluations") as mock:
-            management.call_command("update_evaluation_states")
+            management.call_command("update_evaluation_states", stdout=StringIO())
 
         self.assertEqual(mock.call_count, 1)
 
@@ -317,7 +317,7 @@ class TestSendRemindersCommand(TestCase):
         )
 
         with patch("evap.evaluation.models.EmailTemplate.send_reminder_to_user") as mock:
-            management.call_command("send_reminders")
+            management.call_command("send_reminders", stdout=StringIO())
 
         self.assertEqual(mock.call_count, 1)
         mock.assert_called_once_with(user_to_remind, first_due_in_days=2, due_evaluations=[(evaluation, 2)])
@@ -340,7 +340,7 @@ class TestSendRemindersCommand(TestCase):
         )
 
         with patch("evap.evaluation.models.EmailTemplate.send_reminder_to_user") as mock:
-            management.call_command("send_reminders")
+            management.call_command("send_reminders", stdout=StringIO())
 
         self.assertEqual(mock.call_count, 1)
         mock.assert_called_once_with(
@@ -359,7 +359,7 @@ class TestSendRemindersCommand(TestCase):
         )
 
         with patch("evap.evaluation.models.EmailTemplate.send_reminder_to_user") as mock:
-            management.call_command("send_reminders")
+            management.call_command("send_reminders", stdout=StringIO())
 
         self.assertEqual(mock.call_count, 0)
         self.assertEqual(len(mail.outbox), 0)
@@ -379,7 +379,7 @@ class TestSendRemindersCommand(TestCase):
         )
 
         with patch("evap.evaluation.models.EmailTemplate.send_to_user") as mock:
-            management.call_command("send_reminders")
+            management.call_command("send_reminders", stdout=StringIO())
 
         mock.assert_has_calls(
             [
@@ -430,7 +430,7 @@ class TestSendRemindersCommand(TestCase):
         )
 
         with patch("evap.evaluation.models.EmailTemplate.send_to_address") as send_mock:
-            management.call_command("send_reminders")
+            management.call_command("send_reminders", stdout=StringIO())
 
         send_mock.assert_has_calls(
             [
@@ -483,7 +483,7 @@ class TestLintCommand(TestCase):
 class TestFormatCommand(TestCase):
     @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_formatters_called(self, mock_subprocess_run):
-        management.call_command("format")
+        management.call_command("format", stdout=StringIO())
         self.assertEqual(len(mock_subprocess_run.mock_calls), 3)
         mock_subprocess_run.assert_has_calls(
             [
@@ -497,7 +497,7 @@ class TestFormatCommand(TestCase):
 class TestTypecheckCommand(TestCase):
     @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     def test_mypy_called(self, mock_subprocess_run):
-        management.call_command("typecheck")
+        management.call_command("typecheck", stdout=StringIO())
         self.assertEqual(len(mock_subprocess_run.mock_calls), 1)
         mock_subprocess_run.assert_has_calls([call(["mypy"], check=False)])
 
@@ -506,7 +506,7 @@ class TestPrecommitCommand(TestCase):
     @patch("subprocess.run", return_value=FakeSubprocessRunResult())
     @patch("evap.evaluation.management.commands.precommit.call_command")
     def test_subcommands_called(self, mock_call_command, mock_subprocess_run):
-        management.call_command("precommit")
+        management.call_command("precommit", stdout=StringIO())
 
         mock_subprocess_run.assert_called_with(["./manage.py", "test"], check=False)
 
@@ -532,12 +532,12 @@ class TestSendTextanswerRemindersCommand(TestCase):
             review_decision=TextAnswer.ReviewDecision.UNDECIDED,
         )
 
-        management.call_command("send_reminders")
+        management.call_command("send_reminders", stdout=StringIO())
 
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn(evaluation.name, mail.outbox[0].body)
 
     def test_send_no_reminder_if_not_needed(self):
         make_manager()
-        management.call_command("send_reminders")
+        management.call_command("send_reminders", stdout=StringIO())
         self.assertEqual(len(mail.outbox), 0)

--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -9,6 +9,7 @@ from django.http import Http404
 from django.utils import translation
 from model_bakery import baker
 
+from evap.evaluation.management.commands.tools import subprocess_run_or_exit
 from evap.evaluation.models import Contribution, Course, Evaluation, TextAnswer, UserProfile
 from evap.evaluation.tests.tools import SimpleTestCase, TestCase, WebTest
 from evap.evaluation.tools import (
@@ -198,6 +199,12 @@ class TestHelperMethods(TestCase):
 
         answer = baker.make(TextAnswer)
         self.assertEqual(get_object_from_dict_pk_entry_or_logged_40x(TextAnswer, {"pk": str(answer.pk)}, "pk"), answer)
+
+    def test_subprocess_run_or_exit(self) -> None:
+        subprocess_run_or_exit(["true"])
+
+        with self.assertRaises(SystemExit):
+            subprocess_run_or_exit(["false"])
 
 
 class TestHelperMethodsWithoutTransaction(SimpleTestCase):


### PR DESCRIPTION
just forward the exit code of the executed program instead