### PR TITLE
Slightly improve evaluation query performance in student index view

### DIFF
--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.db import transaction
-from django.db.models import Exists, F, Max, OuterRef, Q, Sum
+from django.db.models import Exists, F, Max, OuterRef, Sum
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -125,16 +125,26 @@ class GlobalEvaluationProgress:
 def index(request):
     query = (
         Evaluation.objects.annotate(
-            participates_in=Exists(Evaluation.objects.filter(id=OuterRef("id"), participants=request.user))
+            participates_in=Exists(
+                Evaluation.participants.through.objects.filter(
+                    evaluation_id=OuterRef("pk"), userprofile_id=request.user.id
+                )
+            )
         )
-        .annotate(voted_for=Exists(Evaluation.objects.filter(id=OuterRef("id"), voters=request.user)))
-        .filter(~Q(state=Evaluation.State.NEW), course__evaluations__participants=request.user)
+        .annotate(
+            voted_for=Exists(
+                Evaluation.voters.through.objects.filter(evaluation_id=OuterRef("pk"), userprofile_id=request.user.id)
+            )
+        )
+        .filter(course__evaluations__participants=request.user)
         .exclude(state=Evaluation.State.NEW)
-        .prefetch_related(
+        .select_related(
             "course",
             "course__semester",
-            "course__grade_documents",
             "course__type",
+        )
+        .prefetch_related(
+            "course__grade_documents",
             "course__evaluations",
             "course__responsibles",
             "course__programs",


### PR DESCRIPTION
When setting the student index view test to 6000 objects (instead of 100), on average 500ms improvement for the query.

This is work towards #2235, though it is not nearly enough improvement, for a small amount of objects almost negligible.

I did not test it yet to see if it is slower with a small number of elements.

However, the improvement makes sense, as ```prefetch_related``` will do the join in python and ```select_related``` will do the join on the database resulting in a slight improvement, unfortunately it cannot be applied to reverse foreign key relations and the many to many relations.

