### PR TITLE
General contribution can be created lazily

### DIFF
--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -100,9 +100,9 @@ class EvaluationForm(forms.ModelForm):
             self.add_error("vote_end_date", _("The first day of evaluation must be before the last one."))
 
         # Ensure locked questionnaires cannot be deselected and only unlocked ones can be added
-        selected_questionnaires = (
-            self.instance.ensure_general_contribution().questionnaires.filter(is_locked=True).distinct()
-        )
+        selected_questionnaires = Questionnaire.objects.filter(
+            is_locked=True, contributions__contributor=None, contributions__evaluation=self.instance
+        ).distinct()
         selected_questionnaires |= self.cleaned_data.get("general_questionnaires").filter(is_locked=False)
         selected_questionnaires |= self.cleaned_data.get("dropout_questionnaires").filter(is_locked=False)
 

--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -100,7 +100,9 @@ class EvaluationForm(forms.ModelForm):
             self.add_error("vote_end_date", _("The first day of evaluation must be before the last one."))
 
         # Ensure locked questionnaires cannot be deselected and only unlocked ones can be added
-        selected_questionnaires = self.instance.general_contribution.questionnaires.filter(is_locked=True).distinct()
+        selected_questionnaires = (
+            self.instance.ensure_general_contribution().questionnaires.filter(is_locked=True).distinct()
+        )
         selected_questionnaires |= self.cleaned_data.get("general_questionnaires").filter(is_locked=False)
         selected_questionnaires |= self.cleaned_data.get("dropout_questionnaires").filter(is_locked=False)
 
@@ -133,7 +135,7 @@ class EvaluationForm(forms.ModelForm):
         selected_questionnaires = self.cleaned_data.get("general_questionnaires") | self.cleaned_data.get(
             "dropout_questionnaires"
         )
-        evaluation.general_contribution.questionnaires.set(selected_questionnaires)
+        evaluation.ensure_general_contribution().questionnaires.set(selected_questionnaires)
         return evaluation
 
 

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -919,7 +919,7 @@ class Evaluation(LoggedModel):
         if "general_contribution" in self.__dict__ and self.general_contribution is not None:
             return self.general_contribution
 
-        contribution, created = self.contributions.get_or_create(contributor=None)
+        contribution, __ = self.contributions.get_or_create(contributor=None)
         self.__dict__["general_contribution"] = contribution
         return assert_not_none(self.general_contribution)
 

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -50,7 +50,7 @@ from evap.evaluation.tools import (
     translate,
     vote_end_datetime,
 )
-from evap.tools import date_to_datetime
+from evap.tools import assert_not_none, date_to_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -567,7 +567,7 @@ class Evaluation(LoggedModel):
         exam_evaluation.participants.set(self.participants.all())
         for contribution in self.contributions.exclude(contributor=None):
             exam_evaluation.contributions.create(contributor=contribution.contributor)
-        exam_evaluation.general_contribution.questionnaires.set(settings.EXAM_QUESTIONNAIRE_IDS)
+        exam_evaluation.ensure_general_contribution().questionnaires.set(settings.EXAM_QUESTIONNAIRE_IDS)
 
     class TextAnswerReviewState(Enum):
         do_not_call_in_templates = enum.nonmember(True)
@@ -603,10 +603,7 @@ class Evaluation(LoggedModel):
     def save(self, *args, **kw):
         super().save(*args, **kw)
 
-        # make sure there is a general contribution
-        if not self.general_contribution:
-            self.contributions.create(contributor=None)
-            del self.general_contribution  # invalidate cached property
+        self.ensure_general_contribution()
 
         if hasattr(self, "state_change_source"):
 
@@ -693,7 +690,10 @@ class Evaluation(LoggedModel):
 
     @property
     def is_dropout_allowed(self) -> bool:
-        return self.general_contribution.questionnaires.filter(type=Questionnaire.Type.DROPOUT).exists()
+        return (
+            self.general_contribution is not None
+            and self.general_contribution.questionnaires.filter(type=Questionnaire.Type.DROPOUT).exists()
+        )
 
     @property
     def general_contribution_has_questionnaires(self):
