### PR TITLE
Handle proxy users without email as internal users

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -2027,6 +2027,8 @@ class UserProfile(EvapBaseUser, PermissionsMixin):
 
     @property
     def is_external(self):
+        if self.is_proxy_user and not self.email:
+            return False
         if not self.email:
             return True
         return is_external_email(self.email)

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -599,6 +599,23 @@ class TestUserProfile(TestCase):
         del user.is_student
         self.assertFalse(user.is_student)
 
+    @override_settings(INSTITUTION_EMAIL_DOMAINS=["institution.example.com"])
+    def test_is_external(self):
+        user = baker.make(UserProfile, email="user@institution.example.com")
+        self.assertFalse(user.is_external)
+
+        user.is_proxy_user = True
+        user.save()
+        self.assertFalse(user.is_external)
+
+        user.email = None
+        user.save()
+        self.assertFalse(user.is_external)
+
+        user.is_proxy_user = False
+        user.save()
+        self.assertTrue(user.is_external)
+
     def test_can_be_deleted_by_manager(self):
         user = baker.make(UserProfile)
         baker.make(Evaluation, participants=[user], state=Evaluation.State.NEW)


### PR DESCRIPTION
Some proxy users don't have an email address set because there is no distribution list for this group of users.
We don't want to show an "External responsible" badge for evaluations where these users are set as responsibles.