### PR TITLE
Optimize question migration

### DIFF
--- a/evap/evaluation/migrations/0161_temporary_newquestion_relation.py
+++ b/evap/evaluation/migrations/0161_temporary_newquestion_relation.py
@@ -2,6 +2,7 @@
 
 import django.db.models.deletion
 from django.db import migrations, models
+from django.db.models import OuterRef, Subquery
 
 
 def questions_to_question_assignments(apps, _schema_editor):
@@ -10,33 +11,58 @@ def questions_to_question_assignments(apps, _schema_editor):
     QuestionAssignment = apps.get_model("evaluation", "QuestionAssignment")
     RatingAnswerCounter = apps.get_model("evaluation", "RatingAnswerCounter")
     TextAnswer = apps.get_model("evaluation", "TextAnswer")
-    assignments = {}
-    new_questions = {}
-    for question in Question.objects.all():
-        new_question = new_questions.setdefault(
-            (question.text_de, question.text_en, question.allows_additional_textanswers, question.type),
-            NewQuestion(
-                # pk=question.pk,  # was only active when the test data jsons were regenerated to minimize the diff
-                text_de=question.text_de,
-                text_en=question.text_en,
-                allows_additional_textanswers=question.allows_additional_textanswers,
-                type=question.type,
-            ),
-        )
-        assignments[question.pk] = QuestionAssignment(
-            question=new_question, questionnaire_id=question.questionnaire_id, order=question.order
-        )
-    NewQuestion.objects.bulk_create(new_questions.values())
-    QuestionAssignment.objects.bulk_create(assignments.values())
 
-    def set_question_assignment(answer):
-        answer.assignment = assignments[answer.question_id]
-        return answer
+    NewQuestion.objects.bulk_create(
+        # added "pk" to order_by and values for test_data migration
+        (
+            NewQuestion(**v)
+            for v in Question.objects.all()
+            .order_by("text_de", "text_en", "allows_additional_textanswers", "type")
+            .values("text_de", "text_en", "allows_additional_textanswers", "type")
+            .distinct("text_de", "text_en", "allows_additional_textanswers", "type")
+            .iterator()
+        ),
+        batch_size=2000,
+    )
+    QuestionAssignment.objects.bulk_create(
+        (
+            QuestionAssignment(**v)
+            for v in Question.objects.all()
+            .annotate(
+                question_id=NewQuestion.objects.filter(
+                    text_de=OuterRef("text_de"),
+                    text_en=OuterRef("text_en"),
+                    allows_additional_textanswers=OuterRef("allows_additional_textanswers"),
+                    type=OuterRef("type"),
+                ).values("id"),
+            )
+            .values("question_id", "order", "questionnaire_id")
+            .iterator()
+        ),
+        batch_size=2000,
+    )
 
     for model in (RatingAnswerCounter, TextAnswer):
-        model.objects.bulk_update(
-            map(set_question_assignment, model.objects.all()),
-            fields=["assignment"],
+        model.objects.update(
+            assignment=QuestionAssignment.objects.filter(
+                question__text_de=Subquery(
+                    Question.objects.filter(id=OuterRef(OuterRef("question_id"))).values("text_de")[:1]
+                ),
+                question__text_en=Subquery(
+                    Question.objects.filter(id=OuterRef(OuterRef("question_id"))).values("text_en")[:1]
+                ),
+                question__allows_additional_textanswers=Subquery(
+                    Question.objects.filter(id=OuterRef(OuterRef("question_id"))).values(
+                        "allows_additional_textanswers"
+                    )[:1]
+                ),
+                question__type=Subquery(
+                    Question.objects.filter(id=OuterRef(OuterRef("question_id"))).values("type")[:1]
+                ),
+                questionnaire_id=Subquery(
+                    Question.objects.filter(id=OuterRef(OuterRef("question_id"))).values("questionnaire_id")[:1]
+                ),
+            ).values("id")
         )
 
 

--- a/evap/evaluation/migrations/0162_unified_questions_from_tmp_relation.py
+++ b/evap/evaluation/migrations/0162_unified_questions_from_tmp_relation.py
@@ -2,6 +2,7 @@
 
 import django.db.models.deletion
 from django.db import migrations, models
+from django.db.models import F, OuterRef, Subquery
 
 
 def question_assignments_to_questions(apps, _schema_editor):
@@ -9,27 +10,58 @@ def question_assignments_to_questions(apps, _schema_editor):
     QuestionAssignment = apps.get_model("evaluation", "QuestionAssignment")
     RatingAnswerCounter = apps.get_model("evaluation", "RatingAnswerCounter")
     TextAnswer = apps.get_model("evaluation", "TextAnswer")
-    questions = {}
-    for question_assignment in QuestionAssignment.objects.all().prefetch_related("question"):
-        new_question = question_assignment.question
-        questions[question_assignment.pk] = Question(
-            text_de=new_question.text_de,
-            text_en=new_question.text_en,
-            allows_additional_textanswers=new_question.allows_additional_textanswers,
-            type=new_question.type,
-            questionnaire=question_assignment.questionnaire,
-            order=question_assignment.order,
-        )
-    Question.objects.bulk_create(questions.values())
 
-    def set_question(answer):
-        answer.question_id = questions[answer.assignment_id].pk
-        return answer
+    Question.objects.bulk_create(
+        (
+            Question(**v)
+            for v in QuestionAssignment.objects.annotate(
+                text_de=F("question__text_de"),
+                text_en=F("question__text_en"),
+                allows_additional_textanswers=F("question__allows_additional_textanswers"),
+                type=F("question__type"),
+            )
+            .values(
+                "text_de",
+                "text_en",
+                "allows_additional_textanswers",
+                "type",
+                "questionnaire_id",
+                "order",
+            )
+            .iterator()
+        ),
+        batch_size=2000,
+    )
 
     for model in (RatingAnswerCounter, TextAnswer):
-        model.objects.bulk_update(
-            map(set_question, model.objects.all()),
-            fields=["question"],
+        model.objects.update(
+            question=Question.objects.filter(
+                text_de=Subquery(
+                    QuestionAssignment.objects.filter(id=OuterRef(OuterRef("assignment_id"))).values(
+                        "question__text_de"
+                    )[:1]
+                ),
+                text_en=Subquery(
+                    QuestionAssignment.objects.filter(id=OuterRef(OuterRef("assignment_id"))).values(
+                        "question__text_en"
+                    )[:1]
+                ),
+                allows_additional_textanswers=Subquery(
+                    QuestionAssignment.objects.filter(id=OuterRef(OuterRef("assignment_id"))).values(
+                        "question__allows_additional_textanswers"
+                    )[:1]
+                ),
+                type=Subquery(
+                    QuestionAssignment.objects.filter(id=OuterRef(OuterRef("assignment_id"))).values("question__type")[
+                        :1
+                    ]
+                ),
+                questionnaire_id=Subquery(
+                    QuestionAssignment.objects.filter(id=OuterRef(OuterRef("assignment_id"))).values(
+                        "questionnaire_id"
+                    )[:1]
+                ),
+            ).values("id")
         )
 
 


### PR DESCRIPTION
redesign evaluation 0161 and 0162 migration so that all question objects are not stored in python.

- use bulk_create with `batch_size` 2000 on plain querysets only
- update answer objects with single update + subqueries for joined fields

followup for #2513 