### PR TITLE
Use `_bulk_create` more often with baker.make

### DIFF
--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -451,6 +451,7 @@ class TestSendRemindersCommand(TestCase):
             wait_for_grade_upload_before_publishing=True,
             _fill_optional=["name_de", "name_en"],
             _quantity=4,
+            _bulk_create=True,
         )
 
         with patch("evap.evaluation.models.EmailTemplate.send_to_address") as send_mock:

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -721,6 +721,7 @@ class TestUserProfile(TestCase):
             state=Evaluation.State.IN_EVALUATION,
             participants=[student],
             _quantity=3,
+            _bulk_create=True,
         )
 
         sorted_evaluations = student.get_sorted_due_evaluations()
@@ -1017,7 +1018,7 @@ class TestEmailTemplate(TestCase):
         responsible1 = baker.make(UserProfile)
         responsible2 = baker.make(UserProfile)
 
-        students = baker.make(UserProfile, _quantity=3)
+        students = baker.make(UserProfile, _quantity=3, _bulk_create=True)
         evaluation1 = baker.make(
             Evaluation, course__responsibles=[responsible1], participants=students, voters=students
         )

--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -137,7 +137,7 @@ class TestHelperMethods(TestCase):
 
     def test_discard_cached_related_objects_discards_cached_m2m_instances(self):
         evaluation = baker.make(Evaluation)
-        baker.make(UserProfile, evaluations_participating_in=[evaluation], _quantity=2)
+        baker.make(UserProfile, evaluations_participating_in=[evaluation], _quantity=2, _bulk_create=True)
 
         # M2M fields are not implicitly cached
         with self.assertNumQueries(1):

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -406,7 +406,7 @@ class TestCalculateAverageDistribution(TestCase):
 
     def test_calculate_average_course_distribution(self):
         make_rating_answer_counters(self.grade_assignment, self.contribution1, [2, 0, 0, 0, 0])
-        students = baker.make(UserProfile, _quantity=3)
+        students = baker.make(UserProfile, _quantity=3, _bulk_create=True)
 
         course = self.evaluation.course
         second_evaluation = baker.make(

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -206,6 +206,7 @@ class TestResultsView(WebTest):
             answer=2,
             count=2,
             _quantity=len(published),
+            _bulk_create=True,
         )
 
         for evaluation in published:

--- a/evap/rewards/tests/test_views.py
+++ b/evap/rewards/tests/test_views.py
@@ -133,6 +133,7 @@ class TestEventsView(WebTestStaffModeWith200Check):
             event=self.redemption_event1,
             value=1,
             _quantity=quantity,
+            _bulk_create=True,
         )
         response = self.app.get(self.url, user=self.test_users[0])
 

--- a/evap/staff/tests/test_forms.py
+++ b/evap/staff/tests/test_forms.py
@@ -823,6 +823,7 @@ class CourseFormTests(TestCase):
             responsibles=[baker.make(UserProfile)],
             programs=[baker.make(Program)],
             _quantity=2,
+            _bulk_create=True,
         )
 
         form_data = get_form_data_from_instance(CourseForm, courses[0])
@@ -842,6 +843,7 @@ class CourseFormTests(TestCase):
             responsibles=[baker.make(UserProfile)],
             programs=[baker.make(Program)],
             _quantity=2,
+            _bulk_create=True,
         )
 
         form_data = get_form_data_from_instance(CourseForm, courses[1])

--- a/evap/staff/tests/test_live.py
+++ b/evap/staff/tests/test_live.py
@@ -119,7 +119,7 @@ class EvaluationEditLiveTest(LiveServerTest):
 
 class ParticipantCollapseTests(LiveServerTest):
     def test_collapse_with_editor_approved(self) -> None:
-        participants = baker.make(UserProfile, _quantity=20)
+        participants = baker.make(UserProfile, _quantity=20, _bulk_create=True)
         baker.make(UserProfile, last_name="participant")
 
         responsible = baker.make(UserProfile)
@@ -209,6 +209,7 @@ class TextAnswerEditLiveTest(LiveServerTest):
             original_answer=None,
             review_decision=TextAnswer.ReviewDecision.UNDECIDED,
             _quantity=3,
+            _bulk_create=True,
         )
 
         textanswer1 = baker.make(
@@ -228,6 +229,7 @@ class TextAnswerEditLiveTest(LiveServerTest):
             original_answer=None,
             review_decision=TextAnswer.ReviewDecision.UNDECIDED,
             _quantity=3,
+            _bulk_create=True,
         )
 
         with self.enter_staff_mode():

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -596,6 +596,7 @@ class TestUserExportView(WebTestStaffMode):
         baker.make(
             UserProfile,
             _quantity=5,
+            _bulk_create=True,
             _fill_optional=["first_name_given", "last_name", "email"],
             title=iter(("", "Some", "Custom", "Titles", "")),
         )
@@ -952,12 +953,12 @@ class TestSemesterQuestionnaireAssignment(WebTestStaffMode):
 
         cls.responsible = baker.make(UserProfile)
 
