### PR TITLE
Add automatic cleanup of local storage for saved forms of evaluations

### DIFF
--- a/evap/static/ts/src/auto-form-saver.ts
+++ b/evap/static/ts/src/auto-form-saver.ts
@@ -29,6 +29,13 @@ New portions and modifications are licensed under the conditions in LICENSE.md
 
 import { assert } from "./utils.js";
 
+type LocalStorageConstantsDictionary = Record<string, string>;
+export const localStorageConstants: LocalStorageConstantsDictionary = {
+    "local-storage-key-last-saved-at": "student-vote-last-saved-at",
+    "local-storage-key-language": "student-vote-language",
+    "local-storage-key-form-data": "student-vote",
+};
+
 interface AutoFormSaverOptions {
     href: string;
     customKeySuffix: string;
@@ -80,6 +87,10 @@ export class AutoFormSaver {
 
     getPrefix(field: Element) {
         return (
+            localStorageConstants["local-storage-key-form-data"] +
+            "-" +
+            this.options.href.split("/").slice(-1)[0] +
+            "-" +
             this.options.href +
             this.target.id +
             this.target.name +

--- a/evap/student/templates/student_index.html
+++ b/evap/student/templates/student_index.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 
+{% load static %}
 {% load infotext_templatetags %}
 {% load evaluation_filters %}
 
@@ -30,4 +31,67 @@
         </div>
     {% endif %}
     {% include 'student_index_semester_evaluations_list.html' %}
+{% endblock %}
+
+{% block additional_javascript %}
+    {% if not preview %}
+        <script type="module">
+            import { assert } from "{% static 'js/utils.js' %}";
+            import { CSRF_HEADERS } from "{% static 'js/csrf-utils.js' %}";
+            import { localStorageConstants } from "{% static 'js/auto-form-saver.js' %}";
+
+            var evaluationIdDictionary = {};
+            for (var i = 0; i < localStorage.length; i++){
+                var key = localStorage.key(i);
+                var evaluationId = null;
+                if (key.startsWith(localStorageConstants["local-storage-key-last-saved-at"])) {
+                    var shortenedKey = key.replace(localStorageConstants["local-storage-key-last-saved-at"], "");
+                    evaluationId = shortenedKey.split("-")[1];
+                } else if (key.startsWith(localStorageConstants["local-storage-key-language"])) {
+                    var shortenedKey = key.replace(localStorageConstants["local-storage-key-language"], "");
+                    evaluationId = shortenedKey.split("-")[1];
+                } else if (key.startsWith(localStorageConstants["local-storage-key-form-data"])) {
+                    var shortenedKey = key.replace(localStorageConstants["local-storage-key-form-data"], "");
+                    evaluationId = shortenedKey.split("-")[1];
+                }
+
+                if (evaluationId === null) {
+                    continue;
+                }
+
+                if (evaluationIdDictionary[evaluationId] === undefined) {
+                    evaluationIdDictionary[evaluationId] = [];
+                }
+                evaluationIdDictionary[evaluationId].push(key);
+            }
+
+            async function fetchEndDate(evaluationId) {
+                try {
+                    const response = await fetch("{% url 'student:get_end_date' %}", {
+                        body: new URLSearchParams({ evaluation_id: evaluationId }),
+                        headers: CSRF_HEADERS,
+                        method: "POST",
+                    });
+                    assert(response.ok);
+                    return response.text();
+                } catch (err) {
+                    console.error(err);
+                    window.alert("The server is not responding, or invalid response.");
+                }
+
+                return Date.now();
+            }
+
+            for (var evaluationId in evaluationIdDictionary) {
+                const endDate = new Date(Date.parse(await fetchEndDate(evaluationId)));
+                const distance = Date.now() - endDate;
+                if (distance >= 365 * 24 * 60 * 60 * 1000) {
+                    console.log("The evaluation period for " + evaluationId + " has ended more than a year ago, removing data from local storage. ");
+                    for (var key of evaluationIdDictionary[evaluationId]) {
+                        localStorage.removeItem(key);
+                    }
+                }
+            }
+        </script>
+    {% endif %}
 {% endblock %}

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -228,12 +228,12 @@
         {{ text_answer_warnings|text_answer_warning_trigger_strings|json_script:'text-answer-warnings' }}
 
         <script type="module">
-            import { AutoFormSaver } from "{% static 'js/auto-form-saver.js' %}";
+            import { AutoFormSaver, localStorageConstants } from "{% static 'js/auto-form-saver.js' %}";
             import { CSRF_HEADERS } from "{% static 'js/csrf-utils.js' %}";
             import { initTextAnswerWarnings } from "{% static 'js/text-answer-warnings.js' %}";
             import { assert } from "{% static 'js/utils.js' %}";
 
-            const lastSavedStorageKey = "student-vote-last-saved-at-{{ evaluation.id }}-{{ request.user.id }}";
+            const lastSavedStorageKey = localStorageConstants["local-storage-key-last-saved-at"] + "-{{ evaluation.id }}-{{ request.user.id }}";
             const textResultsPublishConfirmation = {
                 top: document.querySelector("#text_results_publish_confirmation_top"),
                 bottom: document.querySelector("#text_results_publish_confirmation_bottom"),
@@ -241,7 +241,7 @@
             };
 
             // Ensure that selected questionnaire language is saved and loaded
-            const languageStorageKey = "student-vote-language-{{ evaluation.id }}-{{ request.user.id }}";
+            const languageStorageKey = localStorageConstants["local-storage-key-language"] + "-{{ evaluation.id }}-{{ request.user.id }}";
             const params = new URLSearchParams(document.location.search);
             const currentlySelectedLanguage = "{{ evaluation_language|escapejs }}";
             const savedLanguage = localStorage.getItem(languageStorageKey);
@@ -340,6 +340,12 @@
                     return response.text();
                 }).then(response_text => {
                     if(response_text === "{{ success_magic_string }}") {
+                        if (localStorage.getItem(languageStorageKey) !== null) {
+                            localStorage.removeItem(languageStorageKey);
+                        }
+                        if (localStorage.getItem(lastSavedStorageKey) !== null) {
+                            localStorage.removeItem(lastSavedStorageKey);
+                        }
                         formSaver.releaseData();
                         window.location.replace("{{ success_redirect_url }}");
                     } else {

--- a/evap/student/urls.py
+++ b/evap/student/urls.py
@@ -6,6 +6,7 @@ app_name = "student"
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("get_end_date", views.get_end_date, name="get_end_date"),
     path("vote/<int:evaluation_id>", views.vote, name="vote"),
     path("drop/<int:evaluation_id>", views.vote, {"dropout": True}, name="drop"),
 ]

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -16,6 +16,7 @@ from django.urls import reverse
 from django.utils import translation
 from django.utils.translation import get_language
 from django.utils.translation import gettext as _
+from django.views.decorators.http import require_POST
 
 from evap.evaluation.auth import participant_required
 from evap.evaluation.models import (
@@ -388,3 +389,12 @@ def vote(request: HttpRequest, evaluation_id: int, dropout: bool = False) -> Htt
 
     messages.success(request, _("Your vote was recorded."))
     return HttpResponse(SUCCESS_MAGIC_STRING)
+
+@require_POST
+def get_end_date(request):
+    evaluation = get_object_or_404(Evaluation, id=request.POST["evaluation_id"])
+
+    if not evaluation.can_be_voted_for_by(request.user):
+        raise PermissionDenied
+
+    return HttpResponse(evaluation.vote_end_date.isoformat())


### PR DESCRIPTION
This PR adds an automatic cleanup of the `localStorage` for forms of evaluations that have ended more than a year ago. The automatic cleanup happens when opening the student index page. We check `localStorage` for our entries, check the when the corresponding evaluations have ended and then remove the old entries. I implemented a POST request for fetching the evaluation end date based on id.

The commit additionally includes cleanup for other `localStorage` parameters when completing the evaluation.

Closes #2448.