### PR TITLE
Run `./manage.py run`, TS, SCSS in process-compose; README changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -286,5 +286,5 @@ jobs:
         with:
           submodules: true
       - uses: ./.github/setup_evap
-        with:
-          start-db: true
+      - name: Build default process-compose setup
+        run: nix build

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To exit the development shell, press `Ctrl-D` or type `exit`.
 
 If you start your code editor from the `nix develop` shell, it should automatically pick up all dependencies. If this does not work automatically, try using the `nix/nix-python` script in the EvaP project as the Python interpreter in your IDE.
 
-After quitting the services, you can run the command `nix run .#clean-setup` to remove persistent state (database, node modules, localsettings).
+After quitting `nix run`, you can run the command `nix run .#clean-setup` to remove persistent state (database, node modules, localsettings).
 Afterwards, `nix run` will recreate everything when you run it the next time.
 
 Before committing, run `./manage.py precommit` or alternatively, the individual commands:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ For the documentation, please see our [wiki](https://github.com/e-valuation/EvaP
 
 ## Development Setup
 
-We use [nix](https://nixos.org/) to manage the development environment.
+We use [nix](https://nixos.org/) to manage the development environment. To get a local version of EvaP running, follow these steps:
 
 1. Windows only: Install the Windows Subsystem for Linux (WSL) using `wsl --install -d Ubuntu-24.04` (you may have to restart your computer and run this command again). Enter the WSL environment using the `wsl` command. On your first entry, you need to choose a username and password - anything works (for example: username "evap", password "evap"). Perform the next step outside of `/mnt`, for example by going to your home directory (`cd ~`).
 2. Install [git](https://git-scm.com/downloads). Run the following commands to clone and enter the EvaP repository:
    ```bash
-   git clone --recurse-submodules https://github.com/e-valuation/EvaP.git
+   git clone https://github.com/e-valuation/EvaP.git
    cd EvaP
    ```
 3. On Linux and WSL, install nix by running `./nix/setup-nix`. On MacOS, install nix using the [Determinate Nix Installer](https://install.determinate.systems/). Afterwards, if you get any errors when running nix, restart your computer.
@@ -29,27 +29,34 @@ We use [nix](https://nixos.org/) to manage the development environment.
    ```
 5. Open your web browser at http://localhost:8000/ and login with email `evap@institution.example.com` and password `evap`.
 
-When developing EvaP, you can open a shell with all dependencies available:
-```bash
-cd EvaP
-nix develop
-```
+To stop EvaP, press `Ctrl-C` and confirm with `Enter`.
 
-To stop the EvaP services, press `Ctrl-C`.
-To exit the development shell, press `Ctrl-D` or type `exit`.
+### What is going on?
 
-Inside the development shell, after quitting the services, you can run the command `clean-setup` to remove persistent state (database, node modules, localsettings).
-Afterwards, `nix run` will recreate a default development environment on startup.
+The command `nix run` starts a program called `process-compose` which performs some initial setup and orchestrates a number of processes needed to run EvaP. In particular, `nix` and `process-compose` handle installation of all dependencies, setup of the postgres database and redis cache, compilation of TypeScript, SCSS, and translation files, and running the Django development server. When changing Python, HTML, SCSS, or TypeScript files, you do not have to restart the server.
 
 ## Contributing
 
-We'd love to see contributions! PRs solving existing issues are most helpful to us. It's best if you ask to be assigned for the issue so we won't have multiple people working on the same issue. Feel free to open issues for bugs, setup problems, or feature requests. If you have other questions, feel free to contact the [organization members](https://github.com/orgs/e-valuation/people). You should probably branch off `main`, the branch `release` is used for stable revisions.
+We'd love to see contributions! PRs solving existing issues are most helpful to us. It's best if you ask to be assigned for the issue so we won't have multiple people working on the same issue. Feel free to open issues for bugs, setup problems, or feature requests. If you have other questions, feel free to contact the [organization members](https://github.com/orgs/e-valuation/people).
+
+To work on EvaP, you can open a shell with all dependencies available:
+```bash
+cd EvaP
+nix develop
+./manage.py test # In the shell, you can use ./manage.py commands
+```
+To exit the development shell, press `Ctrl-D` or type `exit`.
+
+If you start your code editor from the `nix develop` shell, it should automatically pick up all dependencies. If this does not work automatically, try using the `nix/nix-python` script in the EvaP project as the Python interpreter in your IDE.
+
+After quitting the services, you can run the command `nix run .#clean-setup` to remove persistent state (database, node modules, localsettings).
+Afterwards, `nix run` will recreate everything when you run it the next time.
 
 Before committing, run `./manage.py precommit` or alternatively, the individual commands:
 - `./manage.py typecheck`
 - `./manage.py test` (check out [--keepdb](https://docs.djangoproject.com/en/6.0/ref/django-admin/#cmdoption-test-keepdb) and [--parallel](https://docs.djangoproject.com/en/6.0/ref/django-admin/#cmdoption-test-parallel) for faster execution)
 - `./manage.py lint`
-- `./manage.py format` (applies automatic code formatting)
+- `./manage.py format`
 
 You can also set up `ruff`, `pylint`, and `prettier` in your IDE to avoid doing this manually all the time.
 

--- a/README.md
+++ b/README.md
@@ -18,28 +18,28 @@ We use [nix](https://nixos.org/) to manage the development environment.
 
 1. Windows only: Install the Windows Subsystem for Linux (WSL) using `wsl --install -d Ubuntu-24.04` (you may have to restart your computer and run this command again). Enter the WSL environment using the `wsl` command. On your first entry, you need to choose a username and password - anything works (for example: username "evap", password "evap"). Perform the next step outside of `/mnt`, for example by going to your home directory (`cd ~`).
 2. Install [git](https://git-scm.com/downloads). Run the following commands to clone and enter the EvaP repository:
-   ```
+   ```bash
    git clone --recurse-submodules https://github.com/e-valuation/EvaP.git
    cd EvaP
    ```
-3. On Linux and WSL, install nix by running `./nix/setup-nix`. On MacOS, install nix using the [Determinate Nix Installer](https://install.determinate.systems/). Afterwards, if you get a permission error when running nix, restart your computer.
-4. Start the needed background services for EvaP:
+3. On Linux and WSL, install nix by running `./nix/setup-nix`. On MacOS, install nix using the [Determinate Nix Installer](https://install.determinate.systems/). Afterwards, if you get any errors when running nix, restart your computer.
+4. Start EvaP and wait until you see a table view and the "evap" row shows "Running":
+   ```bash
+   nix run
    ```
-   nix run .#services-full
-   ```
-5. Open a new terminal. Enter the development shell and start EvaP:
-   ```
-   cd EvaP
-   nix develop
-   ./manage.py run
-   ```
-6. Open your web browser at http://localhost:8000/ and login with email `evap@institution.example.com` and password `evap`.
+5. Open your web browser at http://localhost:8000/ and login with email `evap@institution.example.com` and password `evap`.
 
-To stop EvaP or the background services, press `Ctrl-C`.
+When developing EvaP, you can open a shell with all dependencies available:
+```bash
+cd EvaP
+nix develop
+```
+
+To stop the EvaP services, press `Ctrl-C`.
 To exit the development shell, press `Ctrl-D` or type `exit`.
 
-Inside the development shell, after quitting the background services, you can run the command `clean-setup` to remove persistent state (database, node modules, localsettings).
-Afterwards, `nix run .#services-full` will recreate a default development environment on startup.
+Inside the development shell, after quitting the services, you can run the command `clean-setup` to remove persistent state (database, node modules, localsettings).
+Afterwards, `nix run` will recreate a default development environment on startup.
 
 ## Contributing
 

--- a/evap/development/management/commands/run.py
+++ b/evap/development/management/commands/run.py
@@ -1,5 +1,4 @@
 import sys
-from subprocess import Popen  # nosec
 
 from django.core.management import execute_from_command_line
 from django.core.management.base import BaseCommand
@@ -10,8 +9,6 @@ class Command(BaseCommand):
     help = 'Execute "runserver 0.0.0.0:8000"'
 
     def handle(self, *args, **options):
-        self.stdout.write('Executing "manage.py scss" and "manage.py ts compile"')
-        with Popen(["./manage.py", "scss"]), Popen(["./manage.py", "ts", "compile"]):  # nosec
-            self.stdout.write('Executing "manage.py runserver 0.0.0.0:8000"')
-            sys.argv = ["manage.py", "runserver", "0.0.0.0:8000"]
-            execute_from_command_line(sys.argv)
+        self.stdout.write('Executing "manage.py runserver 0.0.0.0:8000"')
+        sys.argv = ["manage.py", "runserver", "0.0.0.0:8000"]
+        execute_from_command_line(sys.argv)

--- a/evap/development/tests/test_commands.py
+++ b/evap/development/tests/test_commands.py
@@ -65,15 +65,6 @@ class TestReloadTestdataCommand(TestCase):
 class TestRunCommand(TestCase):
     def test_calls_runserver(self):
         with patch("django.core.management.execute_from_command_line") as execute_mock:
-            with patch("subprocess.Popen") as popen_mock:
-                management.call_command("run", stdout=StringIO())
+            management.call_command("run", stdout=StringIO())
 
         execute_mock.assert_called_once_with(["manage.py", "runserver", "0.0.0.0:8000"])
-        self.assertEqual(popen_mock.call_count, 2)
-        popen_mock.assert_has_calls(
-            [
-                call(["./manage.py", "scss"]),
-                call(["./manage.py", "ts", "compile"]),
-            ],
-            any_order=True,
-        )

--- a/evap/development/tests/test_commands.py
+++ b/evap/development/tests/test_commands.py
@@ -1,5 +1,5 @@
 from io import StringIO
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 from django.conf import settings
 from django.core import management

--- a/evap/evaluation/management/commands/ts.py
+++ b/evap/evaluation/management/commands/ts.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
         ]
 
         if watch:
-            command += ["--watch"]
+            command += ["--watch", "--preserveWatchOutput"]
 
         if fresh:
             (static_directory / "ts" / ".tsbuildinfo.json").unlink(missing_ok=True)

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -253,7 +253,7 @@ class TestTsCommand(TestCase):
         management.call_command("ts", "compile", "--watch", stdout=StringIO())
 
         mock_subprocess_run.assert_called_once_with(
-            ["npx", "tsc", "--project", self.ts_path / "tsconfig.compile.json", "--watch"],
+            ["npx", "tsc", "--project", self.ts_path / "tsconfig.compile.json", "--watch", "--preserveWatchOutput"],
             check=False,
         )
 

--- a/flake.nix
+++ b/flake.nix
@@ -77,19 +77,22 @@
             inherit pkgs;
             inherit (self.devShells.${system}.evap.passthru) venv;
           };
-          make-process-compose = with-devenv-setup: (import inputs.process-compose-flake.lib { inherit pkgs; }).makeProcessCompose {
+          make-process-compose = mode: (import inputs.process-compose-flake.lib { inherit pkgs; }).makeProcessCompose {
             modules = [
               inputs.services-flake.processComposeModules.default
               pc-modules.databases
-              (lib.mkIf with-devenv-setup pc-modules.devenv-setup)
+              (lib.mkIf (mode > 0) pc-modules.devenv-setup)
+              (lib.mkIf (mode > 1) pc-modules.devenv)
             ];
           };
         in
         rec {
           python3 = pkgs.python313;
 
-          services = make-process-compose false;
-          services-full = make-process-compose true;
+          services = make-process-compose 0;
+          services-full = make-process-compose 1;
+          services-fuller = make-process-compose 2;
+          default = services-fuller;
 
           wait-for-pc = pkgs.writeShellApplication {
             name = "wait-for-pc";

--- a/nix/services.nix
+++ b/nix/services.nix
@@ -91,6 +91,7 @@
               ${inner-command}
             '';
           };
+          is_tty = true;
           depends_on = {
             "init-django".condition = "process_completed_successfully";
             "npm-ci".condition = "process_completed_successfully";

--- a/nix/services.nix
+++ b/nix/services.nix
@@ -78,4 +78,29 @@
       };
     };
   };
+
+  devenv = {
+    settings.processes =
+      let
+        make-dev-command = name: inner-command: {
+          command = pkgs.writeShellApplication {
+            inherit name;
+            runtimeInputs = [ venv pkgs.nodejs ];
+            text = ''
+              set -ex
+              ${inner-command}
+            '';
+          };
+          depends_on = {
+            "init-django".condition = "process_completed_successfully";
+            "npm-ci".condition = "process_completed_successfully";
+          };
+        };
+      in
+      {
+        ts = make-dev-command "ts" "./manage.py ts compile --fresh --watch";
+        scss = make-dev-command "scss" "./manage.py scss --watch";
+        evap = make-dev-command "evap" "./manage.py run";
+      };
+  };
 }


### PR DESCRIPTION
See the README change. I kept the old services-full name around so that we don't break setups in the transition period.

If any of these services should be stopped or restarted, this can be done in the process-compose TUI with the keyboard shortcuts listed at the bottom.
