### PR TITLE
Update nix flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741010256,
-        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
+        "lastModified": 1752480373,
+        "narHash": "sha256-JHQbm+OcGp32wAsXTE/FLYGNpb+4GLi5oTvCxwSoBOA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
+        "rev": "62e0f05ede1da0d54515d4ea8ce9c733f12d9f08",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1740324671,
-        "narHash": "sha256-djc+wRG9L70jlW95Ck4GKr7nTPp1drfsXshJkYZAd9s=",
+        "lastModified": 1749418557,
+        "narHash": "sha256-wJHHckWz4Gvj8HXtM5WVJzSKXAEPvskQANVoRiu2w1w=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "2a17e49b8a5d32278ed77e4a881f992472be18a1",
+        "rev": "91dcc48a6298e47e2441ec76df711f4e38eab94e",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740362541,
-        "narHash": "sha256-S8Mno07MspggOv/xIz5g8hB2b/C5HPiX8E+rXzKY+5U=",
+        "lastModified": 1752574539,
+        "narHash": "sha256-Dl/TGWnrsmmyFVApbpoVosAwOjocJRP2VAoOVbYK+KA=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "e151741c848ba92331af91f4e47640a1fb82be19",
+        "rev": "dfa1792728c7a3c34e22491e9fa272ed24e53012",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740921768,
-        "narHash": "sha256-4d27TdYoJ8B99b4kU7qESB4QVjiV9gPSuP2/MDqjDWo=",
+        "lastModified": 1752578158,
+        "narHash": "sha256-zWBxipfOc+BNj5WjGC6HiZinDnUHgO+23F1tNiSZmyE=",
         "owner": "nix-community",
         "repo": "pyproject.nix",
-        "rev": "ca5d23f044943a23cc4274b2d3dea45682dc025f",
+        "rev": "833df4a9531932e3320a18e5496c51b9f89ea06f",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
     },
     "services-flake": {
       "locked": {
-        "lastModified": 1740875886,
-        "narHash": "sha256-jdY2BdRw6RDYCSuuM/P27Fe46Z5FsZ44AoTb6LAIueY=",
+        "lastModified": 1752367454,
+        "narHash": "sha256-AHGZ2kzmd98Gg6TjhkMKxyCJzbwVGlJvC6VWRpDXd0M=",
         "owner": "juspay",
         "repo": "services-flake",
-        "rev": "c0860f08e38f858448eafbfd2641f45150de1485",
+        "rev": "ab7ae7d4c767663cbdc0bd2262a9ce08ebfd6c2a",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746048139,
-        "narHash": "sha256-LdCLyiihLg6P2/mjzP0+W7RtraDSIaJJPTy6SCtW5Ag=",
+        "lastModified": 1752545833,
+        "narHash": "sha256-mnYQICW9vf9F6wTgfUGlb32ie1OHxHRv2Delxul2LIU=",
         "owner": "adisbladis",
         "repo": "uv2nix",
-        "rev": "680e2f8e637bc79b84268949d2f2b2f5e5f1d81c",
+        "rev": "24a98828b90224ed8a811d7a54315e0f9d0ec3cd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
             packages = with pkgs; [
               (self.packages.${system}.python3)
               uv
-              postgresql
+              postgresql.pg_config
             ];
             env = {
               UV_NO_SYNC = "1";

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -11,7 +11,7 @@ let
   overlay = workspace.mkPyprojectOverlay { sourcePreference = "wheel"; };
   package-overrides = final: prev: {
     psycopg-c = prev.psycopg-c.overrideAttrs (old: {
-      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ final.setuptools pkgs.postgresql ];
+      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ final.setuptools pkgs.postgresql.pg_config ];
     });
   };
   evap-override = final: prev: {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -60,7 +60,7 @@ pkgs.mkShell {
   env = {
     PUPPETEER_SKIP_DOWNLOAD = 1;
     UV_NO_SYNC = "1";
-    UV_PYTHON = "${venv}/bin/python";
+    UV_PYTHON = python3.interpreter;
     UV_PYTHON_DOWNLOADS = "never";
   };
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -58,7 +58,6 @@ pkgs.mkShell {
   passthru = { inherit venv; };
 
   env = {
-    PUPPETEER_SKIP_DOWNLOAD = 1;
     UV_NO_SYNC = "1";
     UV_PYTHON = python3.interpreter;
     UV_PYTHON_DOWNLOADS = "never";


### PR DESCRIPTION
I checked the diffs for everything non-nixpkgs, nothing stands out:
- https://github.com/pyproject-nix/build-system-pkgs/compare/e151741c848ba92331af91f4e47640a1fb82be19..dfa1792728c7a3c34e22491e9fa272ed24e53012
- https://github.com/pyproject-nix/pyproject.nix/compare/ca5d23f044943a23cc4274b2d3dea45682dc025f..833df4a9531932e3320a18e5496c51b9f89ea06f
- https://github.com/pyproject-nix/uv2nix/compare/680e2f8e637bc79b84268949d2f2b2f5e5f1d81c..24a98828b90224ed8a811d7a54315e0f9d0ec3cd
- https://github.com/Platonic-Systems/process-compose-flake/compare/2a17e49b8a5d32278ed77e4a881f992472be18a1..91dcc48a6298e47e2441ec76df711f4e38eab94e
- https://github.com/juspay/services-flake/compare/c0860f08e38f858448eafbfd2641f45150de1485..ab7ae7d4c767663cbdc0bd2262a9ce08ebfd6c2a

I also made the change to account for the nixpkgs postgresql package refactor I mentioned here: https://github.com/e-valuation/EvaP/pull/2453#issuecomment-3020687059. Finally I removed a mention of puppeteer, which we removed in #2077 and #2409.