### PR TITLE
Place questionnaire tooltips to the right.

### DIFF
--- a/evap/evaluation/templates/questionnaires_widget.html
+++ b/evap/evaluation/templates/questionnaires_widget.html
@@ -7,7 +7,7 @@
                 <li><hr class="mb-1 mt-1" /></li>
             {% endif %}
         {% endifchanged %}
-        <li class="form-check" data-bs-toggle="tooltip" data-bs-placement="left" title="{% spaceless %}
+        <li class="form-check col-8" data-bs-toggle="tooltip" data-bs-placement="right" title="{% spaceless %}
             {% if questionnaire.is_locked and not manager %}
                 {% translate 'This questionnaire is locked, its selection cannot be changed.' %}<br /><br />
             {% endif %}


### PR DESCRIPTION
Contributes to #2591 

After discussion with janno42, we decided that placing the tooltips to the right would be the most consistent solution for most situations, as it is highly viewport dependent and bootstrap's positioning of tooltips is quite wild otherwise, i.e. there's not really a great solution, this is one with a fairly okay consistency.