### PR TITLE
Mark `__name__ == "__main__"` as nocover in check_dist.py

### DIFF
--- a/tools/check_dist.py
+++ b/tools/check_dist.py
@@ -42,5 +42,5 @@ def main(argv):
     return ensure_all_artifacts_included(pyproject, args.wheels)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: nocover
     sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
We already do this in `enrollment_preprocessor.py` and it makes sense.
