### PR TITLE
Fix mixed query/create_defaults for Contribution in CMS import

### DIFF
--- a/evap/cms/json_importer.py
+++ b/evap/cms/json_importer.py
@@ -639,10 +639,10 @@ class JSONImporter:
         if user_profile.email in settings.NON_RESPONSIBLE_USERS:
             return None, False
 
-        contribution, created = Contribution.objects.update_or_create(
+        contribution, created = Contribution.objects.get_or_create(
             evaluation=evaluation,
             contributor=user_profile,
-            create_defaults={
+            defaults={
                 "role": Contribution.Role.EDITOR,
                 "textanswer_visibility": Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
             },

--- a/evap/cms/json_importer.py
+++ b/evap/cms/json_importer.py
@@ -642,8 +642,10 @@ class JSONImporter:
         contribution, created = Contribution.objects.update_or_create(
             evaluation=evaluation,
             contributor=user_profile,
-            role=Contribution.Role.EDITOR,
-            textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
+            create_defaults={
+                "role": Contribution.Role.EDITOR,
+                "textanswer_visibility": Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
+            },
         )
         return contribution, created
 

--- a/evap/cms/tests/test_json_importer.py
+++ b/evap/cms/tests/test_json_importer.py
@@ -430,6 +430,28 @@ class TestImportEvents(TestCase):
         # Overall, 3 log entries should exist: Create Evaluation, Create General Contribution, Create Contribution of 3@example.com
         self.assertEqual(main_evaluation.related_logentries().count(), 3)
 
+    def test_import_contributor_contribution_update(self) -> None:
+        """Regression test for #2728"""
+
+        contributions = Contribution.objects.exclude(contributor=None)
+
+        self._import()
+        self.assertFalse(
+            contributions.exclude(
+                role=Contribution.Role.EDITOR,
+                textanswer_visibility=Contribution.TextAnswerVisibility.GENERAL_TEXTANSWERS,
+            ).exists(),
+            msg="assumed default values from import",
+        )
+
+        contributions.update(role=Contribution.Role.CONTRIBUTOR)
+        self._import(assert_nop=True)
+        contributions.update(
+            role=Contribution.Role.EDITOR,  # back to default
+            textanswer_visibility=Contribution.TextAnswerVisibility.OWN_TEXTANSWERS,
+        )
+        self._import(assert_nop=True)
+
     def test_import_courses_exam_without_related_evaluation(self):
         CourseType.objects.create(name_en="Foo", name_de="Foo", import_names=["nat"])
         course_type = CourseType.objects.create(name_en="Bar", name_de="Bar", import_names=["Bachelorprojekt"])


### PR DESCRIPTION
Fixes #2728

This is a pretty obvious mistake, but it slipped through in two PRs. I wonder how hard it would be to write a lint for this, maybe with pylint_django. I don't see how `update_or_create(**kwargs)` where `kwargs` is a strict superset of a key can ever be correct. For our codebase, this lint should also cover `update_or_create_with_changes`.
