### PR TITLE
Use django 5.2 features: `reverse` with query/fragment, auto-imports on `manage.py shell`

### DIFF
--- a/evap/evaluation/management/commands/shell.py
+++ b/evap/evaluation/management/commands/shell.py
@@ -1,0 +1,28 @@
+from django.core.management.commands import shell
+
+
+class Command(shell.Command):
+    def get_auto_imports(self):
+        return super().get_auto_imports() + [
+            "django.conf.settings",
+            "django.contrib.auth.get_user_model",
+            "django.core.cache.cache",
+            "django.db.models.Avg",
+            "django.db.models.Case",
+            "django.db.models.Count",
+            "django.db.models.Exists",
+            "django.db.models.F",
+            "django.db.models.Max",
+            "django.db.models.Min",
+            "django.db.models.OuterRef",
+            "django.db.models.Prefetch",
+            "django.db.models.Q",
+            "django.db.models.Subquery",
+            "django.db.models.Sum",
+            "django.db.models.When",
+            "django.db.transaction",
+            "django.urls.resolve",
+            "django.urls.reverse",
+            "django.urls.reverse",
+            "django.utils.timezone",
+        ]

--- a/evap/evaluation/views.py
+++ b/evap/evaluation/views.py
@@ -9,7 +9,7 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.encoding import iri_to_uri
-from django.utils.http import url_has_allowed_host_and_scheme, urlencode
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.decorators.http import require_POST
@@ -91,8 +91,7 @@ def index(request):
 
             # redirect to this view again so the staff mode middleware runs for the authenticated user.
             redirect_to = request.GET.get("next", None)
-            query_string = urlencode({"next": redirect_to}) if redirect_to else ""
-            return redirect(reverse("evaluation:index") + "?" + query_string)
+            return redirect(reverse("evaluation:index", query=({"next": redirect_to} if redirect_to else None)))
 
     # if not logged in by now, render form
     if not request.user.is_authenticated:

--- a/evap/grades/tests.py
+++ b/evap/grades/tests.py
@@ -60,9 +60,8 @@ class GradeUploadTest(WebTest):
     def helper_upload_grades(self, course, final_grades):
         upload_files = [("file", "grades.txt", b"Some content")]
 
-        final = "?final=true" if final_grades else ""
         return self.app.post(
-            f"{reverse('grades:upload_grades', args=[course.id])}{final}",
+            reverse("grades:upload_grades", args=[course.id], query=({"final": "true"} if final_grades else None)),
             params={"description_en": "Grades", "description_de": "Grades"},
             user=self.grade_publisher,
             content_type="multipart/form-data",

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -3756,7 +3756,7 @@ class ParticipationArchivingTests(WebTestStaffMode):
             reverse("staff:semester_import", args=[semester.pk]),
             reverse("staff:semester_questionnaire_assign", args=[semester.pk]),
             reverse("staff:evaluation_create_for_semester", args=[semester.pk]),
-            f"{reverse('staff:evaluation_operation', args=[semester.pk])}?evaluation={evaluation.pk}",
+            reverse("staff:evaluation_operation", args=[semester.pk], query={"evaluation": evaluation.pk}),
         ]
 
         for url in urls:

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1811,7 +1811,7 @@ def evaluation_textanswer_edit(request, textanswer_id):
     if form.is_valid():
         form.save()
         # jump to edited answer
-        url = reverse("staff:evaluation_textanswers", args=[evaluation.pk]) + "#" + str(textanswer.id)
+        url = reverse("staff:evaluation_textanswers", args=[evaluation.pk], fragment=str(textanswer.id))
         return HttpResponseRedirect(url)
 
     template_data = {


### PR DESCRIPTION
depends on #2427.

We still need django-extensions for `reset_db`. Maybe we can get by without it, I think we could then drop the dependency. There is [one usage in `reload_testdata`](https://github.com/e-valuation/EvaP/blob/main/evap/development/management/commands/reload_testdata.py#L21) and [one usage in the load_production_backup script](https://github.com/e-valuation/evap-deployment/blob/770d35fd5cb64fb6f380a0aa87ab74455d03f461/load_production_backup.sh#L47) in the deployment repo.