@@ -913,8 +913,18 @@ class Evaluation(LoggedModel):
     def state_str(self):
         return Evaluation.State(self.state).label
 
+    def ensure_general_contribution(self) -> "Contribution":
+        assert self.pk is not None
+
+        if "general_contribution" in self.__dict__ and self.general_contribution is not None:
+            return self.general_contribution
+
+        contribution, created = self.contributions.get_or_create(contributor=None)
+        self.__dict__["general_contribution"] = contribution
+        return assert_not_none(self.general_contribution)
+
     @cached_property
-    def general_contribution(self):
+    def general_contribution(self) -> "Contribution | None":
         if self.pk is None:
             return None
 
@@ -2405,9 +2415,9 @@ class EmailTemplate(models.Model):
         evaluations_per_contributor = defaultdict(set)
         for evaluation in evaluations:
             # an average grade is published or a general text answer exists
-            relevant_information_published_for_responsibles = (
-                evaluation.can_publish_average_grade
-                or evaluation.textanswer_set.filter(contribution=evaluation.general_contribution).exists()
+            relevant_information_published_for_responsibles = evaluation.can_publish_average_grade or (
+                evaluation.general_contribution is not None
+                and evaluation.textanswer_set.filter(contribution=evaluation.general_contribution).exists()
             )
             if relevant_information_published_for_responsibles:
                 for responsible in evaluation.course.responsibles.all():

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -50,7 +50,7 @@ from evap.evaluation.tools import (
     translate,
     vote_end_datetime,
 )
-from evap.tools import assert_not_none, date_to_datetime
+from evap.tools import date_to_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -921,7 +921,7 @@ class Evaluation(LoggedModel):
 
         contribution, __ = self.contributions.get_or_create(contributor=None)
         self.__dict__["general_contribution"] = contribution
-        return assert_not_none(self.general_contribution)
+        return contribution
 
     @cached_property
     def general_contribution(self) -> "Contribution | None":

--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -163,7 +163,7 @@ class TestHelperMethods(TestCase):
 
     def test_discard_cached_related_objects_discards_cached_m2m_reverse_instances(self):
         user = baker.make(UserProfile)
-        baker.make(Evaluation, participants=[user], _quantity=2)
+        baker.make(Evaluation, participants=[user], _quantity=2, _bulk_create=True)
 
         # Reverse M2M fields are not implicitly cached
         with self.assertNumQueries(1):

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -190,12 +190,13 @@ class TestResultsView(WebTest):
             participants=participants,
             voters=participants,
             _quantity=3,
+            _bulk_create=True,
             _fill_optional=["name_de"],
         )[1:]
 
         questionnaire = baker.make(Questionnaire)
 
