### PR TITLE
Stop recommending the Determinate Nix installer; eagerly install nix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We use [nix](https://nixos.org/) to manage the development environment. To get a
    git clone https://github.com/e-valuation/EvaP.git
    cd EvaP
    ```
-3. On Linux and WSL, install nix by running `./nix/setup-nix`. On MacOS, install nix using the [Determinate Nix Installer](https://install.determinate.systems/). Afterwards, if you get any errors when running nix, restart your computer.
+3. Install nix by running `./nix/setup-nix`. Afterwards, if you get any errors when running nix, restart your computer.
 4. Start EvaP and wait until you see a table view and the "evap" row shows "Running":
    ```bash
    nix run

--- a/nix/setup-nix
+++ b/nix/setup-nix
@@ -2,16 +2,32 @@
 
 set -e
 
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
+NIX_CONF="$XDG_CONFIG_HOME/nix/nix.conf"
+
+if test -e "$NIX_CONF"; then
+    echo "Nix config already found at $NIX_CONF"
+    echo "Please make sure it contains the following settings:"
+    echo
+    cat $(dirname $0)/nix.conf
+    echo
+else
+    echo "Installing nix config at $NIX_CONF"
+    mkdir -p "$XDG_CONFIG_HOME/nix/"
+    cp --verbose $(dirname $0)/nix.conf "$NIX_CONF"
+fi
+
 if nix --version &> /dev/null; then
-    echo "Nix already installed. Please follow the appropriate steps from the script manually."
+    echo "Nix already installed, exiting."
     exit 1
 fi
 
-if apt --version &> /dev/null; then
+if apt-get --version &> /dev/null; then
     set -x
     sudo apt-get update -y
     sudo apt-get install -y nix
     sudo usermod -aG nix-users $USER
+    # Spawn new shell with updated group membership
     newgrp nix-users
 elif pacman --version &> /dev/null; then
     set -x
@@ -21,11 +37,8 @@ elif dnf --version &> /dev/null; then
     sudo dnf install nix nix-daemon -y
 else
     echo "Failed to detect package manager. Please install nix manually."
-    echo "We recommend using the Determinate Nix Installer: https://install.determinate.systems"
-    exit 1
+    echo "We recommend using the official nix installer: https://nixos.org/download/"
+    exit 2
 fi
 
-XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
-mkdir -p "$XDG_CONFIG_HOME/nix/"
-cat $(dirname $0)/nix.conf >> "$XDG_CONFIG_HOME/nix/nix.conf"
 sudo systemctl enable --now nix-daemon


### PR DESCRIPTION
The Determinate Nix installer is no longer the Determinate (Nix Installer) but rather the (Determinate Nix) Installer, that is, it installs the proprietary version of nix built by Determinate Systems. I don't think there is anything wrong with their nix build, but I don't want to recommend installing proprietary software.

One benefit of the Determinate installer is that it had some sane default settings (the same that we include in our Linux installation script). With this PR, we now let the nix install script set up these settings even if installing nix does not work. This way, for Mac users the process is "run installer", "installer installs config", "installer says no package manager found and suggests manual download", "user does manual download". I think this is pretty okay. If the Mac users complain, we can add support for homebrew or so to our installer script.