### PR TITLE
Care about nix-users group only on Debian-ish

### DIFF
--- a/nix/setup-nix
+++ b/nix/setup-nix
@@ -11,6 +11,8 @@ if apt --version &> /dev/null; then
     set -x
     sudo apt-get update -y
     sudo apt-get install -y nix
+    sudo usermod -aG nix-users $USER
+    newgrp nix-users
 elif pacman --version &> /dev/null; then
     set -x
     sudo pacman -S nix
@@ -24,6 +26,4 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 mkdir -p "$XDG_CONFIG_HOME/nix/"
 echo "experimental-features = flakes nix-command" >> "$XDG_CONFIG_HOME/nix/nix.conf"
 echo "max-jobs = auto" >> "$XDG_CONFIG_HOME/nix/nix.conf"
-sudo usermod -aG nix-users $USER
-newgrp nix-users
 sudo systemctl enable --now nix-daemon


### PR DESCRIPTION
On Arch based distros, the nix-users group is not used anymore.

See https://gitlab.archlinux.org/archlinux/packaging/packages/nix/-/issues/13 and https://wiki.archlinux.org/index.php?title=Nix&diff=845276&oldid=814747