-        cls.questionnaires = baker.make(Questionnaire, type=Questionnaire.Type.TOP, _quantity=4)
+        cls.questionnaires = baker.make(Questionnaire, type=Questionnaire.Type.TOP, _quantity=4, _bulk_create=True)
         cls.questionnaire_contributor, cls.questionnaire_responsible = baker.make(
-            Questionnaire, type=Questionnaire.Type.CONTRIBUTOR, _quantity=2
+            Questionnaire, type=Questionnaire.Type.CONTRIBUTOR, _quantity=2, _bulk_create=True
         )
-        cls.course_types = baker.make(CourseType, _quantity=3)
-        cls.exam_types = baker.make(ExamType, _quantity=3)
+        cls.course_types = baker.make(CourseType, _quantity=3, _bulk_create=True)
+        cls.exam_types = baker.make(ExamType, _quantity=3, _bulk_create=True)
         cls.evaluations = baker.make(
             Evaluation,
             course__semester=semester,
@@ -982,6 +983,7 @@ class TestSemesterQuestionnaireAssignment(WebTestStaffMode):
             role=Contribution.Role.EDITOR,
             textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             _quantity=3,
+            _bulk_create=True,
         )
 
     def test_questionnaire_assignment(self):
@@ -1105,6 +1107,7 @@ class TestGradeReminderView(WebTestStaffMode):
             wait_for_grade_upload_before_publishing=True,
             _fill_optional=["name_de", "name_en"],
             _quantity=2,
+            _bulk_create=True,
         )
         cls.course2_evaluation = baker.make(
             Evaluation,
@@ -2030,7 +2033,7 @@ class TestEvaluationExamCreation(WebTestStaffMode):
         cls.course = baker.make(Course)
         vote_start_datetime = datetime.datetime.now() - datetime.timedelta(days=50)
         cls.evaluation = baker.make(Evaluation, course=cls.course, vote_start_datetime=vote_start_datetime)
-        cls.evaluation.participants.set(baker.make(UserProfile, _quantity=3))
+        cls.evaluation.participants.set(baker.make(UserProfile, _quantity=3, _bulk_create=True))
         cls.contributions = baker.make(
             Contribution, evaluation=cls.evaluation, _fill_optional=["contributor"], _quantity=3, _bulk_create=True
         )
@@ -2306,6 +2309,7 @@ class TestEvaluationEditView(WebTestStaffMode):
             evaluations_participating_in=[self.evaluation, already_evaluated],
             evaluations_voted_for=[already_evaluated],
             _quantity=5,
+            _bulk_create=True,
         )
 
         page = self.app.get(self.url, user=self.manager)
@@ -2332,6 +2336,7 @@ class TestEvaluationEditView(WebTestStaffMode):
             evaluations_participating_in=[self.evaluation, already_evaluated],
             evaluations_voted_for=[already_evaluated],
             _quantity=4,
+            _bulk_create=True,
         )
         baker.make(
             RewardPointGranting,
@@ -2464,6 +2469,7 @@ class TestEvaluationDeleteView(WebTestStaffMode):
             evaluations_participating_in=[self.evaluation, already_evaluated],
             evaluations_voted_for=[already_evaluated],
             _quantity=5,
+            _bulk_create=True,
         )
 
         self.assertEqual(reward_points_of_user(student), 0)
@@ -2978,6 +2984,7 @@ class TestEvaluationTextAnswerView(WebTest):
             vote_end_date=datetime.date.today() - datetime.timedelta(days=2),
             can_publish_text_results=True,
             _quantity=2,
+            _bulk_create=True,
         )
 
         for evaluation, answer_count in zip(evaluations, [1, 2], strict=True):
@@ -2987,6 +2994,7 @@ class TestEvaluationTextAnswerView(WebTest):
                 contribution=contribution,
                 assignment__question__type=QuestionType.TEXT,
                 _quantity=answer_count,
+                _bulk_create=True,
             )
 
         url = reverse("staff:evaluation_textanswers", args=[self.evaluation2.pk])

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -92,11 +92,11 @@ class TestStudentIndexView(WebTestWith200Check):
         make_evaluation(course__is_private=True)
         make_evaluation(id=1043)
         make_evaluation(course__type__id=1042)
-        make_evaluation(_quantity=len(excluded_states), state=iter(excluded_states))
+        make_evaluation(_quantity=len(excluded_states), _bulk_create=True, state=iter(excluded_states))
 
         # included
         included_evaluations = [
-            *make_evaluation(_quantity=len(included_states), state=iter(included_states)),
+            *make_evaluation(_quantity=len(included_states), _bulk_create=True, state=iter(included_states)),
             make_evaluation(_voter_count=123, _participant_count=456),
         ]
 


### PR DESCRIPTION
https://github.com/model-bakers/model_bakery/issues/489 has been closed, so we can now use this more widely.

We still cannot use it _everywhere_, because some tests rely on `Evaluation`s to have a `general_contribution`, see https://github.com/e-valuation/EvaP/issues/1847.