### PR TITLE
Restrict automated changes to new courses and evaluations

### DIFF
--- a/evap/staff/tests/test_json_importer.py
+++ b/evap/staff/tests/test_json_importer.py
@@ -686,6 +686,39 @@ class TestImportEvents(TestCase):
             self.assertTrue(UserProfile.objects.filter(email="ignored.lecturer@example.com").exists())
             self.assertTrue(UserProfile.objects.filter(email="ignored.lecturer2@example.com").exists())
 
+    def test_import_courses_evaluation_not_new(self):
+        self._import()
+
+        evaluation = Evaluation.objects.get(name_en="")
+
+        evaluation.is_rewarded = False
+        evaluation.save()
+        evaluation.course.name_en = "Change"
+        evaluation.course.save()
+
+        importer = self._import()
+
+        evaluation = Evaluation.objects.get(pk=evaluation.pk)
+
+        self.assertTrue(evaluation.is_rewarded)
+        self.assertEqual(evaluation.course.name_en, "Process-oriented information systems")
+        self.assertEqual(len(importer.statistics.attempted_evaluation_changes), 0)
+        self.assertEqual(len(importer.statistics.attempted_course_changes), 0)
+
+        evaluation.ready_for_editors()
+        evaluation.is_rewarded = False
+        evaluation.save()
+        evaluation.course.name_en = "Change"
+        evaluation.course.save()
+
+        importer = self._import()
+
+        evaluation = Evaluation.objects.get(pk=evaluation.pk)
+        self.assertFalse(evaluation.is_rewarded)
+        self.assertEqual(evaluation.course.name_en, "Change")
+        self.assertEqual(len(importer.statistics.attempted_evaluation_changes), 1)
+        self.assertEqual(len(importer.statistics.attempted_course_changes), 1)
+
     def test_import_courses_evaluation_approved(self):
         self._import()
 

--- a/evap/staff/tests/test_json_importer.py
+++ b/evap/staff/tests/test_json_importer.py
@@ -702,8 +702,8 @@ class TestImportEvents(TestCase):
 
         self.assertTrue(evaluation.is_rewarded)
         self.assertEqual(evaluation.course.name_en, "Process-oriented information systems")
-        self.assertEqual(len(importer.statistics.attempted_evaluation_changes), 0)
-        self.assertEqual(len(importer.statistics.attempted_course_changes), 0)
+        self.assertEqual(importer.statistics.attempted_evaluation_changes, [])
+        self.assertEqual(importer.statistics.attempted_course_changes, set())
 
         evaluation.ready_for_editors()
         evaluation.is_rewarded = False


### PR DESCRIPTION
changes to courses and evaluations should only be made by the cms importer as long as they are in preparation