### PR TITLE
Hide info icon on results page in print view

### DIFF
--- a/evap/results/templates/textanswer_list.html
+++ b/evap/results/templates/textanswer_list.html
@@ -14,7 +14,7 @@
         {% for answer in question_result.answers %}
             <li>
                 {% if answer.is_private %}
-                    <span data-bs-toggle="tooltip" data-bs-placement="left" class="fas fa-circle-info" title="{% translate 'This answer is only visible to you. Other contributors and your delegates cannot see it.' %}"></span>
+                    <span data-bs-toggle="tooltip" data-bs-placement="left" class="fas fa-circle-info d-print-none" title="{% translate 'This answer is only visible to you. Other contributors and your delegates cannot see it.' %}"></span>
                 {% endif %}
                 {{ answer.answer|linebreaksbr }}
             </li>


### PR DESCRIPTION
fixes #2519 