### PR TITLE
Fix error when previewing evaluations with undecided main language

### DIFF
--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -128,6 +128,7 @@ class EvaluationForm(forms.ModelForm):
         main_language = self.cleaned_data.get("main_language")
         if main_language == Evaluation.UNDECIDED_MAIN_LANGUAGE:
             self.add_error("main_language", _("You have to set a main language for this evaluation."))
+
         return main_language
 
     def save(self, *args, **kw):

--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -128,7 +128,6 @@ class EvaluationForm(forms.ModelForm):
         main_language = self.cleaned_data.get("main_language")
         if main_language == Evaluation.UNDECIDED_MAIN_LANGUAGE:
             self.add_error("main_language", _("You have to set a main language for this evaluation."))
-
         return main_language
 
     def save(self, *args, **kw):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2509,15 +2509,14 @@ class TestEvaluationPreviewView(WebTestStaffModeWith200Check):
         cls.url2 = reverse("staff:evaluation_preview", args=[cls.evaluation_un.pk])
         cls.evaluation_un.general_contribution.questionnaires.set([baker.make(Questionnaire)])
 
-
     def test_without_questionnaires_assigned(self):
         # regression test for #1747
         self.evaluation.general_contribution.questionnaires.set([])
         self.app.get(self.url, user=self.manager, status=200)
 
     def test_lang_undecided(self):
-        response = self.app.get(self.url2, user=self.manager, status=200)
-        
+        self.app.get(self.url2, user=self.manager, status=200)
+
 
 class TestEvaluationImportPersonsView(WebTestStaffMode):
     @classmethod

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2510,11 +2510,11 @@ class TestEvaluationPreviewView(WebTestStaffModeWith200Check):
         self.evaluation.general_contribution.questionnaires.set([])
         self.app.get(self.url, user=self.manager, status=200)
 
-    def test_lang_undecided(self):
-        self.evaluation_un = baker.make(Evaluation, main_language=Evaluation.UNDECIDED_MAIN_LANGUAGE)
-        self.url2 = reverse("staff:evaluation_preview", args=[self.evaluation_un.pk])
-        self.evaluation_un.general_contribution.questionnaires.set([baker.make(Questionnaire)])
-        self.app.get(self.url2, user=self.manager, status=200)
+    def test_lang_undecided(self) -> None:
+        evaluation = baker.make(Evaluation, main_language=Evaluation.UNDECIDED_MAIN_LANGUAGE)
+        evaluation.ensure_general_contribution().questionnaires.set([baker.make(Questionnaire)])
+        url = reverse("staff:evaluation_preview", args=[evaluation.pk])
+        self.app.get(url, user=self.manager, status=200)
 
 
 class TestEvaluationImportPersonsView(WebTestStaffMode):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2505,10 +2505,18 @@ class TestEvaluationPreviewView(WebTestStaffModeWith200Check):
         cls.test_users = [cls.manager]
         cls.url = reverse("staff:evaluation_preview", args=[cls.evaluation.pk])
 
+        cls.evaluation_un = baker.make(Evaluation, main_language="x")
+        cls.url2 = reverse("staff:evaluation_preview", args=[cls.evaluation_un.pk])
+
+
     def test_without_questionnaires_assigned(self):
         # regression test for #1747
         self.evaluation.general_contribution.questionnaires.set([])
         self.app.get(self.url, user=self.manager, status=200)
+
+    def test_lang_undecided(self):
+        self.app.get(self.url2, user=self.manager, status=200)
+        
 
 
 class TestEvaluationImportPersonsView(WebTestStaffMode):

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2505,16 +2505,15 @@ class TestEvaluationPreviewView(WebTestStaffModeWith200Check):
         cls.test_users = [cls.manager]
         cls.url = reverse("staff:evaluation_preview", args=[cls.evaluation.pk])
 
-        cls.evaluation_un = baker.make(Evaluation, main_language=Evaluation.UNDECIDED_MAIN_LANGUAGE)
-        cls.url2 = reverse("staff:evaluation_preview", args=[cls.evaluation_un.pk])
-        cls.evaluation_un.general_contribution.questionnaires.set([baker.make(Questionnaire)])
-
     def test_without_questionnaires_assigned(self):
         # regression test for #1747
         self.evaluation.general_contribution.questionnaires.set([])
         self.app.get(self.url, user=self.manager, status=200)
 
     def test_lang_undecided(self):
+        self.evaluation_un = baker.make(Evaluation, main_language=Evaluation.UNDECIDED_MAIN_LANGUAGE)
+        self.url2 = reverse("staff:evaluation_preview", args=[self.evaluation_un.pk])
+        self.evaluation_un.general_contribution.questionnaires.set([baker.make(Questionnaire)])
         self.app.get(self.url2, user=self.manager, status=200)
 
 

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2505,8 +2505,9 @@ class TestEvaluationPreviewView(WebTestStaffModeWith200Check):
         cls.test_users = [cls.manager]
         cls.url = reverse("staff:evaluation_preview", args=[cls.evaluation.pk])
 
-        cls.evaluation_un = baker.make(Evaluation, main_language="x")
+        cls.evaluation_un = baker.make(Evaluation, main_language=Evaluation.UNDECIDED_MAIN_LANGUAGE)
         cls.url2 = reverse("staff:evaluation_preview", args=[cls.evaluation_un.pk])
