### PR TITLE
Actually use non-breaking space in `test_clean_whitespace`

### DIFF
--- a/evap/cms/tests/test_json_importer.py
+++ b/evap/cms/tests/test_json_importer.py
@@ -815,8 +815,8 @@ class TestImportEvents(TestCase):
         self.assertEqual(_clean_whitespaces_and_hyphens("back "), "back")
         self.assertEqual(_clean_whitespaces_and_hyphens("inbetween  inbetween"), "inbetween inbetween")
         self.assertEqual(_clean_whitespaces_and_hyphens("inbetween \n inbetween"), "inbetween inbetween")
-        # non-breaking whitespace
-        self.assertEqual(_clean_whitespaces_and_hyphens("inbetween  inbetween"), "inbetween inbetween")
+        # normal and narrow non-breaking space
+        self.assertEqual(_clean_whitespaces_and_hyphens("inbetween\u00a0 \u202finbetween"), "inbetween inbetween")
 
     def test_clean_hyphens(self):
         self.assertEqual(_clean_whitespaces_and_hyphens("Course - Evaluation"), "Course – Evaluation")


### PR DESCRIPTION
See https://github.com/e-valuation/EvaP/pull/2632#discussion_r2843230832