### PR TITLE
Fix artifact glob for .mo files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ artifacts = [
     "evap/static/bootstrap/dist/js/bootstrap.bundle.min.js.map",
     "evap/static/font-awesome/webfonts/",
 
-    "evap/locale/*.mo",
+    "evap/locale/**/*.mo",
 ]
 
 ##############################################


### PR DESCRIPTION
I am going to follow up with a PR to ensure that all artifacts specified in pyproject.toml are actually used.
