### PR TITLE
Fix TomSelect autocompleting prefixes to existing options on tag inputs

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -115,8 +115,12 @@
             const tagTomSelectOptions = {
                 create: true,
                 createOnBlur: true,
-                dropdownParent: document.createElement("div"),  // To make it invisible
                 delimiter: '', // we don't want the default "comma creates entry" behavior
+
+                dropdownParent: document.createElement("div"),  // To make it invisible
+                // On enter, with hidden dropdown, always add current text. Otherwise, adding a
+                // prefix of an existing item doesn't work
+                addPrecedence: true,
             };
 
             class MinimumInputLengthTomSelect extends TomSelect {


### PR DESCRIPTION
By default, TomSelect prefers previous options if the currently entered text is a prefix/substring of any of those, instead of adding a new option (note that "Add awe..." is not selected by default)
<img src="https://github.com/user-attachments/assets/aea8e1d0-a25f-479b-8bdb-a9f57a55d269" width=30%/>

We have hidden the dropdown menu for tag inputs by attaching it to some div that is not in the DOM, so from the perspective of the user, the input just "disappears" when pressing enter (as the prefix-expanded already existing element is added and then deduplicated), or a magically expanded version is added, unless we tell tomselect to prefer adding a new option

Setting this option fixes that (although still hacky, but it works, so 🤷🏼‍♂️)