### PR TITLE
Tests debuggability improvements. Fix flaky `test_edit_textanswer_redirect`. Improve live test speed.

### DIFF
--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -1,3 +1,4 @@
+import random
 import time
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
@@ -44,10 +45,11 @@ from evap.evaluation.models import (
 class EvapTestRunner(DiscoverRunner):
     """Skips selenium tests by default, if no other tags are specified."""
 
-    def __init__(self, *args: Any, headed=False, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, headed: bool, baker_seed: int, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
         self.__headed = headed
+        self.__baker_seed = baker_seed
 
         if not self.tags and not self.exclude_tags:
             self.exclude_tags = {"selenium"}
@@ -62,10 +64,21 @@ class EvapTestRunner(DiscoverRunner):
             action="store_true",
         )
 
+        parser.add_argument(
+            "--baker-seed",
+            nargs="?",
+            type=int,
+            default=random.getrandbits(32),
+            help="Force model-bakery to use this seed to generate random values. Default: random value",
+        )
+
     def setup_test_environment(self, **kwargs):
         super().setup_test_environment(**kwargs)
 
         LiveServerTest.headless = not self.__headed
+
+        baker.seed(self.__baker_seed)
+        self.log(f"Using baker seed: {self.__baker_seed}")
 
 
 class ResetLanguageOnTearDownMixin:

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -77,8 +77,8 @@ class EvapTestRunner(DiscoverRunner):
 
         LiveServerTest.headless = not self.__headed
 
-        baker.seed(self.__baker_seed)
         self.log(f"Using baker seed: {self.__baker_seed}")
+        settings.EVAP_TEST_BAKER_SEED = self.__baker_seed
 
 
 class ResetLanguageOnTearDownMixin:
@@ -87,15 +87,32 @@ class ResetLanguageOnTearDownMixin:
         super().tearDown()
 
 
-class TestCase(ResetLanguageOnTearDownMixin, django.test.TestCase):
+class SeedBakerMixin:
+    @classmethod
+    def setUpClass(cls):
+        # runs before `setUpTestData`
+        baker.seed(settings.EVAP_TEST_BAKER_SEED)
+        super().setUpClass()
+
+    @classmethod
+    def _pre_setup(cls):
+        # runs before `setUp`
+        # Same seed would imply the same value sequence, which causes problems:
+        # * uniqueness constraints fail if setUpTestData and setUp both generate an instance of the same model class
+        # * "assert name not in page"-style asserts fail for shared names with non-unique fields
+        baker.seed(settings.EVAP_TEST_BAKER_SEED + 1)
+        super()._pre_setup()
+
+
+class TestCase(SeedBakerMixin, ResetLanguageOnTearDownMixin, django.test.TestCase):
     pass
 
 
-class SimpleTestCase(ResetLanguageOnTearDownMixin, django.test.SimpleTestCase):
+class SimpleTestCase(SeedBakerMixin, ResetLanguageOnTearDownMixin, django.test.SimpleTestCase):
     pass
 
 
-class WebTest(ResetLanguageOnTearDownMixin, django_webtest.WebTest):
+class WebTest(SeedBakerMixin, ResetLanguageOnTearDownMixin, django_webtest.WebTest):
     pass
 
 
@@ -317,7 +334,7 @@ def assert_no_database_modifications(*args, **kwargs):
 
 # For the average LiveServerTest, if the "server" has an internal error, we want to abort/stacktrace/drop into debugger
 @override_settings(DEBUG_PROPAGATE_EXCEPTIONS=True)
-class LiveServerTest(SeleniumTestCase):
+class LiveServerTest(SeedBakerMixin, SeleniumTestCase):
     browser = "firefox"
     selenium: WebDriver
     headless = True

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -14,6 +14,7 @@ from django.contrib.auth.models import Group
 from django.contrib.staticfiles.handlers import StaticFilesHandler
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.http.request import HttpRequest, QueryDict
+from django.test import override_settings
 from django.test.runner import DiscoverRunner
 from django.test.selenium import SeleniumTestCase
 from django.test.utils import CaptureQueriesContext
@@ -301,6 +302,8 @@ def assert_no_database_modifications(*args, **kwargs):
                     raise AssertionError("Unexpected modifying query found: " + query["sql"])
 
 
+# For the average LiveServerTest, if the "server" has an internal error, we want to abort/stacktrace/drop into debugger
+@override_settings(DEBUG_PROPAGATE_EXCEPTIONS=True)
 class LiveServerTest(SeleniumTestCase):
     browser = "firefox"
     selenium: WebDriver

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -321,6 +321,7 @@ class LiveServerTest(SeleniumTestCase):
     browser = "firefox"
     selenium: WebDriver
     headless = True
+    implicit_wait = 0
     window_size = (1920, 4096)  # large height to workaround scrolling
     serialized_rollback = True  # SeleniumTestCase is a TransactionTestCase, which drops migration data. This keeps fixture data but may slow down tests, see https://docs.djangoproject.com/en/5.0/topics/testing/overview/#test-case-serialized-rollback
     static_handler = StaticFilesHandler  # see StaticLiveServerTestCase
@@ -329,7 +330,6 @@ class LiveServerTest(SeleniumTestCase):
         super().setUp()
         self.request = self.make_request()
         self.manager = make_manager()
-        self.selenium.implicitly_wait(0)
         self.selenium.get(self.live_server_url)
         self.login(self.manager)
 

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -313,6 +313,7 @@ class LiveServerTest(SeleniumTestCase):
         super().setUp()
         self.request = self.make_request()
         self.manager = make_manager()
+        self.selenium.implicitly_wait(0)
         self.selenium.get(self.live_server_url)
         self.login(self.manager)
 
@@ -352,7 +353,7 @@ class LiveServerTest(SeleniumTestCase):
 
     @property
     def wait(self) -> WebDriverWait:
-        return WebDriverWait(self.selenium, 10)
+        return WebDriverWait(self.selenium, 10, 0.1)
 
     @contextmanager
     def wait_until_page_reloads(self):
@@ -380,3 +381,8 @@ def classes_of_element(element: WebElement) -> list[str]:
     if classes is None:
         return []
     return classes.split(" ")
+
+
+def get_open_modals(driver: WebDriver, by: str, value: str) -> list[WebElement]:
+    modals = driver.find_elements(by, value)
+    return [modal for modal in modals if len(modal.shadow_root.find_elements(By.CSS_SELECTOR, "dialog:open")) == 1]

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -78,7 +78,7 @@ class EvapTestRunner(DiscoverRunner):
         LiveServerTest.headless = not self.__headed
 
         self.log(f"Using baker seed: {self.__baker_seed}")
-        settings.EVAP_TEST_BAKER_SEED = self.__baker_seed
+        SeedBakerMixin.BAKER_SEED = self.__baker_seed
 
 
 class ResetLanguageOnTearDownMixin:
@@ -88,10 +88,12 @@ class ResetLanguageOnTearDownMixin:
 
 
 class SeedBakerMixin:
+    BAKER_SEED: int
+
     @classmethod
     def setUpClass(cls):
         # runs before `setUpTestData`
-        baker.seed(settings.EVAP_TEST_BAKER_SEED)
+        baker.seed(cls.BAKER_SEED)
         super().setUpClass()
 
     @classmethod
@@ -100,7 +102,7 @@ class SeedBakerMixin:
         # Same seed would imply the same value sequence, which causes problems:
         # * uniqueness constraints fail if setUpTestData and setUp both generate an instance of the same model class
         # * "assert name not in page"-style asserts fail for shared names with non-unique fields
-        baker.seed(settings.EVAP_TEST_BAKER_SEED + 1)
+        baker.seed(cls.BAKER_SEED + 1)
         super()._pre_setup()
 
 

--- a/evap/results/tests/test_live.py
+++ b/evap/results/tests/test_live.py
@@ -130,8 +130,10 @@ class ResultsIndexLiveTests(LiveServerTest):
         self.selenium.get(self.url)
         self.wait.until(visibility_of_element_located((By.CLASS_NAME, "reset-button"))).click()
 
+        course_c_span = self.selenium.find_element(By.XPATH, "//span[contains(text(),'Course C')]")
+
         self.selenium.find_element(By.CSS_SELECTOR, "input[name=search]").send_keys("Exam")
-        self.wait.until(invisibility_of_element_located((By.XPATH, "//span[contains(text(),'Course C')]")))
+        self.wait.until(invisibility_of_element_located(course_c_span))
 
         self.assertRowsVisible(("Course A", "ST 13"))
 

--- a/evap/staff/tests/test_live.py
+++ b/evap/staff/tests/test_live.py
@@ -16,6 +16,7 @@ from evap.evaluation.models import (
     Question,
     QuestionAssignment,
     Questionnaire,
+    QuestionType,
     Semester,
     TextAnswer,
     UserProfile,
@@ -253,7 +254,7 @@ class TextAnswerEditLiveTest(LiveServerTest):
             can_publish_text_results=True,
         )
 
-        question1 = baker.make(Question)
+        question1 = baker.make(Question, type=QuestionType.TEXT)
 
         general_questionnaire = baker.make(Questionnaire, questions=[question1])
         evaluation.general_contribution.questionnaires.set([general_questionnaire])

--- a/evap/staff/tests/test_live.py
+++ b/evap/staff/tests/test_live.py
@@ -220,6 +220,7 @@ class EvaluationGridLiveTest(LiveServerTest):
             self.wait.until(make_order_is_as_expected(expected_descending))
 
             self.set_page_language("en")
+            # The table remembers and restores the last ordering, which is "name descending" now
             self.wait.until(make_order_is_as_expected(expected_descending))
             self.selenium.find_element(By.CSS_SELECTOR, "#evaluation-table th[data-col=name]").click()
             self.wait.until(make_order_is_as_expected(expected_ascending))

--- a/evap/staff/tests/test_live.py
+++ b/evap/staff/tests/test_live.py
@@ -181,63 +181,48 @@ class ParticipantCollapseTests(LiveServerTest):
 
 class EvaluationGridLiveTest(LiveServerTest):
     def test_evaluation_grid_sorting(self):
-        test_semester = baker.make(Semester)
+        semester = baker.make(Semester)
 
         baker.make(
             Evaluation,
             _quantity=7,
-            name_de=iter(f"Evaluation {i}" for i in range(1, 8)),
-            name_en=iter(f"Evaluation {i}" for i in range(1, 8)),
+            name_en=baker.seq("Evaluation"),
+            name_de=baker.seq("Evaluation"),
+            course__name_en=iter(("AA", "ÄB", "AC", "AE", "UB", "ÜC", "Z")),
             course__name_de=iter(("AA", "ÄB", "AC", "AE", "UB", "ÜC", "Z")),
-            course__name_en=iter(("Z", "ÜC", "UB", "AE", "AC", "ÄB", "AA")),
-            course__semester=test_semester,
+            course__semester=semester,
         )
 
+        expected_ascending = [
+            "AA – Evaluation1",
+            "ÄB – Evaluation2",
+            "AC – Evaluation3",
+            "AE – Evaluation4",
+            "UB – Evaluation5",
+            "ÜC – Evaluation6",
+            "Z – Evaluation7",
+        ]
+        expected_descending = expected_ascending[::-1]
+
+        def make_order_is_as_expected(expected: list[str]):
+            def predicate(driver):
+                table_entries = driver.find_elements(By.CSS_SELECTOR, "#evaluation-table td[data-col=name]")
+                return expected == [entry.get_attribute("data-order") for entry in table_entries]
+
+            return predicate
+
         with self.enter_staff_mode():
-            self.selenium.get(self.reverse("staff:semester_view", args=[test_semester.id]))
+            self.selenium.get(self.reverse("staff:semester_view", args=[semester.id]))
+
             self.set_page_language("de")
-
-            table_entries = self.selenium.find_elements(
-                By.XPATH, "//table[@id='evaluation-table']//tbody//child::td[@data-col='name']"
-            )
-
-            expected = [
-                "AA – Evaluation 1",
-                "ÄB – Evaluation 2",
-                "AC – Evaluation 3",
-                "AE – Evaluation 4",
-                "UB – Evaluation 5",
-                "ÜC – Evaluation 6",
-                "Z – Evaluation 7",
-            ]
-
-            actual = [entry.get_attribute("data-order") for entry in table_entries]
-            self.assertEqual(actual, expected)
+            self.wait.until(make_order_is_as_expected(expected_ascending))
+            self.selenium.find_element(By.CSS_SELECTOR, "#evaluation-table th[data-col=name]").click()
+            self.wait.until(make_order_is_as_expected(expected_descending))
 
             self.set_page_language("en")
-
-            self.wait.until(visibility_of_element_located((By.ID, "evaluation-table")))
-
-            toggle_sort_button = self.selenium.find_element(By.XPATH, "//thead//th[@data-col='name']")
-            toggle_sort_button.click()
-            self.wait.until(visibility_of_element_located((By.ID, "evaluation-table")))
-
-            table_entries = self.selenium.find_elements(
-                By.XPATH, "//table[@id='evaluation-table']//tbody//child::td[@data-col='name']"
-            )
-
-            expected = [
-                "Z – Evaluation 1",
-                "ÜC – Evaluation 2",
-                "UB – Evaluation 3",
-                "AE – Evaluation 4",
-                "AC – Evaluation 5",
-                "ÄB – Evaluation 6",
-                "AA – Evaluation 7",
-            ]
-
-            actual = [entry.get_attribute("data-order") for entry in table_entries]
-            self.assertEqual(actual, expected)
+            self.wait.until(make_order_is_as_expected(expected_descending))
+            self.selenium.find_element(By.CSS_SELECTOR, "#evaluation-table th[data-col=name]").click()
+            self.wait.until(make_order_is_as_expected(expected_ascending))
 
 
 class TextAnswerEditLiveTest(LiveServerTest):

--- a/evap/staff/tests/test_live.py
+++ b/evap/staff/tests/test_live.py
@@ -1,14 +1,12 @@
 from datetime import date, datetime
 
 from model_bakery import baker
-from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.expected_conditions import (
     element_to_be_clickable,
     invisibility_of_element_located,
     visibility_of_element_located,
 )
-from selenium.webdriver.support.wait import WebDriverWait
 
 from evap.evaluation.models import (
     Contribution,
@@ -144,7 +142,9 @@ class ParticipantCollapseTests(LiveServerTest):
         counter = card_header.find_element(By.CSS_SELECTOR, ".rounded-pill")
         self.assertEqual(counter.text, "20")
 
-        tomselect_input = self.selenium.find_element(By.CSS_SELECTOR, "input#id_participants-ts-control")
+        tomselect_input = self.wait.until(
+            visibility_of_element_located((By.CSS_SELECTOR, "input#id_participants-ts-control"))
+        )
         tomselect_input.click()
         tomselect_input.send_keys("participant")
         self.selenium.find_element(By.CSS_SELECTOR, ".option.active").click()
@@ -296,31 +296,31 @@ class TextAnswerEditLiveTest(LiveServerTest):
                 self.reverse("staff:evaluation_textanswers", query={"view": "quick"}, args=[evaluation.pk])
             )
 
-        next_textanswer_btn = self.selenium.find_element(By.XPATH, "//span[@data-slide='right']")
-        edit_btn = self.selenium.find_element(By.ID, "textanswer-edit-btn")
+            next_textanswer_btn = self.wait.until(
+                visibility_of_element_located((By.CSS_SELECTOR, "span[data-slide=right]"))
+            )
+            edit_btn = self.selenium.find_element(By.ID, "textanswer-edit-btn")
 
-        while True:
-            try:
-                WebDriverWait(self.selenium, 1).until(
-                    visibility_of_element_located((By.ID, f"textanswer-{str(textanswer1.pk)}"))
+            while True:
+                textanswer_element_visible = self.wait.until(
+                    visibility_of_element_located((By.CSS_SELECTOR, ".slider-item.card-body.active[id^=textanswer-]"))
                 )
+                if textanswer_element_visible.get_attribute("id") != f"textanswer-{str(textanswer1.pk)}":
+                    next_textanswer_btn.click()
+                    continue
                 break
-            except TimeoutException:
-                next_textanswer_btn.click()
 
-        with self.enter_staff_mode():
             edit_btn.click()
 
-        textanswer_field = self.selenium.find_element(By.XPATH, "//textarea[@name='answer']")
-        submit_btn = self.selenium.find_element(By.ID, "textanswer-edit-submit-button")
+            textanswer_field = self.selenium.find_element(By.XPATH, "//textarea[@name='answer']")
+            submit_btn = self.selenium.find_element(By.ID, "textanswer-edit-submit-button")
 
-        textanswer_field.clear()
-        textanswer_field.send_keys("edited answer")
+            textanswer_field.clear()
+            textanswer_field.send_keys("edited answer")
 
-        with self.enter_staff_mode():
             submit_btn.click()
 
-        self.wait.until(visibility_of_element_located((By.XPATH, "//div[contains(text(), 'edited answer')]")))
-        self.wait.until(
-            invisibility_of_element_located((By.XPATH, "//div[contains(text(), 'this is a dummy answer')]"))
-        )
+            self.wait.until(visibility_of_element_located((By.XPATH, "//div[contains(text(), 'edited answer')]")))
+            self.wait.until(
+                invisibility_of_element_located((By.XPATH, "//div[contains(text(), 'this is a dummy answer')]"))
+            )

--- a/evap/student/tests/test_live.py
+++ b/evap/student/tests/test_live.py
@@ -134,7 +134,7 @@ class StudentVoteLiveTest(LiveServerTest):
         with self.wait_until_page_reloads():
             self.selenium.find_element(By.ID, "vote-submit-btn").click()
 
-        # wait for all java script to full execute, so our click handlers are registered
+        # wait for all javascript to fully execute, so our click handlers are registered
         self.wait.until(lambda driver: driver.execute_script("return document.readyState") == "complete")
 
         row = self.selenium.find_element(By.CSS_SELECTOR, "#student-vote-form .row:has(.btn-check)")

--- a/evap/student/tests/test_live.py
+++ b/evap/student/tests/test_live.py
@@ -18,10 +18,12 @@ from evap.evaluation.models import (
     QuestionType,
     UserProfile,
 )
-from evap.evaluation.tests.tools import LiveServerTest
+from evap.evaluation.tests.tools import LiveServerTest, get_open_modals
 
 
 class StudentVoteLiveTest(LiveServerTest):
+    SKIP_CONTRIBUTOR_SELECTORS = (By.CSS_SELECTOR, "confirmation-modal.mark-no-answer-modal")
+
     def setUp(self) -> None:
         super().setUp()
         voting_user1 = baker.make(UserProfile, email="voting_user1@institution.example.com")
@@ -130,12 +132,19 @@ class StudentVoteLiveTest(LiveServerTest):
     def test_resolving_submit_errors_clears_warning(self) -> None:
         self.selenium.get(self.url)
         with self.wait_until_page_reloads():
-            self.wait.until(presence_of_element_located((By.ID, "vote-submit-btn"))).click()
+            self.selenium.find_element(By.ID, "vote-submit-btn").click()
+
+        # wait for all java script to full execute, so our click handlers are registered
+        self.wait.until(lambda driver: driver.execute_script("return document.readyState") == "complete")
 
         row = self.selenium.find_element(By.CSS_SELECTOR, "#student-vote-form .row:has(.btn-check)")
+        error_marked = row.find_elements(By.CSS_SELECTOR, ".choice-error")
+        self.assertEqual(len(error_marked), 7)
+
         checkbox = row.find_element(By.CSS_SELECTOR, "input[type=radio][value='2'] + label.choice-error")
         checkbox.click()
-        self.assertEqual(row.find_elements(By.CSS_SELECTOR, ".choice-error"), [])
+
+        self.wait.until(lambda __: row.find_elements(By.CSS_SELECTOR, ".choice-error") == [])
 
     @override_settings(SMALL_COURSE_SIZE=2)
     def test_skip_contributor(self) -> None:
@@ -163,10 +172,6 @@ class StudentVoteLiveTest(LiveServerTest):
         id_ = button.get_attribute("data-mark-no-answers-for")
         self.assertEqual(len(self.selenium.find_elements(By.CSS_SELECTOR, f"#vote-area-{id_} .choice-error")), 0)
 
-    def get_open_modals(self):
-        modals = self.selenium.find_elements(By.CSS_SELECTOR, "confirmation-modal.mark-no-answer-modal")
-        return [modal for modal in modals if len(modal.shadow_root.find_elements(By.CSS_SELECTOR, "dialog:open")) == 1]
-
     def test_skip_contributor_modal_not_shown(self) -> None:
         self.selenium.get(self.url)
 
@@ -179,12 +184,13 @@ class StudentVoteLiveTest(LiveServerTest):
         open_textanswer = vote_area.find_element(By.CSS_SELECTOR, "button.btn-textanswer")
         open_textanswer.click()
 
-        collapsible = vote_area.find_element(By.CSS_SELECTOR, "div.collapse.show")
+        collapsible = self.wait.until(lambda __: vote_area.find_element(By.CSS_SELECTOR, "div.collapse.show"))
 
         radio_button.click()
         button.click()
-        self.assertEqual(len(self.get_open_modals()), 0)
-        self.assertFalse(collapsible.is_displayed())
+
+        self.wait.until(lambda __: not collapsible.is_displayed())
+        self.assertEqual(get_open_modals(self.selenium, *self.SKIP_CONTRIBUTOR_SELECTORS), [])
 
     def test_skip_contributor_modal_shown(self) -> None:
         self.selenium.get(self.url)
@@ -200,15 +206,17 @@ class StudentVoteLiveTest(LiveServerTest):
 
         textarea.send_keys("a")
         button.click()
-        modals = self.get_open_modals()
+        modals = get_open_modals(self.selenium, *self.SKIP_CONTRIBUTOR_SELECTORS)
         self.assertEqual(len(modals), 1)
         ActionChains(self.selenium).send_keys(Keys.ESCAPE).perform()
         self.assertEqual(textarea.get_attribute("value"), "a")
 
         button.click()
-        modal = self.get_open_modals()[0]
+
+        (modal,) = get_open_modals(self.selenium, *self.SKIP_CONTRIBUTOR_SELECTORS)
+
         confirm_button = modal.shadow_root.find_element(By.CSS_SELECTOR, "button[data-event-type='confirm']")
         confirm_button.click()
         self.wait.until(invisibility_of_element(modal))
-        self.assertEqual(len(self.get_open_modals()), 0)
-        self.assertEqual(textarea.get_attribute("value"), "")
+        self.wait.until(lambda __: textarea.get_attribute("value") == "")
+        self.wait.until(lambda driver: len(get_open_modals(driver, *self.SKIP_CONTRIBUTOR_SELECTORS)) == 0)

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -348,6 +348,8 @@ def vote(request: HttpRequest, evaluation_id: int, dropout: bool = False) -> Htt
     if not evaluation.can_be_voted_for_by(request.user):
         raise PermissionDenied
 
+    assert False, "oh noes"
+
     form_groups = get_vote_page_form_groups(request, evaluation, preview=False, dropout=dropout)
     if not all(form.is_valid() for form_group in form_groups.values() for form in form_group):
         return render_vote_page(request, evaluation, preview=False, dropout=dropout)

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -348,8 +348,6 @@ def vote(request: HttpRequest, evaluation_id: int, dropout: bool = False) -> Htt
     if not evaluation.can_be_voted_for_by(request.user):
         raise PermissionDenied
 
-    assert False, "oh noes"
-
     form_groups = get_vote_page_form_groups(request, evaluation, preview=False, dropout=dropout)
     if not all(form.is_valid() for form_group in form_groups.values() for form in form_group):
         return render_vote_page(request, evaluation, preview=False, dropout=dropout)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ method-rgx = "(^[a-z0-9_]+$)|(^assert[A-Za-z]+$)"
 # Allow 4 leading digits for migrations
 module-rgx = "^([0-9]{4})?([a-z_][a-z0-9_]+)$"
 
-good-names = [ "i", "j", "k", "ex", "Run", "_", "__", "e", "logger", "setUpTestData", "setUp", "tearDown", "do_not_call_in_templates" ]
+good-names = [ "i", "j", "k", "ex", "Run", "_", "__", "e", "logger", "setUpClass", "setUpTestData", "setUp", "tearDown", "do_not_call_in_templates" ]
 
 [tool.pylint.format]
 expected-line-ending-format = "LF"


### PR DESCRIPTION
Fixes #2652.

Best reviewed by commit.

* Removes implicit wait on selenium web driver find interactions. This made tests flaky before, we had scenarios where we actually needed to wait, but we didn't use an explicit wait with a long enough timeout. Rationale: We should be explicit and strict about whether interactions need to wait or whether elements should already be there. I also reduced our explicit wait polling wait time from the default of 500ms to 100ms. Most of our javascript is extremely lightweight, if something isn't there immediately, most likely, after 100ms, it will be there.
* Moves out `get_open_modals` into a generic helper function.
* Fixes instances where the tests get stuck waiting needlessly.
* Makes LiveServerTests produce a stacktrace / drop into debugger when we run into an internal server error. Before, we returned our generic production "Something went wrong" page, which caused later test assertions to fail in a way that made in unnecessarily hard to debug.
* Adds a mechanism to re-run tests with the same baker-generated values using test command line flag `--baker-seed`. UX is copied from django's `--shuffle` feature. This should allow reproducing flaky test failures much more easily.
* Fixes flakiness of `test_edit_textanswer_redirect`: There was a timing issue, and the server would fail an assertion when the question type happened to be randomly generated as `HEADING`. I ran all tests with a default question type `HEADING` to see if there are more affected tests, but every other test passes.

Runtime (`time ./manage.py test --tag selenium`)
* before: 138s
* after: 44s