### PR TITLE
Introduce new bootstrap_form styling option

### DIFF
--- a/evap/contributor/templates/contributor_index.html
+++ b/evap/contributor/templates/contributor_index.html
@@ -214,7 +214,7 @@
                         <div class="modal-body">
                             {% translate 'Do you really want to delegate the preparation of the evaluation <strong data-label=""></strong>?' %}
                             <div class="my-4">
-                                {% include 'bootstrap_form.html' with form=delegate_selection_form %}
+                                {% include 'bootstrap_form.html' with form=delegate_selection_form plain=True %}
                             </div>
                             <div class="modal-submit-group">
                                 <button type="button" class="btn btn-light" data-bs-dismiss="modal">{% translate 'Cancel' %}</button>

--- a/evap/evaluation/templates/bootstrap_form_field.html
+++ b/evap/evaluation/templates/bootstrap_form_field.html
@@ -8,6 +8,11 @@
         {% elif email_form %}
             {% include 'bootstrap_form_field_label.html' with field=field class='col-md-2 pe-4' %}
             {% include 'bootstrap_form_field_widget.html' with field=field class='col-md-10' %}
+        {% elif plain %}
+            <div class="d-flex align-items-start mb-3 w-100">
+                {% include 'bootstrap_form_field_label.html' with field=field class='me-3 flex-shrink-0' %}
+                {% include 'bootstrap_form_field_widget.html' with field=field class='flex-grow-1' %}
+            </div>
         {% else %}
             {% include 'bootstrap_form_field_label.html' with field=field class='col-md-3 pe-4' %}
             {% include 'bootstrap_form_field_widget.html' with field=field class='col-md-7' %}


### PR DESCRIPTION
fix #2463 

I couldn't find any other modals with only one field, except the delegate preparation modal.