### PR TITLE
Importer logging and attempted changes

### DIFF
--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -441,16 +441,17 @@ def update_or_create_with_changes(
     return obj, False, changes
 
 
-def update_with_changes(obj: Model, defaults: dict[str, Any]) -> dict[str, tuple[Any, Any]]:
+def update_with_changes(obj: Model, defaults: dict[str, Any], dry_run: bool = False) -> dict[str, tuple[Any, Any]]:
     """Update a model instance and track changed values."""
 
     changes = {}
     for key, value in defaults.items():
         if getattr(obj, key) != value:
             changes[key] = (getattr(obj, key), value)
-            setattr(obj, key, value)
+            if not dry_run:
+                setattr(obj, key, value)
 
-    if changes:
+    if changes and not dry_run:
         obj.save()
 
     return changes


### PR DESCRIPTION
- fix attempted changes logging in json importer
- allow participant changes until evaluation begins