+        cls.evaluation_un.general_contribution.questionnaires.set([baker.make(Questionnaire)])
 
 
     def test_without_questionnaires_assigned(self):
@@ -2515,9 +2516,8 @@ class TestEvaluationPreviewView(WebTestStaffModeWith200Check):
         self.app.get(self.url, user=self.manager, status=200)
 
     def test_lang_undecided(self):
-        self.app.get(self.url2, user=self.manager, status=200)
+        response = self.app.get(self.url2, user=self.manager, status=200)
         
-
 
 class TestEvaluationImportPersonsView(WebTestStaffMode):
     @classmethod

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -287,7 +287,7 @@ def render_vote_page(
     for_rendering_in_modal: bool = False,
 ) -> HttpResponse:
     fallback_language = (
-        evaluation.main_language if evaluation.main_language != evaluation.UNDECIDED_MAIN_LANGUAGE else "en"
+       evaluation.main_language if evaluation.main_language != evaluation.UNDECIDED_MAIN_LANGUAGE else "en"
     )
     language = request.GET.get("language", fallback_language)
 

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -278,7 +278,7 @@ def get_vote_page_form_groups(
     return form_groups
 
 
-def render_vote_page(
+def render_vote_page(  # pylint: disable=too-many-locals
     request: HttpRequest,
     evaluation: Evaluation,
     *,

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -286,7 +286,7 @@ def render_vote_page(
     dropout: bool,
     for_rendering_in_modal: bool = False,
 ) -> HttpResponse:
-    if(evaluation.main_language == evaluation.UNDECIDED_MAIN_LANGUAGE):
+    if evaluation.main_language == evaluation.UNDECIDED_MAIN_LANGUAGE:
         evaluation.main_language = "en"
     language = request.GET.get("language", evaluation.main_language)
     with translation.override(language):

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -286,10 +286,11 @@ def render_vote_page(
     dropout: bool,
     for_rendering_in_modal: bool = False,
 ) -> HttpResponse:
-    if evaluation.main_language == evaluation.UNDECIDED_MAIN_LANGUAGE:
-        language = request.GET.get("language", "en")
-    else:
-        language = request.GET.get("language", evaluation.main_language)
+    fallback_language = (
+        evaluation.main_language if evaluation.main_language != evaluation.UNDECIDED_MAIN_LANGUAGE else "en"
+    )
+    language = request.GET.get("language", fallback_language)
+
     with translation.override(language):
         form_groups = get_vote_page_form_groups(request, evaluation, preview=preview, dropout=dropout)
 

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -287,7 +287,7 @@ def render_vote_page(
     for_rendering_in_modal: bool = False,
 ) -> HttpResponse:
     fallback_language = (
-        evaluation.main_language if evaluation.main_language != evaluation.UNDECIDED_MAIN_LANGUAGE else "en"
+        evaluation.main_language if evaluation.main_language != Evaluation.UNDECIDED_MAIN_LANGUAGE else "en"
     )
     language = request.GET.get("language", fallback_language)
 

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -287,8 +287,9 @@ def render_vote_page(
     for_rendering_in_modal: bool = False,
 ) -> HttpResponse:
     if evaluation.main_language == evaluation.UNDECIDED_MAIN_LANGUAGE:
-        evaluation.main_language = "en"
-    language = request.GET.get("language", evaluation.main_language)
+        language = request.GET.get("language", "en")
+    else:
+        language = request.GET.get("language", evaluation.main_language)
     with translation.override(language):
         form_groups = get_vote_page_form_groups(request, evaluation, preview=preview, dropout=dropout)
 

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -287,7 +287,7 @@ def render_vote_page(
     for_rendering_in_modal: bool = False,
 ) -> HttpResponse:
     fallback_language = (
-       evaluation.main_language if evaluation.main_language != evaluation.UNDECIDED_MAIN_LANGUAGE else "en"
+        evaluation.main_language if evaluation.main_language != evaluation.UNDECIDED_MAIN_LANGUAGE else "en"
     )
     language = request.GET.get("language", fallback_language)
 

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -286,9 +286,9 @@ def render_vote_page(
     dropout: bool,
     for_rendering_in_modal: bool = False,
 ) -> HttpResponse:
+    if(evaluation.main_language == evaluation.UNDECIDED_MAIN_LANGUAGE):
+        evaluation.main_language = "en"
     language = request.GET.get("language", evaluation.main_language)
-    if language == "x":
-        language = "en"
     with translation.override(language):
         form_groups = get_vote_page_form_groups(request, evaluation, preview=preview, dropout=dropout)
 

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -287,6 +287,8 @@ def render_vote_page(
     for_rendering_in_modal: bool = False,
 ) -> HttpResponse:
     language = request.GET.get("language", evaluation.main_language)
+    if language == "x":
+        language = "en"
     with translation.override(language):
         form_groups = get_vote_page_form_groups(request, evaluation, preview=preview, dropout=dropout)
 


### PR DESCRIPTION
Fixes #2555

Preview of evaluation form failed with undecided language. Fixed by checking in render_vote_page()