### PR TITLE
fix(results): guard participationclass against zero participants (#2709)

### DIFF
--- a/evap/results/templatetags/results_templatetags.py
+++ b/evap/results/templatetags/results_templatetags.py
@@ -34,6 +34,8 @@ def evaluation_results_cache_timeout(evaluation: Evaluation) -> int | None:
 
 @register.filter(name="participationclass")
 def participationclass(number_of_voters: int, number_of_participants: int) -> int:
+    if number_of_participants == 0:
+        return 0
     return round((number_of_voters / number_of_participants) * 10)
 
 

--- a/evap/results/tests/test_views.py
+++ b/evap/results/tests/test_views.py
@@ -983,3 +983,17 @@ class TestTextAnswerExportView(WebTest):
             self.app.get(self.url + "?contributor_id=", user=self.reviewer, status=400)
             self.app.get(self.url + "?contributor_id=asd", user=self.reviewer, status=400)
             export_method.assert_not_called()
+
+
+class TestParticipationClassFilter(TestCase):
+    def test_handles_zero_participants(self):
+        from evap.results.templatetags.results_templatetags import participationclass
+
+        self.assertEqual(participationclass(0, 0), 0)
+
+    def test_returns_rounded_class(self):
+        from evap.results.templatetags.results_templatetags import participationclass
+
+        self.assertEqual(participationclass(0, 10), 0)
+        self.assertEqual(participationclass(5, 10), 5)
+        self.assertEqual(participationclass(10, 10), 10)


### PR DESCRIPTION
Fixes #2709.

`participationclass` divided `number_of_voters` by `number_of_participants` without a guard, so loading the results page for an evaluation with zero participants raised `ZeroDivisionError`. Returning 0 (the empty-bucket badge class) when `number_of_participants` is 0 mirrors the safe pattern already used in `results/exporters.py:241` for the same ratio.

Added `TestParticipationClassFilter` covering the zero-participant case and the existing rounding behavior.