### PR TITLE
Require just one default name for exam evaluation

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -496,7 +496,7 @@ class Evaluation(LoggedModel):
 
     @property
     def has_exam_evaluation(self):
-        return self.course.evaluations.filter(name_de="Klausur", name_en="Exam").exists()
+        return self.course.evaluations.filter(Q(name_de="Klausur") | Q(name_en="Exam")).exists()
 
     @property
     def earliest_possible_exam_date(self):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2079,6 +2079,19 @@ class TestEvaluationExamCreation(WebTestStaffMode):
         with assert_no_database_modifications():
             self.app.post(self.url, user=self.manager, status=400, params=self.params)
 
+    def test_exam_evaluation_for_already_existing_exam_evaluation_without_default_en_name(self):
+        baker.make(Evaluation, course=self.course, name_en="Test", name_de="Klausur")
+        self.assertTrue(self.evaluation.has_exam_evaluation)
+        with assert_no_database_modifications():
+            self.app.post(self.url, user=self.manager, status=400, params=self.params)
+        baker.make(Evaluation, course=self.course, name_en="Exam", name_de="Prüfung")
+
+    def test_exam_evaluation_for_already_existing_exam_evaluation_without_default_de_name_(self):
+        baker.make(Evaluation, course=self.course, name_en="Exam", name_de="Prüfung")
+        self.assertTrue(self.evaluation.has_exam_evaluation)
+        with assert_no_database_modifications():
+            self.app.post(self.url, user=self.manager, status=400, params=self.params)
+
     def test_exam_evaluation_with_wrong_date(self):
         self.evaluation.vote_start_datetime = datetime.datetime.now() + datetime.timedelta(days=100)
         self.evaluation.vote_end_date = datetime.date.today() + datetime.timedelta(days=150)

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2084,9 +2084,8 @@ class TestEvaluationExamCreation(WebTestStaffMode):
         self.assertTrue(self.evaluation.has_exam_evaluation)
         with assert_no_database_modifications():
             self.app.post(self.url, user=self.manager, status=400, params=self.params)
-        baker.make(Evaluation, course=self.course, name_en="Exam", name_de="Prüfung")
 
-    def test_exam_evaluation_for_already_existing_exam_evaluation_without_default_de_name_(self):
+    def test_exam_evaluation_for_already_existing_exam_evaluation_without_default_de_name(self):
         baker.make(Evaluation, course=self.course, name_en="Exam", name_de="Prüfung")
         self.assertTrue(self.evaluation.has_exam_evaluation)
         with assert_no_database_modifications():


### PR DESCRIPTION
Fixes #2475