### PR TITLE
Fix various TypeScript / ESLint warnings

### DIFF
--- a/evap/grades/templates/grades_course_view.html
+++ b/evap/grades/templates/grades_course_view.html
@@ -1,5 +1,7 @@
 {% extends 'grades_course_base.html' %}
 
+{% load static %}
+
 {% block content %}
     {{ block.super }}
 

--- a/evap/grades/templates/grades_course_view.html
+++ b/evap/grades/templates/grades_course_view.html
@@ -55,6 +55,8 @@
                 </table>
 
                 <script type="module">
+                    import { fadeOutThenRemove } from "{% static 'js/utils.js' %}";
+
                     document.getElementById("grade-document-deletion-form").addEventListener("submit-success", event => {
                         fadeOutThenRemove(document.getElementById(`grade-document-row-${event.detail.body.get("grade_document_id")}`));
                     });

--- a/evap/rewards/templates/rewards_reward_point_redemption_events.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_events.html
@@ -22,6 +22,8 @@
     </form>
 
     <script type="module">
+        import { fadeOutThenRemove } from "{% static 'js/utils.js' %}";
+
         const form = document.getElementById("event-deletion-form");
         form.addEventListener("submit", event => {
             event.preventDefault();

--- a/evap/rewards/templates/rewards_reward_point_redemption_events.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_events.html
@@ -1,5 +1,7 @@
 {% extends 'staff_base.html' %}
 
+{% load static %}
+
 {% block breadcrumb %}
     {{ block.super }}
     <li class="breadcrumb-item">{% translate 'Reward Point Redemption Events' %}</li>

--- a/evap/rewards/templates/rewards_reward_point_redemption_events.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_events.html
@@ -22,7 +22,7 @@
     </form>
 
     <script type="module">
-        import { fadeOutThenRemove } from "{% static 'js/utils.js' %}";
+        import { assert, fadeOutThenRemove } from "{% static 'js/utils.js' %}";
 
         const form = document.getElementById("event-deletion-form");
         form.addEventListener("submit", event => {

--- a/evap/staff/templates/staff_evaluation_person_management.html
+++ b/evap/staff/templates/staff_evaluation_person_management.html
@@ -216,9 +216,9 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}"></script>
+    <script type="module">
+        import { copyHeaders } from "{% static 'js/copy-to-clipboard.js' %}";
 
-    <script type="text/javascript">
         for(const button of document.querySelectorAll(".copy-user-headers-button")) {
             button.addEventListener("click", async () => await copyHeaders(['Title', 'First name', 'Last name', 'Email']));
         }

--- a/evap/staff/templates/staff_questionnaire_index.html
+++ b/evap/staff/templates/staff_questionnaire_index.html
@@ -37,6 +37,8 @@
         </form>
 
         <script type="module">
+            import { fadeOutThenRemove } from "{% static 'js/utils.js' %}";
+
             const form = document.getElementById("questionnaire-deletion-form");
             form.addEventListener("submit", event => {
                 event.preventDefault();

--- a/evap/staff/templates/staff_questionnaire_index.html
+++ b/evap/staff/templates/staff_questionnaire_index.html
@@ -81,7 +81,9 @@
         });
     </script>
 
-    <script type="text/javascript">
+    <script type="module">
+        import { CSRF_HEADERS } from "{% static 'js/csrf-utils.js' %}";
+
         function changeVisibility(element) {
             const questionnaire = element.closest(".questionnaire");
             const visibility = element.dataset.visibility;

--- a/evap/staff/templates/staff_questionnaire_index.html
+++ b/evap/staff/templates/staff_questionnaire_index.html
@@ -37,7 +37,7 @@
         </form>
 
         <script type="module">
-            import { fadeOutThenRemove } from "{% static 'js/utils.js' %}";
+            import { assert, fadeOutThenRemove } from "{% static 'js/utils.js' %}";
 
             const form = document.getElementById("questionnaire-deletion-form");
             form.addEventListener("submit", event => {
@@ -85,6 +85,7 @@
 
     <script type="module">
         import { CSRF_HEADERS } from "{% static 'js/csrf-utils.js' %}";
+        import { assert } from "{% static 'js/utils.js' %}";
 
         function changeVisibility(element) {
             const questionnaire = element.closest(".questionnaire");

--- a/evap/staff/templates/staff_semester_import.html
+++ b/evap/staff/templates/staff_semester_import.html
@@ -48,8 +48,9 @@
 
 {% block additional_javascript %}
     {% include 'bootstrap_datetimepicker.html' %}
-    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}"></script>
-    <script type="text/javascript">
+    <script type="module">
+        import { copyHeaders } from "{% static 'js/copy-to-clipboard.js' %}";
+
         document.getElementById("copy-headers-button").addEventListener("click", async () => await copyHeaders([
             'Program', 'Participant last name', 'Participant first name', 'Participant email address', 'Course kind',
             'Course is graded', 'Course name (de)', 'Course name (en)', 'Responsible title', 'Responsible last name',

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -497,6 +497,8 @@
                         {% csrf_token %}
                     </form>
                     <script type="module">
+                        import { fadeOutThenRemove } from "{% static 'js/utils.js' %}";
+
                         document.getElementById("course-deletion-form").addEventListener("submit-success", event => {
                             fadeOutThenRemove(document.querySelector(`#course-row-${event.detail.body.get("course_id")}`));
                         });

--- a/evap/staff/templates/staff_template_form.html
+++ b/evap/staff/templates/staff_template_form.html
@@ -40,8 +40,6 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}"></script>
-
     <script type="text/javascript">
         for(const button of document.querySelectorAll(".copy-variable-to-clipboard-btn")) {
             button.addEventListener("click", async event => await navigator.clipboard.writeText(button.dataset.variable));

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -51,8 +51,9 @@
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript" src="{% static 'js/copy-to-clipboard.js' %}"></script>
-    <script type="text/javascript">
+    <script type="module">
+        import { copyHeaders } from "{% static 'js/copy-to-clipboard.js' %}";
+
         document.getElementById("copy-user-headers-button").addEventListener("click", async () => await copyHeaders(['Title', 'First name', 'Last name', 'Email']));
     </script>
 {% endblock %}

--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -43,7 +43,7 @@ export default tseslint.config(
             "@typescript-eslint/no-unnecessary-condition": "warn",
             "@typescript-eslint/no-misused-promises": "warn",
             "@typescript-eslint/no-namespace": "warn",
-            "@typescript-eslint/no-non-null-assertion": "warn",
+            "@typescript-eslint/no-non-null-assertion": "off",
             "@typescript-eslint/no-unsafe-call": "warn",
             "@typescript-eslint/no-unsafe-member-access": "warn",
             "@typescript-eslint/no-unsafe-argument": "warn",

--- a/evap/static/ts/src/auto-form-saver.ts
+++ b/evap/static/ts/src/auto-form-saver.ts
@@ -27,11 +27,17 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 New portions and modifications are licensed under the conditions in LICENSE.md
  */
 
+import { assert } from "./utils.js";
+
 interface AutoFormSaverOptions {
     href: string;
     customKeySuffix: string;
     onSave: (arg0: AutoFormSaver) => void;
     onRestore: (arg0: AutoFormSaver) => void;
+}
+
+interface ValueElement extends Element {
+    value: string | string[] | boolean;
 }
 
 export class AutoFormSaver {
@@ -55,8 +61,8 @@ export class AutoFormSaver {
         this.bindSaveData();
     }
 
-    findFieldsToProtect(): Element[] {
-        return Array.of(...this.target.elements).filter((el: Element) => {
+    findFieldsToProtect(): ValueElement[] {
+        return Array.of(...this.target.elements).filter((el: Element): el is ValueElement => {
             if (
                 el instanceof HTMLInputElement &&
                 ["submit", "reset", "button", "file", "password", "hidden"].includes(el.type.toLowerCase())
@@ -66,6 +72,7 @@ export class AutoFormSaver {
             if (["BUTTON", "FIELDSET", "OBJECT", "OUTPUT"].includes(el.tagName)) {
                 return false;
             }
+            assert(Object.hasOwn(el, "value"));
             return true;
         });
     }
@@ -97,8 +104,7 @@ export class AutoFormSaver {
             }
             const prefix = this.getPrefix(field);
             const fieldType = field.getAttribute("type");
-            // @ts-expect-error All field objects are some kind of input field with value.
-            let value: string | string[] | boolean = field.value;
+            let value = field.value;
 
             if (field instanceof HTMLInputElement && fieldType === "checkbox") {
                 value = field.checked;

--- a/evap/static/ts/src/auto-form-saver.ts
+++ b/evap/static/ts/src/auto-form-saver.ts
@@ -72,7 +72,8 @@ export class AutoFormSaver {
             if (["BUTTON", "FIELDSET", "OBJECT", "OUTPUT"].includes(el.tagName)) {
                 return false;
             }
-            assert(Object.hasOwn(el, "value"));
+            assert("value" in el);
+            assert(typeof el.value === "string" || Array.isArray(el.value) || typeof el.value === "boolean");
             return true;
         });
     }

--- a/evap/static/ts/src/copy-to-clipboard.ts
+++ b/evap/static/ts/src/copy-to-clipboard.ts
@@ -1,3 +1,3 @@
-async function copyHeaders(headers: string[]): Promise<void> {
+export async function copyHeaders(headers: string[]): Promise<void> {
     await navigator.clipboard.writeText(headers.join("\t"));
 }

--- a/evap/static/ts/src/csrf-utils.ts
+++ b/evap/static/ts/src/csrf-utils.ts
@@ -14,8 +14,6 @@ function getCookie(name: string): string | null {
 const csrftoken = getCookie("csrftoken")!;
 export const CSRF_HEADERS = { "X-CSRFToken": csrftoken };
 
-(globalThis as any).CSRF_HEADERS = CSRF_HEADERS;
-
 export const testable = {
     getCookie,
 };

--- a/evap/static/ts/src/datagrid.ts
+++ b/evap/static/ts/src/datagrid.ts
@@ -198,12 +198,12 @@ abstract class DataGrid {
     }
 
     private restoreStateFromStorage(): State {
-        const stored = JSON.parse(localStorage.getItem(this.storageKey)!) || {};
+        const stored = JSON.parse(localStorage.getItem(this.storageKey)!) ?? {};
         return {
             equalityFilter: new Map(stored.equalityFilter),
             rangeFilter: new Map(stored.rangeFilter),
-            search: stored.search || "",
-            order: stored.order || this.defaultOrder,
+            search: stored.search ?? "",
+            order: stored.order ?? this.defaultOrder,
         };
     }
 

--- a/evap/static/ts/src/quick-review-slider.ts
+++ b/evap/static/ts/src/quick-review-slider.ts
@@ -323,7 +323,8 @@ export class QuickReviewSlider {
         this.slider.querySelector<HTMLElement>(".btn:focus")?.blur();
     };
     private updateNextEvaluation = () => {
-        let foundNext = false;
+        // https://typescript-eslint.io/rules/no-unnecessary-condition/#values-modified-within-function-calls
+        let foundNext = false as boolean;
         document.querySelectorAll<HTMLElement>("[data-next-evaluation-index]").forEach(element => {
             const isNext = saneParseInt(element.dataset.nextEvaluationIndex!) === this.nextEvaluationIndex;
             element.classList.toggle("d-none", !isNext);

--- a/evap/static/ts/src/student-vote.ts
+++ b/evap/static/ts/src/student-vote.ts
@@ -1,3 +1,5 @@
+import { selectOrError } from "./utils.js";
+
 function isInvisible(el: Element): boolean {
     if (getComputedStyle(el).display === "none") {
         return true;
@@ -24,7 +26,7 @@ function selectByNumberKey(row: HTMLElement, num: number) {
     nextElement.click();
 }
 
-const studentForm = document.getElementById("student-vote-form")!;
+const studentForm = selectOrError<HTMLFormElement>("#student-vote-form");
 const selectables: NodeListOf<HTMLElement> = studentForm.querySelectorAll(".tab-selectable");
 const rows = Array.from(studentForm.getElementsByClassName("tab-row")) as HTMLElement[];
 const letterRegex = new RegExp("^[A-Za-zÄÖÜäöü.*+-]$");

--- a/evap/static/ts/src/utils.ts
+++ b/evap/static/ts/src/utils.ts
@@ -50,5 +50,3 @@ export const fadeOutThenRemove = (element: HTMLElement) => {
         element.remove();
     }, 600);
 };
-
-(globalThis as any).assert = assert;

--- a/evap/static/ts/src/utils.ts
+++ b/evap/static/ts/src/utils.ts
@@ -52,4 +52,3 @@ export const fadeOutThenRemove = (element: HTMLElement) => {
 };
 
 (globalThis as any).assert = assert;
-(globalThis as any).fadeOutThenRemove = fadeOutThenRemove;

--- a/evap/static/ts/tsconfig.json
+++ b/evap/static/ts/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "baseUrl": ".",
-        "target": "es2022",
+        "target": "es2019",
         "strict": true,
         "esModuleInterop": true,
         "moduleResolution": "node"

--- a/evap/static/ts/tsconfig.json
+++ b/evap/static/ts/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "baseUrl": ".",
-        "target": "es2019",
+        "target": "es2022",
         "strict": true,
         "esModuleInterop": true,
         "moduleResolution": "node"

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -177,7 +177,9 @@
 
         <script type="module">
             import { AutoFormSaver } from "{% static 'js/auto-form-saver.js' %}";
-            import {initTextAnswerWarnings} from "{% static 'js/text-answer-warnings.js' %}";
+            import { CSRF_HEADERS } from "{% static 'js/csrf-utils.js' %}";
+            import { initTextAnswerWarnings } from "{% static 'js/text-answer-warnings.js' %}";
+
             const lastSavedStorageKey = "student-vote-last-saved-at-{{ evaluation.id }}-{{ request.user.id }}";
             const textResultsPublishConfirmation = {
                 top: document.querySelector("#text_results_publish_confirmation_top"),

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -179,6 +179,7 @@
             import { AutoFormSaver } from "{% static 'js/auto-form-saver.js' %}";
             import { CSRF_HEADERS } from "{% static 'js/csrf-utils.js' %}";
             import { initTextAnswerWarnings } from "{% static 'js/text-answer-warnings.js' %}";
+            import { assert } from "{% static 'js/utils.js' %}";
 
             const lastSavedStorageKey = "student-vote-last-saved-at-{{ evaluation.id }}-{{ request.user.id }}";
             const textResultsPublishConfirmation = {


### PR DESCRIPTION
The remaining warnings are:
- Various "unsafe" operations in `datagrid.ts`. I am going to leave these as is for now, as they are somewhat contained and I don't know what the best approach is.
- `typescript-eslint/no-misused-promises`, which indicates that we passed an `async` function where a sync one was expected. Our two usages are fine though.

Importantly for the second point, calling `event.preventDefault()` in an async event handler is fine if done before the first `await`, [quote MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function#description):

> Top-level code, up to and including the first await expression (if there is one), is run synchronously. In this way, an async function without an await expression will run synchronously.

Still, we might want to research whether this pattern can be enforced at compile time.

