### PR TITLE
Fix misplaced form error tooltip

### DIFF
--- a/evap/static/scss/components/_forms.scss
+++ b/evap/static/scss/components/_forms.scss
@@ -10,12 +10,9 @@
     }
 }
 
-select[multiple='multiple'] {
-    height: 0px;
-}
-
-select[multiple] {
-    min-height: 40px;
+// place tooltip for tomselect based on form-element height
+.tomselected {
+    height: 38px;
 }
 
 .email-form {

--- a/evap/static/scss/components/_forms.scss
+++ b/evap/static/scss/components/_forms.scss
@@ -11,7 +11,7 @@
 }
 
 select[multiple='multiple'] {
-    height: 200px;
+    height: 0px;
 }
 
 select[multiple] {

--- a/evap/static/scss/components/_forms.scss
+++ b/evap/static/scss/components/_forms.scss
@@ -10,7 +10,7 @@
     }
 }
 
-// place tooltip for tomselect based on form-element height
+// place tooltip for tomselect based on form-element height. See https://github.com/orchidjs/tom-select/issues/1038
 .tomselected {
     height: 38px;
 }


### PR DESCRIPTION
Closes #2646. Removed height attribute was introduced [here](https://github.com/e-valuation/EvaP/blob/4e07a0b4c61e0468513a6d0c033ddf9b3664c5e0/evap/static/css/evap.css).