### PR TITLE
Skip MacOS CI check if nix files are unchanged

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,4 @@
 {
-
   description = "EvaP";
 
   inputs = {


### PR DESCRIPTION
Came up during #2615, but useful already before I figure that one out.

Notably, we don't even request the MacOS runner if the files are not changed.
