### PR TITLE
Prevent double tab opening

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -189,6 +189,7 @@
             // activate clickable hover tables
             document.querySelectorAll(".table-seamless-links [data-url]").forEach(row => {
                 row.addEventListener("click", event => {
+                    event.preventDefault();
                     // We navigate via the <a> tag to enable browser behavior for Ctrl-Click. We cannot insert an actual
                     // <a> tag, because there cannot be any non-table tags between for example <tbody> and <tr>.
                     const anchor = document.createElement("a");


### PR DESCRIPTION
don't open two tabs when ctrl-clicking on the vote button on the student index page