### PR TITLE
Fix semester default course end date fallback in import_cms_data

### DIFF
--- a/evap/evaluation/management/commands/import_cms_data.py
+++ b/evap/evaluation/management/commands/import_cms_data.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         file_mode = mode.add_parser("file")
         file_mode.add_argument("path-to-json", type=Path)
         file_mode.add_argument("--semester-id", type=int, required=True)
-        file_mode.add_argument("--default-course-end-date", type=parse_course_end_date)
+        file_mode.add_argument("--default-course-end-date", type=parse_course_end_date, default=argparse.SUPPRESS)
 
     def handle(self, *args, **options):
         logger.info("import_cms_data called.")

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -611,3 +611,21 @@ class TestImportCMSData(TestCase):
                     stdout=StringIO(),
                 )
             self.assertEqual(cm.exception.args, ("Semester does not exist.",))
+
+    @patch("evap.evaluation.management.commands.import_cms_data.JSONImporter")
+    def test_uses_semester_default_course_end_date(self, mock_json_importer):
+        semester = baker.make(Semester, default_course_end_date=date(2001, 2, 3))
+        with TemporaryDirectory() as temp_dir:
+            test_filename = os.path.join(temp_dir, "test.json")
+            with open(test_filename, "w", encoding="utf-8") as f:
+                f.write("example contents")
+            call_command(
+                "import_cms_data",
+                "file",
+                "--semester-id",
+                semester.id,
+                test_filename,
+                stdout=StringIO(),
+            )
+
+            mock_json_importer.assert_called_once_with(semester, date(2001, 2, 3))


### PR DESCRIPTION
Closes #2620

It turns out that by default the namespace gets populated with `None` already, so the `.get(...)` would return the stored `None`.