-        contributions = [e.general_contribution for e in published]
+        contributions = [e.ensure_general_contribution() for e in published]
         for contribution in contributions:
             contribution.questionnaires.add(questionnaire)
         baker.make(

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -23,7 +23,7 @@ from evap.evaluation.models import (
     UserProfile,
 )
 from evap.evaluation.tools import discard_cached_related_objects
-from evap.tools import unordered_groupby
+from evap.tools import assert_not_none, unordered_groupby
 
 STATES_WITH_RESULTS_CACHING = {Evaluation.State.EVALUATED, Evaluation.State.REVIEWED, Evaluation.State.PUBLISHED}
 STATES_WITH_RESULT_TEMPLATE_CACHING = {Evaluation.State.PUBLISHED}
@@ -457,16 +457,21 @@ def get_grade_color(grade):
     return color_mix(GRADE_COLORS[next_lower], GRADE_COLORS[next_higher], grade - next_lower)
 
 
-def textanswers_visible_to(contribution):
+def textanswers_visible_to(contribution: Contribution | None) -> TextAnswerVisibility:
+    if contribution is None:
+        return TextAnswerVisibility(visible_by_contribution=[], visible_by_delegation_count=0)
+
+    contributors: set[UserProfile]
     if contribution.is_general:
         contributors = {
             other_contribution.contributor
             for other_contribution in contribution.evaluation.contributions.all()
             if other_contribution.textanswer_visibility == Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS
+            and other_contribution.contributor is not None
         }
         contributors.update(contribution.evaluation.course.responsibles.all())
     else:
-        contributors = {contribution.contributor}
+        contributors = {assert_not_none(contribution.contributor)}
 
     non_proxy_contributors = [contributor for contributor in contributors if not contributor.is_proxy_user]
     delegates = {delegate for contributor in non_proxy_contributors for delegate in contributor.delegates.all()}

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -530,18 +530,20 @@ class EvaluationForm(forms.ModelForm):
 
     def save(self, *args, **kw):
         evaluation = super().save(*args, **kw)
+        general_contribution = evaluation.ensure_general_contribution()
+
         selected_questionnaires = self.cleaned_data.get("general_questionnaires") | self.cleaned_data.get(
             "dropout_questionnaires"
         )
-        removed_questionnaires = set(self.instance.ensure_general_contribution().questionnaires.all()) - set(
-            selected_questionnaires
-        )
-        evaluation.ensure_general_contribution().remove_answers_to_questionnaires(removed_questionnaires)
-        evaluation.ensure_general_contribution().questionnaires.set(selected_questionnaires)
-        if hasattr(self.instance, "old_course"):
-            if self.instance.old_course != evaluation.course:
-                update_template_cache_of_published_evaluations_in_course(self.instance.old_course)
+        removed_questionnaires = set(general_contribution.questionnaires.all()) - set(selected_questionnaires)
+        general_contribution.remove_answers_to_questionnaires(removed_questionnaires)
+        general_contribution.questionnaires.set(selected_questionnaires)
+
+        if hasattr(evaluation, "old_course"):
+            if evaluation.old_course != evaluation.course:
+                update_template_cache_of_published_evaluations_in_course(evaluation.old_course)
                 update_template_cache_of_published_evaluations_in_course(evaluation.course)
+
         return evaluation
 
 

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -533,11 +533,11 @@ class EvaluationForm(forms.ModelForm):
         selected_questionnaires = self.cleaned_data.get("general_questionnaires") | self.cleaned_data.get(
             "dropout_questionnaires"
         )
-        removed_questionnaires = set(self.instance.general_contribution.questionnaires.all()) - set(
+        removed_questionnaires = set(self.instance.ensure_general_contribution().questionnaires.all()) - set(
             selected_questionnaires
         )
-        evaluation.general_contribution.remove_answers_to_questionnaires(removed_questionnaires)
-        evaluation.general_contribution.questionnaires.set(selected_questionnaires)
+        evaluation.ensure_general_contribution().remove_answers_to_questionnaires(removed_questionnaires)
+        evaluation.ensure_general_contribution().questionnaires.set(selected_questionnaires)
         if hasattr(self.instance, "old_course"):
             if self.instance.old_course != evaluation.course:
                 update_template_cache_of_published_evaluations_in_course(self.instance.old_course)
@@ -549,7 +549,8 @@ class EvaluationCopyForm(EvaluationForm):
     def __init__(self, data=None, instance=None):
         opts = self._meta
         initial = forms.models.model_to_dict(instance, opts.fields, opts.exclude)
-        initial["general_questionnaires"] = instance.general_contribution.questionnaires.all()
+        if instance.general_contribution is not None:
+            initial["general_questionnaires"] = instance.general_contribution.questionnaires.all()
         super().__init__(data=data, initial=initial, semester=instance.course.semester)
 
 

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -2421,7 +2421,13 @@ class TestEvaluationEditView(WebTestStaffMode):
     def test_general_contribution_log_entry(self):
         page = self.app.get(self.url, user=self.manager)
         self.assertContains(
-            page, '<p class="mt-3">The Contribution "General Contribution" was created.</p><ul></ul>', html=True
+            page,
+            f"""
+            <p class="mt-3">The Contribution "General Contribution" was created.</p>
+            <ul>
+                <li>Questionnaires added: {self.general_questionnaire.name}</li>
+            </ul>""",
+            html=True,
         )
 
 

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -964,6 +964,7 @@ class TestSemesterQuestionnaireAssignment(WebTestStaffMode):
             course__responsibles=[cls.responsible],
             course__type=iter(cls.course_types),
             _quantity=3,
+            _bulk_create=True,
         )
         cls.exam_evaluations = [
             baker.make(
@@ -3129,7 +3130,9 @@ class TestSemesterFlaggedTextAnswersView(WebTestStaffMode):
 
         manager = make_manager()
         student = baker.make(UserProfile)
-        evaluations = baker.make(Evaluation, course__semester=semester, participants=[student], _quantity=3)
+        evaluations = baker.make(
+            Evaluation, course__semester=semester, participants=[student], _quantity=3, _bulk_create=True
+        )
         textanswers = [
             [baker.make(TextAnswer, answer=f"Answer {i} {j}", contribution__evaluation=evaluation) for j in range(3)]
             for i, evaluation in enumerate(evaluations)

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -927,7 +927,7 @@ def semester_questionnaire_assign(request, semester_id):
                 )
 
             if general_questionnaires:
-                evaluation.general_contribution.questionnaires.set(general_questionnaires)
+                evaluation.ensure_general_contribution().questionnaires.set(general_questionnaires)
 
             if contributor_questionnaires:
                 for contribution in evaluation.contributions.exclude(contributor=None):

--- a/evap/student/tests/test_live.py
+++ b/evap/student/tests/test_live.py
@@ -98,7 +98,9 @@ class StudentVoteLiveTest(LiveServerTest):
             evaluation=evaluation,
         )
 
-        evaluation.general_contribution.questionnaires.set([top_general_questionnaire, bottom_general_questionnaire])
+        evaluation.ensure_general_contribution().questionnaires.set(
+            [top_general_questionnaire, bottom_general_questionnaire]
+        )
         self.url = self.reverse("student:vote", args=[evaluation.pk])
         self.login(voting_user1)
 

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -282,8 +282,6 @@ def render_vote_page(
 
     assert preview or not all(form.is_valid() for form_group in form_groups.values() for form in form_group)
 
-    # TODO: Can we do this more elegantly? dict.pop requires that first input type is key type (=Contribution), but
-    # passing any other type (especially None) is fine and falls back to the default.
     if evaluation.general_contribution is None:
         evaluation_form_group = []
     else:

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -282,7 +282,12 @@ def render_vote_page(
 
     assert preview or not all(form.is_valid() for form_group in form_groups.values() for form in form_group)
 
-    evaluation_form_group = form_groups.pop(evaluation.general_contribution, default=[])
+    # TODO: Can we do this more elegantly? dict.pop requires that first input type is key type (=Contribution), but
+    # passing any other type (especially None) is fine and falls back to the default.
+    if evaluation.general_contribution is None:
+        evaluation_form_group = []
+    else:
+        evaluation_form_group = form_groups.pop(evaluation.general_contribution, default=[])
 
     contributor_form_groups = [
         (


### PR DESCRIPTION
Relates to #1847, #1839, #1846

This defensively still creates a general contribution on `.save()`. If we remove that, we get lots of test failures, but it's mostly tests that expect that it was created. I would make this conditional on `not DEBUG`, so that we don't accidentally break production but have some time to check for problems in dev environments.

The big gain we get from this is that `general_contribution` is now typed to be able to return `None`, which should, in typed code, catch problems when we try to access it in an unsafe way.

* [x] One TODO in code
* [x] See what the change set would be to make the tests pass when not calling `ensure_general_contribution` in `Evaluation.save` anymore
    * ~70 tests require us to explicitly create a general contribution -- I'll do this separately