### PR TITLE
prefetch participant and voter counts in contributor index

### DIFF
--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -89,7 +89,6 @@ class TestContributorView(WebTestWith200Check):
 
     def test_num_queries_is_not_constant(self):
         """Current defect, see https://github.com/e-valuation/EvaP/issues/1229#issuecomment-4239035495."""
-        url = "/contributor/"
         represented = baker.make(UserProfile, email="represented@example.com")
         self.responsible.represented_users.add(represented)
         evaluations = baker.make(
@@ -108,7 +107,7 @@ class TestContributorView(WebTestWith200Check):
             _bulk_create=True,
         )
         with self.assertNumQueries(FuzzyInt(80, 100)):
-            self.app.get(url, user=self.responsible)
+            self.app.get(self.url, user=self.responsible)
 
 
 class TestContributorEvaluationView(WebTestWith200Check):

--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -6,6 +6,7 @@ from model_bakery import baker
 
 from evap.evaluation.models import Contribution, Course, Evaluation, Questionnaire, UserProfile
 from evap.evaluation.tests.tools import (
+    FuzzyInt,
     WebTest,
     WebTestWith200Check,
     create_evaluation_with_responsible_and_editor,
@@ -82,8 +83,32 @@ class TestContributorView(WebTestWith200Check):
 
     @classmethod
     def setUpTestData(cls):
-        users = create_evaluation_with_responsible_and_editor()
-        cls.test_users = [users["editor"], users["responsible"]]
+        result = create_evaluation_with_responsible_and_editor()
+        cls.responsible = result["responsible"]
+        cls.test_users = [result["editor"], cls.responsible]
+
+    def test_num_queries_is_not_constant(self):
+        """Current defect, see https://github.com/e-valuation/EvaP/issues/1229#issuecomment-4239035495."""
+        url = "/contributor/"
+        represented = baker.make(UserProfile, email="represented@example.com")
+        self.responsible.represented_users.add(represented)
+        evaluations = baker.make(
+            Evaluation,
+            name_en=iter(range(10)),
+            name_de=iter(range(10)),
+            state=Evaluation.State.PUBLISHED,
+            course__responsibles=[represented],
+            _quantity=10,
+            _bulk_create=True,
+        )
+        baker.make(
+            Contribution,
+            evaluation=iter(evaluations),
+            _quantity=10,
+            _bulk_create=True,
+        )
+        with self.assertNumQueries(FuzzyInt(80, 100)):
+            self.app.get(url, user=self.responsible)
 
 
 class TestContributorEvaluationView(WebTestWith200Check):

--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -58,7 +58,7 @@ def index(request):
     )
 
     own_evaluations = (
-        Evaluation.objects.filter(course__in=own_courses)
+        Evaluation.annotate_with_participant_and_voter_counts(Evaluation.objects.filter(course__in=own_courses))
         .annotate(contributes_to=Exists(Evaluation.objects.filter(id=OuterRef("id"), contributions__contributor=user)))
         .prefetch_related("course", "course__evaluations", "course__programs", "course__type", "course__semester")
     )
@@ -77,9 +77,17 @@ def index(request):
                 )
             )
         )
-        delegated_evaluations = Evaluation.objects.filter(course__in=delegated_courses).prefetch_related(
-            "course", "course__evaluations", "course__programs", "course__type", "course__semester"
+        delegated_evaluations = Evaluation.annotate_with_participant_and_voter_counts(
+            Evaluation.objects.filter(course__in=delegated_courses)
+        ).prefetch_related(
+            "course",
+            "course__evaluations",
+            "course__programs",
+            "course__type",
+            "course__semester",
+            "course__responsibles",
         )
+
         delegated_evaluations = [evaluation for evaluation in delegated_evaluations if evaluation.can_be_seen_by(user)]
         for evaluation in delegated_evaluations:
             evaluation.delegated_evaluation = True

--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -60,7 +60,8 @@ def index(request):
     own_evaluations = (
         Evaluation.annotate_with_participant_and_voter_counts(Evaluation.objects.filter(course__in=own_courses))
         .annotate(contributes_to=Exists(Evaluation.objects.filter(id=OuterRef("id"), contributions__contributor=user)))
-        .prefetch_related("course", "course__evaluations", "course__programs", "course__type", "course__semester")
+        .select_related("course", "course__type", "course__semester")
+        .prefetch_related("course__evaluations", "course__programs")
     )
     own_evaluations = [evaluation for evaluation in own_evaluations if evaluation.can_be_seen_by(user)]
 
@@ -77,15 +78,12 @@ def index(request):
                 )
             )
         )
-        delegated_evaluations = Evaluation.annotate_with_participant_and_voter_counts(
-            Evaluation.objects.filter(course__in=delegated_courses)
-        ).prefetch_related(
-            "course",
-            "course__evaluations",
-            "course__programs",
-            "course__type",
-            "course__semester",
-            "course__responsibles",
+        delegated_evaluations = (
+            Evaluation.annotate_with_participant_and_voter_counts(
+                Evaluation.objects.filter(course__in=delegated_courses)
+            )
+            .select_related("course", "course__type", "course__semester")
+            .prefetch_related("course__evaluations", "course__programs", "course__responsibles")
         )
 
         delegated_evaluations = [evaluation for evaluation in delegated_evaluations if evaluation.can_be_seen_by(user)]


### PR DESCRIPTION
relates to #1229

Directly reduces n database hits.
When testing with 200 evaluations 10 times, the accumulated test-runtime was reduced from 50s to 44s on my laptop. Even with 10 evaluations, I see a speedup (4.820s -> 3.689s).