### PR TITLE
Require dashboard approval for major Django updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,8 +14,10 @@
       matchManagers: ["pep621"],
     },
     {
-      matchPackageNames: ["django-fsm"],
-      allowedVersions: "!/^3.0.0$/", // 3.0.0 adds deprecation warnings without functional changes
+      matchUpdateTypes: ["major"],
+      matchDepNames: ["Django"], // commonly breaks other dependencies requiring async changes
+      groupName: "Django major",
+      dependencyDashboardApproval: true,
     },
     {
       matchManagers: ["npm"],


### PR DESCRIPTION
Also removes useless django-fsm exclusion after #2581.

See https://github.com/e-valuation/EvaP/pull/2627#issuecomment-3872829095