### PR TITLE
Use template tag for breadcrumb items

### DIFF
--- a/evap/cms/templates/cms_evaluation_merge_selection.html
+++ b/evap/cms/templates/cms_evaluation_merge_selection.html
@@ -10,7 +10,7 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item %}
-    {% translate 'Merge evaluations' %}
+        {% translate 'Merge evaluations' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/cms/templates/cms_evaluation_merge_selection.html
+++ b/evap/cms/templates/cms_evaluation_merge_selection.html
@@ -1,5 +1,7 @@
 {% extends 'staff_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block title %}
     {% translate 'Merge evaluations' %}
     {{ block.super }}
@@ -7,7 +9,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Merge evaluations' %}</li>
+    {% breadcrumb_item %} 
+        {% translate 'Merge evaluations' %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -1,14 +1,19 @@
 {% extends 'base.html' %}
 
 {% load evaluation_filters %}
+{% load staff_templatetags %}
 
 {% block title %}{% translate 'Your EvaP' %} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb_bar %}
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
-            <li class="breadcrumb-item">{{ evaluation.course.semester.name }}</li>
-            <li class="breadcrumb-item">{{ evaluation.full_name }}</li>
+                {% breadcrumb_item %} 
+                    {{ evaluation.course.semester.name }}
+                {% endbreadcrumb_item %}
+                {% breadcrumb_item %} 
+                    {{ evaluation.full_name }}
+                {% endbreadcrumb_item %}
         </ul>
     </div>
 {% endblock %}

--- a/evap/contributor/templates/contributor_evaluation_form.html
+++ b/evap/contributor/templates/contributor_evaluation_form.html
@@ -9,10 +9,10 @@
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
             {% breadcrumb_item %}
-            {{ evaluation.course.semester.name }}
+                {{ evaluation.course.semester.name }}
             {% endbreadcrumb_item %}
             {% breadcrumb_item %}
-            {{ evaluation.full_name }}
+                {{ evaluation.full_name }}
             {% endbreadcrumb_item %}
         </ul>
     </div>

--- a/evap/development/templates/development_components.html
+++ b/evap/development/templates/development_components.html
@@ -9,7 +9,7 @@
         <ul class="breadcrumb">
             {% block breadcrumb %}
                 {% breadcrumb_item %}
-                {% translate 'Development' %}
+                    {% translate 'Development' %}
                 {% endbreadcrumb_item %}
             {% endblock %}
         </ul>

--- a/evap/development/templates/development_components.html
+++ b/evap/development/templates/development_components.html
@@ -1,12 +1,16 @@
 {% extends 'base.html' %}
 
+{% load staff_templatetags %}
+
 {% block title %}{% translate 'Development' %} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb_bar %}
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
             {% block breadcrumb %}
-                <li class="breadcrumb-item">{% translate 'Development' %}</li>
+                {% breadcrumb_item %} 
+                    {% translate 'Development' %}
+                {% endbreadcrumb_item %}
             {% endblock %}
         </ul>
     </div>

--- a/evap/grades/templates/grades_base.html
+++ b/evap/grades/templates/grades_base.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load staff_templatetags %}
 
 {% block title %}{% translate 'Grade publishing' %} - {{ block.super }}{% endblock %}
 
@@ -6,10 +7,14 @@
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
             {% block breadcrumb %}
-                {% if disable_breadcrumb_grades or not user.is_grade_publisher %}
-                    <li class="breadcrumb-item">{% translate 'Grade publishing' %}</li>
+                {% if not user.is_grade_publisher %}
+                    {% breadcrumb_item %} 
+                        {% translate 'Grade publishing' %}
+                    {% endbreadcrumb_item %}
                 {% else %}
-                    <li class="breadcrumb-item"><a href="{% url 'grades:index' %}">{% translate 'Grade publishing' %}</a></li>
+                    {% breadcrumb_item_url 'grades:index' %} 
+                        {% translate 'Grade publishing' %}
+                    {% endbreadcrumb_item_url %}
                 {% endif %}
             {% endblock %}
         </ul>

--- a/evap/grades/templates/grades_base.html
+++ b/evap/grades/templates/grades_base.html
@@ -9,11 +9,11 @@
             {% block breadcrumb %}
                 {% if not user.is_grade_publisher %}
                     {% breadcrumb_item %}
-                    {% translate 'Grade publishing' %}
+                        {% translate 'Grade publishing' %}
                     {% endbreadcrumb_item %}
                 {% else %}
                     {% breadcrumb_item_url 'grades:index' %}
-                    {% translate 'Grade publishing' %}
+                        {% translate 'Grade publishing' %}
                     {% endbreadcrumb_item_url %}
                 {% endif %}
             {% endblock %}

--- a/evap/grades/templates/grades_course_base.html
+++ b/evap/grades/templates/grades_course_base.html
@@ -1,14 +1,13 @@
 {% extends 'grades_semester_base.html' %}
+{% load staff_templatetags %}
 
 {% block title %}{{ course.name }} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb %}
     {{ block.super }}
     {% if course %}
-        {% if disable_breadcrumb_course %}
-            <li class="breadcrumb-item">{{ course.name }}</li>
-        {% else %}
-            <li class="breadcrumb-item"><a href="{% url 'grades:course_view' course.id %}">{{ course.name }}</a></li>
-        {% endif %}
+        {% breadcrumb_item_url 'grades:course_view' course.id  %} 
+            {{ course.name }}
+        {% endbreadcrumb_item_url %}
     {% endif %}
 {% endblock %}

--- a/evap/grades/templates/grades_course_base.html
+++ b/evap/grades/templates/grades_course_base.html
@@ -7,7 +7,7 @@
     {{ block.super }}
     {% if course %}
         {% breadcrumb_item_url 'grades:course_view' course.id %}
-        {{ course.name }}
+            {{ course.name }}
         {% endbreadcrumb_item_url %}
     {% endif %}
 {% endblock %}

--- a/evap/grades/templates/grades_semester_base.html
+++ b/evap/grades/templates/grades_semester_base.html
@@ -10,11 +10,11 @@
     {% if semester %}
         {% if not user.is_grade_publisher %}
             {% breadcrumb_item %}
-            {{ semester.name }}
+                {{ semester.name }}
             {% endbreadcrumb_item %}
         {% else %}
             {% breadcrumb_item_url 'grades:semester_view' semester.id %}
-            {{ semester.name }}
+                {{ semester.name }}
             {% endbreadcrumb_item_url %}
         {% endif %}
     {% endif %}

--- a/evap/grades/templates/grades_semester_base.html
+++ b/evap/grades/templates/grades_semester_base.html
@@ -1,16 +1,21 @@
 {% extends 'grades_base.html' %}
 
 {% load evaluation_filters %}
+{% load staff_templatetags %}
 
 {% block title %}{{ semester.name }} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb %}
     {{ block.super }}
     {% if semester %}
-        {% if disable_breadcrumb_semester or not user.is_grade_publisher %}
-            <li class="breadcrumb-item">{{ semester.name }}</li>
+        {% if not user.is_grade_publisher %}
+            {% breadcrumb_item %} 
+                {{ semester.name }}
+            {% endbreadcrumb_item %}
         {% else %}
-            <li class="breadcrumb-item"><a href="{% url 'grades:semester_view' semester.id %}">{{ semester.name }}</a></li>
+            {% breadcrumb_item_url 'grades:semester_view' semester.id  %} 
+                {{ semester.name }}
+            {% endbreadcrumb_item_url %}
         {% endif %}
     {% endif %}
 {% endblock %}

--- a/evap/grades/templates/grades_upload_form.html
+++ b/evap/grades/templates/grades_upload_form.html
@@ -1,8 +1,12 @@
 {% extends 'grades_course_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate "Upload document" %}</li>
+    {% breadcrumb_item %} 
+        {% translate "Upload document" %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/grades/templates/grades_upload_form.html
+++ b/evap/grades/templates/grades_upload_form.html
@@ -5,7 +5,7 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item %}
-    {% translate "Upload document" %}
+        {% translate "Upload document" %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/grades/views.py
+++ b/evap/grades/views.py
@@ -28,8 +28,7 @@ class IndexView(TemplateView):
 
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         return super().get_context_data(**kwargs) | {
-            "semesters": Semester.objects.filter(grade_documents_are_deleted=False),
-            "disable_breadcrumb_grades": True,
+            "semesters": Semester.objects.filter(grade_documents_are_deleted=False)
         }
 
 
@@ -69,10 +68,7 @@ class SemesterView(DetailView):
         )
         courses = course_grade_document_count_tuples(query)
 
-        return super().get_context_data(**kwargs) | {
-            "courses": courses,
-            "disable_breadcrumb_semester": True,
-        }
+        return super().get_context_data(**kwargs) | {"courses": courses}
 
 
 @grade_publisher_or_manager_required
@@ -91,7 +87,6 @@ class CourseView(DetailView):
         return super().get_context_data(**kwargs) | {
             "semester": self.object.semester,
             "grade_documents": self.object.grade_documents.all(),
-            "disable_breadcrumb_course": True,
         }
 
 

--- a/evap/results/templates/results_evaluation_detail.html
+++ b/evap/results/templates/results_evaluation_detail.html
@@ -3,14 +3,19 @@
 {% load static %}
 {% load evaluation_filters %}
 {% load results_templatetags %}
+{% load staff_templatetags %}
 
 {% block title %}{{ evaluation.full_name }} - {{ evaluation.course.semester.name }} - {% translate 'Results' %} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb_bar %}
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
-            <li class="breadcrumb-item">{{ evaluation.course.semester.name }}</li>
-            <li class="breadcrumb-item">{{ evaluation.full_name }}</li>
+                {% breadcrumb_item %} 
+                    {{ evaluation.course.semester.name }}
+                {% endbreadcrumb_item %}
+                {% breadcrumb_item %} 
+                    {{ evaluation.full_name }}
+                {% endbreadcrumb_item %}
         </ul>
     </div>
 {% endblock %}

--- a/evap/results/templates/results_evaluation_detail.html
+++ b/evap/results/templates/results_evaluation_detail.html
@@ -12,10 +12,10 @@
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
             {% breadcrumb_item %}
-            {{ evaluation.course.semester.name }}
+                {{ evaluation.course.semester.name }}
             {% endbreadcrumb_item %}
             {% breadcrumb_item %}
-            {{ evaluation.full_name }}
+                {{ evaluation.full_name }}
             {% endbreadcrumb_item %}
         </ul>
     </div>

--- a/evap/rewards/templates/rewards_reward_point_redemption_event_form.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_event_form.html
@@ -5,10 +5,10 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'rewards:reward_point_redemption_events' %}
-    {% translate 'Reward Point Redemption Events' %}
+        {% translate 'Reward Point Redemption Events' %}
     {% endbreadcrumb_item_url %}
     {% breadcrumb_item %}
-    {% translate 'Edit event' %}
+        {% translate 'Edit event' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/rewards/templates/rewards_reward_point_redemption_event_form.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_event_form.html
@@ -1,9 +1,15 @@
 {% extends 'staff_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'rewards:reward_point_redemption_events' %}">{% translate 'Reward Point Redemption Events' %}</a></li>
-    <li class="breadcrumb-item">{% translate 'Edit event' %}</li>
+    {% breadcrumb_item_url 'rewards:reward_point_redemption_events' %} 
+        {% translate 'Reward Point Redemption Events' %}
+    {% endbreadcrumb_item_url %}
+    {% breadcrumb_item %} 
+        {% translate 'Edit event' %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/rewards/templates/rewards_reward_point_redemption_events.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_events.html
@@ -1,10 +1,13 @@
 {% extends 'staff_base.html' %}
 
 {% load static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Reward Point Redemption Events' %}</li>
+    {% breadcrumb_item %} 
+        {% translate 'Reward Point Redemption Events' %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/rewards/templates/rewards_reward_point_redemption_events.html
+++ b/evap/rewards/templates/rewards_reward_point_redemption_events.html
@@ -6,7 +6,7 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item %}
-    {% translate 'Reward Point Redemption Events' %}
+        {% translate 'Reward Point Redemption Events' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_base.html
+++ b/evap/staff/templates/staff_base.html
@@ -8,14 +8,14 @@
         <ul class="breadcrumb">
             {% block breadcrumb %}
                 {% if disable_breadcrumb_manager or not user.is_manager %}
-                    {% create_breadcrumb %} 
+                    {% breadcrumb_item %} 
                         {% translate 'Manage' %}
-                    {% endcreate_breadcrumb %}
+                    {% endbreadcrumb_item %}
                 {% else %}
                     {% url 'staff:index' as staff_index_url %}
-                    {% create_breadcrumb url=staff_index_url %} 
+                    {% breadcrumb_item staff_index_url %} 
                         {% translate 'Manage' %}
-                    {% endcreate_breadcrumb %}
+                    {% endbreadcrumb_item %}
                 {% endif %}
             {% endblock %}
         </ul>

--- a/evap/staff/templates/staff_base.html
+++ b/evap/staff/templates/staff_base.html
@@ -7,7 +7,7 @@
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
             {% block breadcrumb %}
-                {% if disable_breadcrumb_manager or not user.is_manager %}
+                {% if not user.is_manager %}
                     {% breadcrumb_item %} 
                         {% translate 'Manage' %}
                     {% endbreadcrumb_item %}

--- a/evap/staff/templates/staff_base.html
+++ b/evap/staff/templates/staff_base.html
@@ -9,11 +9,11 @@
             {% block breadcrumb %}
                 {% if not user.is_manager %}
                     {% breadcrumb_item %}
-                    {% translate 'Manage' %}
+                        {% translate 'Manage' %}
                     {% endbreadcrumb_item %}
                 {% else %}
                     {% breadcrumb_item_url 'staff:index' %}
-                    {% translate 'Manage' %}
+                        {% translate 'Manage' %}
                     {% endbreadcrumb_item_url %}
                 {% endif %}
             {% endblock %}

--- a/evap/staff/templates/staff_base.html
+++ b/evap/staff/templates/staff_base.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load staff_templatetags %}
 
 {% block title %}{% translate 'Manage' %} - {{ block.super }}{% endblock %}
 
@@ -7,9 +8,14 @@
         <ul class="breadcrumb">
             {% block breadcrumb %}
                 {% if disable_breadcrumb_manager or not user.is_manager %}
-                    <li class="breadcrumb-item">{% translate 'Manage' %}</li>
+                    {% create_breadcrumb %} 
+                        {% translate 'Manage' %}
+                    {% endcreate_breadcrumb %}
                 {% else %}
-                    <li class="breadcrumb-item"><a href="{% url 'staff:index' %}">{% translate 'Manage' %}</a></li>
+                    {% url 'staff:index' as staff_index_url %}
+                    {% create_breadcrumb url=staff_index_url %} 
+                        {% translate 'Manage' %}
+                    {% endcreate_breadcrumb %}
                 {% endif %}
             {% endblock %}
         </ul>

--- a/evap/staff/templates/staff_base.html
+++ b/evap/staff/templates/staff_base.html
@@ -12,10 +12,9 @@
                         {% translate 'Manage' %}
                     {% endbreadcrumb_item %}
                 {% else %}
-                    {% url 'staff:index' as staff_index_url %}
-                    {% breadcrumb_item staff_index_url %} 
+                    {% breadcrumb_item_url 'staff:index' %} 
                         {% translate 'Manage' %}
-                    {% endbreadcrumb_item %}
+                    {% endbreadcrumb_item_url %}
                 {% endif %}
             {% endblock %}
         </ul>

--- a/evap/staff/templates/staff_course_base.html
+++ b/evap/staff/templates/staff_course_base.html
@@ -12,17 +12,10 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-
     {% if course %}
-        {% if disable_breadcrumb_course %}
-            {% breadcrumb_item %} 
-                {{ course.name }}
-            {% endbreadcrumb_item %}
-        {% else %}
-            {% breadcrumb_item_url 'staff:course_edit' course.id %} 
-                {{ course.name }}
-            {% endbreadcrumb_item_url %}
-        {% endif %}
+        {% breadcrumb_item_url 'staff:course_edit' course.id %} 
+            {{ course.name }}
+        {% endbreadcrumb_item_url %}
     {% elif evaluation.course %}
         {% breadcrumb_item_url 'staff:course_edit' evaluation.course.id %} 
             {{ evaluation.course.name }}

--- a/evap/staff/templates/staff_course_base.html
+++ b/evap/staff/templates/staff_course_base.html
@@ -15,13 +15,13 @@
 
     {% if course %}
         {% url 'staff:course_edit' course.id as course_edit_url %}
-        {% create_breadcrumb course_edit_url %} 
+        {% breadcrumb_item course_edit_url %} 
             {{ course.name }}
-        {% endcreate_breadcrumb %}
+        {% endbreadcrumb_item %}
     {% elif evaluation.course %}
         {% url 'staff:course_edit' evaluation.course.id as course_edit_url %}
-        {% create_breadcrumb course_edit_url %} 
+        {% breadcrumb_item course_edit_url %} 
             {{ evaluation.course.name }}
-        {% endcreate_breadcrumb %}
+        {% endbreadcrumb_item %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_course_base.html
+++ b/evap/staff/templates/staff_course_base.html
@@ -1,4 +1,5 @@
 {% extends 'staff_semester_base.html' %}
+{% load staff_templatetags %}
 
 {% block title %}
     {% if course %}
@@ -11,13 +12,16 @@
 
 {% block breadcrumb %}
     {{ block.super }}
+
     {% if course %}
-        {% if disable_breadcrumb_course %}
-            <li class="breadcrumb-item">{{ course.name }}</li>
-        {% else %}
-            <li class="breadcrumb-item"><a href="{% url 'staff:course_edit' course.id %}">{{ course.name }}</a></li>
-        {% endif %}
+        {% url 'staff:course_edit' course.id as course_edit_url %}
+        {% create_breadcrumb course_edit_url %} 
+            {{ course.name }}
+        {% endcreate_breadcrumb %}
     {% elif evaluation.course %}
-        <li class="breadcrumb-item"><a href="{% url 'staff:course_edit' evaluation.course.id %}">{{ evaluation.course.name }}</a></li>
+        {% url 'staff:course_edit' evaluation.course.id as course_edit_url %}
+        {% create_breadcrumb course_edit_url %} 
+            {{ evaluation.course.name }}
+        {% endcreate_breadcrumb %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_course_base.html
+++ b/evap/staff/templates/staff_course_base.html
@@ -14,11 +14,11 @@
     {{ block.super }}
     {% if course %}
         {% breadcrumb_item_url 'staff:course_edit' course.id %}
-        {{ course.name }}
+            {{ course.name }}
         {% endbreadcrumb_item_url %}
     {% elif evaluation.course %}
         {% breadcrumb_item_url 'staff:course_edit' evaluation.course.id %}
-        {{ evaluation.course.name }}
+            {{ evaluation.course.name }}
         {% endbreadcrumb_item_url %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_course_base.html
+++ b/evap/staff/templates/staff_course_base.html
@@ -14,9 +14,15 @@
     {{ block.super }}
 
     {% if course %}
-        {% breadcrumb_item_url 'staff:course_edit' course.id %} 
-            {{ course.name }}
-        {% endbreadcrumb_item_url %}
+        {% if disable_breadcrumb_course %}
+            {% breadcrumb_item %} 
+                {{ course.name }}
+            {% endbreadcrumb_item %}
+        {% else %}
+            {% breadcrumb_item_url 'staff:course_edit' course.id %} 
+                {{ course.name }}
+            {% endbreadcrumb_item_url %}
+        {% endif %}
     {% elif evaluation.course %}
         {% breadcrumb_item_url 'staff:course_edit' evaluation.course.id %} 
             {{ evaluation.course.name }}

--- a/evap/staff/templates/staff_course_base.html
+++ b/evap/staff/templates/staff_course_base.html
@@ -14,14 +14,12 @@
     {{ block.super }}
 
     {% if course %}
-        {% url 'staff:course_edit' course.id as course_edit_url %}
-        {% breadcrumb_item course_edit_url %} 
+        {% breadcrumb_item_url 'staff:course_edit' course.id %} 
             {{ course.name }}
-        {% endbreadcrumb_item %}
+        {% endbreadcrumb_item_url %}
     {% elif evaluation.course %}
-        {% url 'staff:course_edit' evaluation.course.id as course_edit_url %}
-        {% breadcrumb_item course_edit_url %} 
+        {% breadcrumb_item_url 'staff:course_edit' evaluation.course.id %} 
             {{ evaluation.course.name }}
-        {% endbreadcrumb_item %}
+        {% endbreadcrumb_item_url %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_course_type_index.html
+++ b/evap/staff/templates/staff_course_type_index.html
@@ -1,10 +1,14 @@
 {% extends 'staff_base.html' %}
 
+{% load staff_templatetags %}
 {% load static %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Course types' %}</li>
+    {% url request.resolver_match.view_name as self_url %}
+    {% create_breadcrumb self_url %} 
+        {% translate 'Course types' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_course_type_index.html
+++ b/evap/staff/templates/staff_course_type_index.html
@@ -7,7 +7,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'Course types' %}
+        {% translate 'Course types' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_course_type_index.html
+++ b/evap/staff/templates/staff_course_type_index.html
@@ -5,10 +5,10 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url request.resolver_match.view_name as self_url %}
-    {% create_breadcrumb self_url %} 
+
+    {% breadcrumb_item %} 
         {% translate 'Course types' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_course_type_merge.html
+++ b/evap/staff/templates/staff_course_type_merge.html
@@ -6,11 +6,11 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'staff:course_type_index' %}
-    {% translate 'Course types' %}
+        {% translate 'Course types' %}
     {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item_url 'staff:course_type_merge_selection' %}
-    {% translate 'Merge course types' %}
+        {% translate 'Merge course types' %}
     {% endbreadcrumb_item_url %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_course_type_merge.html
+++ b/evap/staff/templates/staff_course_type_merge.html
@@ -1,11 +1,19 @@
 {% extends 'staff_base.html' %}
 
 {% load evaluation_filters %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:course_type_index' %}">{% translate 'Course types' %}</a></li>
-    <li class="breadcrumb-item">{% translate 'Merge course types' %}</li>
+    {% url 'staff:course_type_index' as course_type_index_url %}
+    {% create_breadcrumb course_type_index_url %} 
+        {% translate 'Course types' %}
+    {% endcreate_breadcrumb %}
+
+    {% url 'staff:course_type_merge_selection' as course_type_merge_url %}
+    {% create_breadcrumb course_type_merge_url %} 
+        {% translate 'Merge course types' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_course_type_merge.html
+++ b/evap/staff/templates/staff_course_type_merge.html
@@ -6,14 +6,14 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% url 'staff:course_type_index' as course_type_index_url %}
-    {% create_breadcrumb course_type_index_url %} 
+    {% breadcrumb_item course_type_index_url %} 
         {% translate 'Course types' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 
     {% url 'staff:course_type_merge_selection' as course_type_merge_url %}
-    {% create_breadcrumb course_type_merge_url %} 
+    {% breadcrumb_item course_type_merge_url %} 
         {% translate 'Merge course types' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_course_type_merge.html
+++ b/evap/staff/templates/staff_course_type_merge.html
@@ -5,7 +5,7 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% breadcrumb_item _url'staff:course_type_index' %} 
+    {% breadcrumb_item_url 'staff:course_type_index' %} 
         {% translate 'Course types' %}
     {% endbreadcrumb_item_url %}
 

--- a/evap/staff/templates/staff_course_type_merge.html
+++ b/evap/staff/templates/staff_course_type_merge.html
@@ -5,15 +5,13 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url 'staff:course_type_index' as course_type_index_url %}
-    {% breadcrumb_item course_type_index_url %} 
+    {% breadcrumb_item _url'staff:course_type_index' %} 
         {% translate 'Course types' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
 
-    {% url 'staff:course_type_merge_selection' as course_type_merge_url %}
-    {% breadcrumb_item course_type_merge_url %} 
+    {% breadcrumb_item_url 'staff:course_type_merge_selection' %} 
         {% translate 'Merge course types' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_course_type_merge_selection.html
+++ b/evap/staff/templates/staff_course_type_merge_selection.html
@@ -5,11 +5,11 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'staff:course_type_index' %}
-    {% translate 'Course types' %}
+        {% translate 'Course types' %}
     {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item %}
-    {% translate 'Merge course types' %}
+        {% translate 'Merge course types' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_course_type_merge_selection.html
+++ b/evap/staff/templates/staff_course_type_merge_selection.html
@@ -4,10 +4,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url 'staff:course_type_index' as course_type_index_url %}
-    {% breadcrumb_item course_type_index_url %} 
+    {% breadcrumb_item_url 'staff:course_type_index' %} 
         {% translate 'Course types' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item %} 
         {% translate 'Merge course types' %}

--- a/evap/staff/templates/staff_course_type_merge_selection.html
+++ b/evap/staff/templates/staff_course_type_merge_selection.html
@@ -5,14 +5,13 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% url 'staff:course_type_index' as course_type_index_url %}
-    {% create_breadcrumb course_type_index_url %} 
+    {% breadcrumb_item course_type_index_url %} 
         {% translate 'Course types' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 
-    {% url request.resolver_match.view_name as self_url %}
-    {% create_breadcrumb self_url %} 
+    {% breadcrumb_item %} 
         {% translate 'Merge course types' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
     
 {% endblock %}
 

--- a/evap/staff/templates/staff_course_type_merge_selection.html
+++ b/evap/staff/templates/staff_course_type_merge_selection.html
@@ -1,9 +1,19 @@
 {% extends 'staff_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:course_type_index' %}">{% translate 'Course types' %}</a></li>
-    <li class="breadcrumb-item">{% translate 'Merge course types' %}</li>
+    {% url 'staff:course_type_index' as course_type_index_url %}
+    {% create_breadcrumb course_type_index_url %} 
+        {% translate 'Course types' %}
+    {% endcreate_breadcrumb %}
+
+    {% url request.resolver_match.view_name as self_url %}
+    {% create_breadcrumb self_url %} 
+        {% translate 'Merge course types' %}
+    {% endcreate_breadcrumb %}
+    
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_evaluation_base.html
+++ b/evap/staff/templates/staff_evaluation_base.html
@@ -13,11 +13,11 @@
     {% if evaluation %}
         {% if evaluation.name %}
             {% breadcrumb_item_url 'staff:evaluation_edit' evaluation.id %}
-            {{ evaluation.name }}
+                {{ evaluation.name }}
             {% endbreadcrumb_item_url %}
         {% else %}
             {% breadcrumb_item_url 'staff:evaluation_edit' evaluation.id %}
-            {{ evaluation.course.name }}
+                {{ evaluation.course.name }}
             {% endbreadcrumb_item_url %}
         {% endif %}
     {% endif %}

--- a/evap/staff/templates/staff_evaluation_base.html
+++ b/evap/staff/templates/staff_evaluation_base.html
@@ -1,5 +1,6 @@
 {% extends 'staff_course_base.html' %}
 
+{% load staff_templatetags %}
 {% block title %}
     {% if evaluation.name %}
         {{ evaluation.name }} -
@@ -11,9 +12,15 @@
     {{ block.super }}
     {% if evaluation %}
     	{% if evaluation.name %}
-        	<li class="breadcrumb-item">{{ evaluation.name }}</li>
+            {% url 'staff:evaluation_edit' evaluation.id as eval_edit_id %}
+            {% create_breadcrumb eval_edit_id %} 
+                {{ evaluation.name }}
+            {% endcreate_breadcrumb %}
     	{% else %}
-    		<li class="breadcrumb-item">{{ evaluation.course.name }}</li>
+            {% url 'staff:evaluation_edit' evaluation.id as eval_edit_id %}
+            {% create_breadcrumb eval_edit_id %} 
+                {{ evaluation.course.name }}
+            {% endcreate_breadcrumb %}
     	{% endif %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_evaluation_base.html
+++ b/evap/staff/templates/staff_evaluation_base.html
@@ -13,14 +13,14 @@
     {% if evaluation %}
     	{% if evaluation.name %}
             {% url 'staff:evaluation_edit' evaluation.id as eval_edit_id %}
-            {% create_breadcrumb eval_edit_id %} 
+            {% breadcrumb_item eval_edit_id %} 
                 {{ evaluation.name }}
-            {% endcreate_breadcrumb %}
+            {% endbreadcrumb_item %}
     	{% else %}
             {% url 'staff:evaluation_edit' evaluation.id as eval_edit_id %}
-            {% create_breadcrumb eval_edit_id %} 
+            {% breadcrumb_item eval_edit_id %} 
                 {{ evaluation.course.name }}
-            {% endcreate_breadcrumb %}
+            {% endbreadcrumb_item %}
     	{% endif %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_evaluation_base.html
+++ b/evap/staff/templates/staff_evaluation_base.html
@@ -12,15 +12,13 @@
     {{ block.super }}
     {% if evaluation %}
     	{% if evaluation.name %}
-            {% url 'staff:evaluation_edit' evaluation.id as eval_edit_id %}
-            {% breadcrumb_item eval_edit_id %} 
+            {% breadcrumb_item_url 'staff:evaluation_edit' evaluation.id %} 
                 {{ evaluation.name }}
-            {% endbreadcrumb_item %}
+            {% endbreadcrumb_item_url %}
     	{% else %}
-            {% url 'staff:evaluation_edit' evaluation.id as eval_edit_id %}
-            {% breadcrumb_item eval_edit_id %} 
+            {% breadcrumb_item_url 'staff:evaluation_edit' evaluation.id %} 
                 {{ evaluation.course.name }}
-            {% endbreadcrumb_item %}
+            {% endbreadcrumb_item_url %}
     	{% endif %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_evaluation_textanswer_edit.html
+++ b/evap/staff/templates/staff_evaluation_textanswer_edit.html
@@ -5,11 +5,11 @@
     {{ block.super }}
 
     {% breadcrumb_item_url 'staff:evaluation_textanswers' evaluation.id fragment=textanswer.id|stringformat:"s" %}
-    {% translate 'Text answers' %}
+        {% translate 'Text answers' %}
     {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item %}
-    {{ textanswer.id }}
+        {{ textanswer.id }}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_evaluation_textanswer_edit.html
+++ b/evap/staff/templates/staff_evaluation_textanswer_edit.html
@@ -4,8 +4,7 @@
 {% block breadcrumb %}
     {{ block.super }}
     
-    {% url 'staff:evaluation_textanswers' evaluation.id as staff_evaluation_textanswer_url %}
-    {% breadcrumb_item staff_evaluation_textanswer_url %}
+    {% breadcrumb_item_url 'staff:evaluation_textanswers' evaluation.id %}
         {% translate 'Text answers' %}
     {% endbreadcrumb_item %}
 

--- a/evap/staff/templates/staff_evaluation_textanswer_edit.html
+++ b/evap/staff/templates/staff_evaluation_textanswer_edit.html
@@ -5,13 +5,13 @@
     {{ block.super }}
     
     {% url 'staff:evaluation_textanswers' evaluation.id as staff_evaluation_textanswer_url %}
-    {% create_breadcrumb staff_evaluation_textanswer_url %}
+    {% breadcrumb_item staff_evaluation_textanswer_url %}
         {% translate 'Text answers' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 
-    {% create_breadcrumb request.path %} 
+    {% breadcrumb_item %} 
         {{ textanswer.id }}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_evaluation_textanswer_edit.html
+++ b/evap/staff/templates/staff_evaluation_textanswer_edit.html
@@ -6,7 +6,7 @@
     
     {% breadcrumb_item_url 'staff:evaluation_textanswers' evaluation.id %}
         {% translate 'Text answers' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item %} 
         {{ textanswer.id }}

--- a/evap/staff/templates/staff_evaluation_textanswer_edit.html
+++ b/evap/staff/templates/staff_evaluation_textanswer_edit.html
@@ -1,9 +1,17 @@
 {% extends 'staff_evaluation_base.html' %}
 
+{% load staff_templatetags %}
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:evaluation_textanswers' evaluation.id %}#{{ textanswer.id }}">{% translate 'Text answers' %}</a></li>
-    <li class="breadcrumb-item">{{ textanswer.id }}</li>
+    
+    {% url 'staff:evaluation_textanswers' evaluation.id as staff_evaluation_textanswer_url %}
+    {% create_breadcrumb staff_evaluation_textanswer_url %}
+        {% translate 'Text answers' %}
+    {% endcreate_breadcrumb %}
+
+    {% create_breadcrumb request.path %} 
+        {{ textanswer.id }}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_evaluation_textanswer_edit.html
+++ b/evap/staff/templates/staff_evaluation_textanswer_edit.html
@@ -4,9 +4,11 @@
 {% block breadcrumb %}
     {{ block.super }}
 
-    {% breadcrumb_item_url 'staff:evaluation_textanswers' evaluation.id fragment=textanswer.id|stringformat:"s" %}
-        {% translate 'Text answers' %}
-    {% endbreadcrumb_item_url %}
+    {% with fragment_id=textanswer.id|stringformat:"s" %}
+        {% breadcrumb_item_url 'staff:evaluation_textanswers' evaluation.id fragment="textanswer-"|add:fragment_id %}
+            {% translate 'Text answers' %}
+        {% endbreadcrumb_item_url %}
+    {% endwith %}
 
     {% breadcrumb_item %}
         {{ textanswer.id }}

--- a/evap/staff/templates/staff_evaluation_textanswers.html
+++ b/evap/staff/templates/staff_evaluation_textanswers.html
@@ -1,10 +1,14 @@
 {% extends 'staff_evaluation_base.html' %}
 
 {% load evaluation_filters %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Text answers' %}</li>
+    {% url request.resolver_match.view_name as self_url %}
+    {% create_breadcrumb self_url %} 
+        {% translate 'Text answers' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_evaluation_textanswers.html
+++ b/evap/staff/templates/staff_evaluation_textanswers.html
@@ -5,10 +5,10 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url request.resolver_match.view_name as self_url %}
-    {% create_breadcrumb self_url %} 
+    
+    {% breadcrumb_item %} 
         {% translate 'Text answers' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_evaluation_textanswers.html
+++ b/evap/staff/templates/staff_evaluation_textanswers.html
@@ -7,7 +7,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'Text answers' %}
+        {% translate 'Text answers' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_exam_type_index.html
+++ b/evap/staff/templates/staff_exam_type_index.html
@@ -1,10 +1,15 @@
 {% extends 'staff_base.html' %}
 
 {% load static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Exam types' %}</li>
+    
+    {% url request.resolver_match.view_name as self_url %}
+    {% create_breadcrumb self_url %} 
+        {% translate 'Exam types' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_exam_type_index.html
+++ b/evap/staff/templates/staff_exam_type_index.html
@@ -7,7 +7,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'Exam types' %}
+        {% translate 'Exam types' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_exam_type_index.html
+++ b/evap/staff/templates/staff_exam_type_index.html
@@ -6,10 +6,9 @@
 {% block breadcrumb %}
     {{ block.super }}
     
-    {% url request.resolver_match.view_name as self_url %}
-    {% create_breadcrumb self_url %} 
+    {% breadcrumb_item %} 
         {% translate 'Exam types' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_faq_index.html
+++ b/evap/staff/templates/staff_faq_index.html
@@ -1,10 +1,15 @@
 {% extends 'staff_base.html' %}
 
 {% load static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'FAQ Sections' %}</li>
+    
+    {% url request.resolver_match.view_name as self_url %}
+    {% create_breadcrumb self_url %} 
+        {% translate 'FAQ Sections' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_faq_index.html
+++ b/evap/staff/templates/staff_faq_index.html
@@ -7,7 +7,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'FAQ Sections' %}
+        {% translate 'FAQ Sections' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_faq_index.html
+++ b/evap/staff/templates/staff_faq_index.html
@@ -6,10 +6,9 @@
 {% block breadcrumb %}
     {{ block.super }}
     
-    {% url request.resolver_match.view_name as self_url %}
-    {% create_breadcrumb self_url %} 
+    {% breadcrumb_item %} 
         {% translate 'FAQ Sections' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_faq_section.html
+++ b/evap/staff/templates/staff_faq_section.html
@@ -1,11 +1,19 @@
 {% extends 'staff_base.html' %}
 
 {% load static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:faq_index' %}">{% translate 'FAQ Sections' %}</a></li>
-    <li class="breadcrumb-item">{{ section.title }}</li>
+    
+    {% url 'staff:faq_index' as staff_faq_url %}
+    {% create_breadcrumb staff_faq_url %} 
+        {% translate 'FAQ Sections' %}
+    {% endcreate_breadcrumb %}
+
+    {% create_breadcrumb %} 
+        {{ section.title }}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_faq_section.html
+++ b/evap/staff/templates/staff_faq_section.html
@@ -6,10 +6,9 @@
 {% block breadcrumb %}
     {{ block.super }}
     
-    {% url 'staff:faq_index' as staff_faq_url %}
-    {% breadcrumb_item staff_faq_url %} 
+    {% breadcrumb_item_url 'staff:faq_index' %} 
         {% translate 'FAQ Sections' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item %} 
         {{ section.title }}

--- a/evap/staff/templates/staff_faq_section.html
+++ b/evap/staff/templates/staff_faq_section.html
@@ -7,13 +7,13 @@
     {{ block.super }}
     
     {% url 'staff:faq_index' as staff_faq_url %}
-    {% create_breadcrumb staff_faq_url %} 
+    {% breadcrumb_item staff_faq_url %} 
         {% translate 'FAQ Sections' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 
-    {% create_breadcrumb %} 
+    {% breadcrumb_item %} 
         {{ section.title }}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_faq_section.html
+++ b/evap/staff/templates/staff_faq_section.html
@@ -7,11 +7,11 @@
     {{ block.super }}
 
     {% breadcrumb_item_url 'staff:faq_index' %}
-    {% translate 'FAQ Sections' %}
+        {% translate 'FAQ Sections' %}
     {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item %}
-    {{ section.title }}
+        {{ section.title }}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_infotexts.html
+++ b/evap/staff/templates/staff_infotexts.html
@@ -1,8 +1,14 @@
 {% extends 'staff_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Infotexts' %}</li>
+    
+    {% url request.resolver_match.view_name as self_url %}
+    {% create_breadcrumb self_url %} 
+        {% translate 'Infotexts' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_infotexts.html
+++ b/evap/staff/templates/staff_infotexts.html
@@ -6,7 +6,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'Infotexts' %}
+        {% translate 'Infotexts' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_infotexts.html
+++ b/evap/staff/templates/staff_infotexts.html
@@ -5,10 +5,9 @@
 {% block breadcrumb %}
     {{ block.super }}
     
-    {% url request.resolver_match.view_name as self_url %}
-    {% create_breadcrumb self_url %} 
+    {% breadcrumb_item %} 
         {% translate 'Infotexts' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_program_index.html
+++ b/evap/staff/templates/staff_program_index.html
@@ -5,11 +5,10 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-
-    {% url request.resolver_match.view_name as self_url %}
-    {% create_breadcrumb self_url %} 
+    
+    {% breadcrumb_item %} 
         {% translate 'Programs' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_program_index.html
+++ b/evap/staff/templates/staff_program_index.html
@@ -1,10 +1,15 @@
 {% extends 'staff_base.html' %}
 
 {% load static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Programs' %}</li>
+
+    {% url request.resolver_match.view_name as self_url %}
+    {% create_breadcrumb self_url %} 
+        {% translate 'Programs' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_program_index.html
+++ b/evap/staff/templates/staff_program_index.html
@@ -7,7 +7,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'Programs' %}
+        {% translate 'Programs' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_program_merge.html
+++ b/evap/staff/templates/staff_program_merge.html
@@ -1,11 +1,19 @@
 {% extends 'staff_base.html' %}
 
 {% load evaluation_filters %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:program_index' %}">{% translate 'Programs' %}</a></li>
-    <li class="breadcrumb-item">{% translate 'Merge programs' %}</li>
+    
+    {% url 'staff:program_index' as programm_index_url %}
+    {% create_breadcrumb programm_index_url %} 
+        {% translate 'Programs' %}
+    {% endcreate_breadcrumb %}
+
+    {% create_breadcrumb %} 
+        {% translate 'Merge programs' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_program_merge.html
+++ b/evap/staff/templates/staff_program_merge.html
@@ -7,13 +7,13 @@
     {{ block.super }}
     
     {% url 'staff:program_index' as programm_index_url %}
-    {% create_breadcrumb programm_index_url %} 
+    {% breadcrumb_item programm_index_url %} 
         {% translate 'Programs' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 
-    {% create_breadcrumb %} 
+    {% breadcrumb_item %} 
         {% translate 'Merge programs' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_program_merge.html
+++ b/evap/staff/templates/staff_program_merge.html
@@ -7,11 +7,11 @@
     {{ block.super }}
 
     {% breadcrumb_item_url 'staff:program_index' %}
-    {% translate 'Programs' %}
+        {% translate 'Programs' %}
     {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item %}
-    {% translate 'Merge programs' %}
+        {% translate 'Merge programs' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_program_merge.html
+++ b/evap/staff/templates/staff_program_merge.html
@@ -6,10 +6,9 @@
 {% block breadcrumb %}
     {{ block.super }}
     
-    {% url 'staff:program_index' as programm_index_url %}
-    {% breadcrumb_item programm_index_url %} 
+    {% breadcrumb_item_url 'staff:program_index' %} 
         {% translate 'Programs' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item %} 
         {% translate 'Merge programs' %}

--- a/evap/staff/templates/staff_program_merge.html
+++ b/evap/staff/templates/staff_program_merge.html
@@ -10,9 +10,9 @@
         {% translate 'Programs' %}
     {% endbreadcrumb_item_url %}
 
-    {% breadcrumb_item %}
+    {% breadcrumb_item_url 'staff:program_merge_selection' %}
         {% translate 'Merge programs' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_program_merge_selection.html
+++ b/evap/staff/templates/staff_program_merge_selection.html
@@ -6,13 +6,13 @@
     {{ block.super }}
 
     {% url 'staff:program_index' as programm_index_url %}
-    {% create_breadcrumb programm_index_url %} 
+    {% breadcrumb_item programm_index_url %} 
         {% translate 'Programs' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 
-    {% create_breadcrumb request.path %} 
+    {% breadcrumb_item %} 
         {% translate 'Merge programs' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_program_merge_selection.html
+++ b/evap/staff/templates/staff_program_merge_selection.html
@@ -6,11 +6,11 @@
     {{ block.super }}
 
     {% breadcrumb_item_url 'staff:program_index' %}
-    {% translate 'Programs' %}
+        {% translate 'Programs' %}
     {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item %}
-    {% translate 'Merge programs' %}
+        {% translate 'Merge programs' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_program_merge_selection.html
+++ b/evap/staff/templates/staff_program_merge_selection.html
@@ -1,9 +1,18 @@
 {% extends 'staff_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:program_index' %}">{% translate 'Programs' %}</a></li>
-    <li class="breadcrumb-item">{% translate 'Merge programs' %}</li>
+
+    {% url 'staff:program_index' as programm_index_url %}
+    {% create_breadcrumb programm_index_url %} 
+        {% translate 'Programs' %}
+    {% endcreate_breadcrumb %}
+
+    {% create_breadcrumb request.path %} 
+        {% translate 'Merge programs' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_program_merge_selection.html
+++ b/evap/staff/templates/staff_program_merge_selection.html
@@ -5,10 +5,9 @@
 {% block breadcrumb %}
     {{ block.super }}
 
-    {% url 'staff:program_index' as programm_index_url %}
-    {% breadcrumb_item programm_index_url %} 
+    {% breadcrumb_item_url 'staff:program_index' %} 
         {% translate 'Programs' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
 
     {% breadcrumb_item %} 
         {% translate 'Merge programs' %}

--- a/evap/staff/templates/staff_questionnaire_base.html
+++ b/evap/staff/templates/staff_questionnaire_base.html
@@ -1,16 +1,30 @@
 {% extends 'staff_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
     {% if questionnaire %}
-        <li class="breadcrumb-item"><a href="{% url 'staff:questionnaire_index' %}">{% translate 'Questionnaires' %}</a></li>
+        {% url 'staff:questionnaire_index' as question_index_url %}
+        {% create_breadcrumb question_index_url %} 
+            {% translate 'Questionnaires' %}
+        {% endcreate_breadcrumb %}
+
         {% if disable_breadcrumb_questionnaire %}
-            <li class="breadcrumb-item">{{ questionnaire.name }}</li>
+            {% create_breadcrumb %} 
+                {{ questionnaire.name }}
+            {% endcreate_breadcrumb %}
         {% else %}
-            <li class="breadcrumb-item"><a href="{% url 'staff:questionnaire_edit' questionnaire.id %}">{{ questionnaire.name }}</a></li>
+        
+            {% url 'staff:questionnaire_edit' questionnaire.id as question_edit_url %}
+            {% create_breadcrumb question_edit_url %} 
+                {{ questionnaire.name }}
+            {% endcreate_breadcrumb %}
         {% endif %}
     {% else %}
-        <li class="breadcrumb-item">{% translate 'Questionnaires' %}</li>
+        {% create_breadcrumb %} 
+            {% translate 'Questionnaires' %}
+        {% endcreate_breadcrumb %}
     {% endif %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_questionnaire_base.html
+++ b/evap/staff/templates/staff_questionnaire_base.html
@@ -6,25 +6,25 @@
     {{ block.super }}
     {% if questionnaire %}
         {% url 'staff:questionnaire_index' as question_index_url %}
-        {% create_breadcrumb question_index_url %} 
+        {% breadcrumb_item question_index_url %} 
             {% translate 'Questionnaires' %}
-        {% endcreate_breadcrumb %}
+        {% endbreadcrumb_item %}
 
         {% if disable_breadcrumb_questionnaire %}
-            {% create_breadcrumb %} 
+            {% breadcrumb_item %} 
                 {{ questionnaire.name }}
-            {% endcreate_breadcrumb %}
+            {% endbreadcrumb_item %}
         {% else %}
         
             {% url 'staff:questionnaire_edit' questionnaire.id as question_edit_url %}
-            {% create_breadcrumb question_edit_url %} 
+            {% breadcrumb_item question_edit_url %} 
                 {{ questionnaire.name }}
-            {% endcreate_breadcrumb %}
+            {% endbreadcrumb_item %}
         {% endif %}
     {% else %}
-        {% create_breadcrumb %} 
+        {% breadcrumb_item %} 
             {% translate 'Questionnaires' %}
-        {% endcreate_breadcrumb %}
+        {% endbreadcrumb_item %}
     {% endif %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_questionnaire_base.html
+++ b/evap/staff/templates/staff_questionnaire_base.html
@@ -8,16 +8,9 @@
         {% breadcrumb_item_url 'staff:questionnaire_index' %} 
             {% translate 'Questionnaires' %}
         {% endbreadcrumb_item_url %}
-
-        {% if disable_breadcrumb_questionnaire %}
-            {% breadcrumb_item %} 
-                {{ questionnaire.name }}
-            {% endbreadcrumb_item %}
-        {% else %}
-            {% breadcrumb_item_url 'staff:questionnaire_edit' questionnaire.id %} 
-                {{ questionnaire.name }}
-            {% endbreadcrumb_item_url %}
-        {% endif %}
+        {% breadcrumb_item_url 'staff:questionnaire_edit' questionnaire.id %} 
+            {{ questionnaire.name }}
+        {% endbreadcrumb_item_url %}
     {% else %}
         {% breadcrumb_item %} 
             {% translate 'Questionnaires' %}

--- a/evap/staff/templates/staff_questionnaire_base.html
+++ b/evap/staff/templates/staff_questionnaire_base.html
@@ -4,17 +4,13 @@
 
 {% block breadcrumb %}
     {{ block.super }}
+    {% breadcrumb_item_url 'staff:questionnaire_index' %}
+        {% translate 'Questionnaires' %}
+    {% endbreadcrumb_item_url %}
     {% if questionnaire %}
-        {% breadcrumb_item_url 'staff:questionnaire_index' %}
-            {% translate 'Questionnaires' %}
-        {% endbreadcrumb_item_url %}
         {% breadcrumb_item_url 'staff:questionnaire_edit' questionnaire.id %}
             {{ questionnaire.name }}
         {% endbreadcrumb_item_url %}
-    {% else %}
-        {% breadcrumb_item %}
-            {% translate 'Questionnaires' %}
-        {% endbreadcrumb_item %}
     {% endif %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_questionnaire_base.html
+++ b/evap/staff/templates/staff_questionnaire_base.html
@@ -5,21 +5,18 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% if questionnaire %}
-        {% url 'staff:questionnaire_index' as question_index_url %}
-        {% breadcrumb_item question_index_url %} 
+        {% breadcrumb_item_url 'staff:questionnaire_index' %} 
             {% translate 'Questionnaires' %}
-        {% endbreadcrumb_item %}
+        {% endbreadcrumb_item_url %}
 
         {% if disable_breadcrumb_questionnaire %}
             {% breadcrumb_item %} 
                 {{ questionnaire.name }}
             {% endbreadcrumb_item %}
         {% else %}
-        
-            {% url 'staff:questionnaire_edit' questionnaire.id as question_edit_url %}
-            {% breadcrumb_item question_edit_url %} 
+            {% breadcrumb_item_url 'staff:questionnaire_edit' questionnaire.id %} 
                 {{ questionnaire.name }}
-            {% endbreadcrumb_item %}
+            {% endbreadcrumb_item_url %}
         {% endif %}
     {% else %}
         {% breadcrumb_item %} 

--- a/evap/staff/templates/staff_questionnaire_base.html
+++ b/evap/staff/templates/staff_questionnaire_base.html
@@ -6,14 +6,14 @@
     {{ block.super }}
     {% if questionnaire %}
         {% breadcrumb_item_url 'staff:questionnaire_index' %}
-        {% translate 'Questionnaires' %}
+            {% translate 'Questionnaires' %}
         {% endbreadcrumb_item_url %}
         {% breadcrumb_item_url 'staff:questionnaire_edit' questionnaire.id %}
-        {{ questionnaire.name }}
+            {{ questionnaire.name }}
         {% endbreadcrumb_item_url %}
     {% else %}
         {% breadcrumb_item %}
-        {% translate 'Questionnaires' %}
+            {% translate 'Questionnaires' %}
         {% endbreadcrumb_item %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_questionnaire_usage.html
+++ b/evap/staff/templates/staff_questionnaire_usage.html
@@ -5,9 +5,9 @@
 {% block breadcrumb %}
     {{ block.super }}
     
-    {% create_breadcrumb %} 
+    {% breadcrumb_item %} 
         {% translate 'Usage' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_questionnaire_usage.html
+++ b/evap/staff/templates/staff_questionnaire_usage.html
@@ -1,8 +1,13 @@
 {% extends 'staff_questionnaire_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Usage' %}</li>
+    
+    {% create_breadcrumb %} 
+        {% translate 'Usage' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_questionnaire_usage.html
+++ b/evap/staff/templates/staff_questionnaire_usage.html
@@ -6,7 +6,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'Usage' %}
+        {% translate 'Usage' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_questionnaire_view.html
+++ b/evap/staff/templates/staff_questionnaire_view.html
@@ -1,8 +1,12 @@
 {% extends 'staff_questionnaire_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Preview' %}</li>
+    {% create_breadcrumb %} 
+        {% translate 'Preview' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_questionnaire_view.html
+++ b/evap/staff/templates/staff_questionnaire_view.html
@@ -4,9 +4,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% create_breadcrumb %} 
+    {% breadcrumb_item %} 
         {% translate 'Preview' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_questionnaire_view.html
+++ b/evap/staff/templates/staff_questionnaire_view.html
@@ -5,7 +5,7 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item %}
-    {% translate 'Preview' %}
+        {% translate 'Preview' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_semester_base.html
+++ b/evap/staff/templates/staff_semester_base.html
@@ -12,8 +12,8 @@
     {{ block.super }}
     {% if semester %}
         {% url 'staff:semester_view' semester.id as semester_view_url %}
-        {% create_breadcrumb url=semester_view_url %} 
+        {% breadcrumb_item semester_view_url %} 
             {{ semester.name }}
-        {% endcreate_breadcrumb %}
+        {% endbreadcrumb_item %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_semester_base.html
+++ b/evap/staff/templates/staff_semester_base.html
@@ -12,7 +12,7 @@
     {{ block.super }}
     {% if semester %}
         {% breadcrumb_item_url 'staff:semester_view' semester.id %}
-        {{ semester.name }}
+            {{ semester.name }}
         {% endbreadcrumb_item_url %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_semester_base.html
+++ b/evap/staff/templates/staff_semester_base.html
@@ -11,9 +11,8 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% if semester %}
-        {% url 'staff:semester_view' semester.id as semester_view_url %}
-        {% breadcrumb_item semester_view_url %} 
+        {% breadcrumb_item_url 'staff:semester_view' semester.id %} 
             {{ semester.name }}
-        {% endbreadcrumb_item %}
+        {% endbreadcrumb_item_url %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_semester_base.html
+++ b/evap/staff/templates/staff_semester_base.html
@@ -1,4 +1,5 @@
 {% extends 'staff_base.html' %}
+{% load staff_templatetags %}
 
 {% block title %}
     {% if semester %}
@@ -9,12 +10,10 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Semesters' %}</li>
     {% if semester %}
-        {% if disable_breadcrumb_semester %}
-            <li class="breadcrumb-item">{{ semester.name }}</li>
-        {% else %}
-            <li class="breadcrumb-item"><a href="{% url 'staff:semester_view' semester.id %}">{{ semester.name }}</a></li>
-        {% endif %}
+        {% url 'staff:semester_view' semester.id as semester_view_url %}
+        {% create_breadcrumb url=semester_view_url %} 
+            {{ semester.name }}
+        {% endcreate_breadcrumb %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_semester_export.html
+++ b/evap/staff/templates/staff_semester_export.html
@@ -6,9 +6,9 @@
 {% block breadcrumb %}
     {{ block.super }}
     
-    {% create_breadcrumb request.path %} 
+    {% breadcrumb_item %} 
         {% translate 'Export' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_export.html
+++ b/evap/staff/templates/staff_semester_export.html
@@ -7,7 +7,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'Export' %}
+        {% translate 'Export' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_semester_export.html
+++ b/evap/staff/templates/staff_semester_export.html
@@ -1,10 +1,14 @@
 {% extends 'staff_semester_base.html' %}
 
 {% load evaluation_filters static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Export' %}</li>
+    
+    {% create_breadcrumb request.path %} 
+        {% translate 'Export' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_flagged_textanswers.html
+++ b/evap/staff/templates/staff_semester_flagged_textanswers.html
@@ -5,9 +5,9 @@
 {% block breadcrumb %}
     {{ block.super }}
     
-    {% create_breadcrumb request.path %} 
+    {% breadcrumb_item %} 
         {% translate 'Flagged textanswers' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_flagged_textanswers.html
+++ b/evap/staff/templates/staff_semester_flagged_textanswers.html
@@ -6,7 +6,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'Flagged textanswers' %}
+        {% translate 'Flagged textanswers' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_semester_flagged_textanswers.html
+++ b/evap/staff/templates/staff_semester_flagged_textanswers.html
@@ -1,8 +1,13 @@
 {% extends 'staff_semester_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Flagged textanswers' %}</li>
+    
+    {% create_breadcrumb request.path %} 
+        {% translate 'Flagged textanswers' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_grade_reminder.html
+++ b/evap/staff/templates/staff_semester_grade_reminder.html
@@ -5,10 +5,9 @@
 {% block breadcrumb %}
     {{ block.super }}
     
-    {% url request.resolver_match.view_name as self_url %}
-    {% create_breadcrumb self_url %} 
+    {% breadcrumb_item %} 
         {% translate 'Grade publish reminder' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_grade_reminder.html
+++ b/evap/staff/templates/staff_semester_grade_reminder.html
@@ -1,8 +1,14 @@
 {% extends 'staff_semester_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Grade publish reminder' %}</li>
+    
+    {% url request.resolver_match.view_name as self_url %}
+    {% create_breadcrumb self_url %} 
+        {% translate 'Grade publish reminder' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_grade_reminder.html
+++ b/evap/staff/templates/staff_semester_grade_reminder.html
@@ -6,7 +6,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'Grade publish reminder' %}
+        {% translate 'Grade publish reminder' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_semester_import.html
+++ b/evap/staff/templates/staff_semester_import.html
@@ -7,7 +7,7 @@
     {{ block.super }}
 
     {% breadcrumb_item %}
-    {% translate 'Import semester data' %}
+        {% translate 'Import semester data' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_semester_import.html
+++ b/evap/staff/templates/staff_semester_import.html
@@ -1,10 +1,15 @@
 {% extends 'staff_semester_base.html' %}
 
 {% load static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Import semester data' %}</li>
+
+    
+    {% create_breadcrumb request.path %} 
+        {% translate 'Import semester data' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_import.html
+++ b/evap/staff/templates/staff_semester_import.html
@@ -6,10 +6,9 @@
 {% block breadcrumb %}
     {{ block.super }}
 
-    
-    {% create_breadcrumb request.path %} 
+    {% breadcrumb_item %} 
         {% translate 'Import semester data' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_preparation_reminder.html
+++ b/evap/staff/templates/staff_semester_preparation_reminder.html
@@ -1,10 +1,13 @@
 {% extends 'staff_semester_base.html' %}
 
 {% load evaluation_filters %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Preparation reminder' %}</li>
+    {% create_breadcrumb request.path %} 
+        {% translate 'Preparation reminder' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_preparation_reminder.html
+++ b/evap/staff/templates/staff_semester_preparation_reminder.html
@@ -6,7 +6,7 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item %}
-    {% translate 'Preparation reminder' %}
+        {% translate 'Preparation reminder' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_semester_preparation_reminder.html
+++ b/evap/staff/templates/staff_semester_preparation_reminder.html
@@ -5,9 +5,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% create_breadcrumb request.path %} 
+    {% breadcrumb_item %} 
         {% translate 'Preparation reminder' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_questionnaire_assign_form.html
+++ b/evap/staff/templates/staff_semester_questionnaire_assign_form.html
@@ -1,8 +1,12 @@
 {% extends 'staff_semester_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Assign questionnaires' %}</li>
+    {% create_breadcrumb request.path %} 
+        {% translate 'Assign questionnaires' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_questionnaire_assign_form.html
+++ b/evap/staff/templates/staff_semester_questionnaire_assign_form.html
@@ -5,7 +5,7 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item %}
-    {% translate 'Assign questionnaires' %}
+        {% translate 'Assign questionnaires' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_semester_questionnaire_assign_form.html
+++ b/evap/staff/templates/staff_semester_questionnaire_assign_form.html
@@ -4,9 +4,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% create_breadcrumb request.path %} 
+    {% breadcrumb_item %} 
         {% translate 'Assign questionnaires' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_send_reminder.html
+++ b/evap/staff/templates/staff_semester_send_reminder.html
@@ -6,10 +6,10 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'staff:semester_preparation_reminder' semester.id %}
-    {% translate 'Preparation reminder' %}
+        {% translate 'Preparation reminder' %}
     {% endbreadcrumb_item_url %}
     {% breadcrumb_item %}
-    {{ responsible }}
+        {{ responsible }}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_semester_send_reminder.html
+++ b/evap/staff/templates/staff_semester_send_reminder.html
@@ -6,12 +6,12 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% url 'staff:semester_preparation_reminder' semester.id as prep_reminder_url %}
-    {% create_breadcrumb prep_reminder_url %} 
+    {% breadcrumb_item prep_reminder_url %} 
         {% translate 'Preparation reminder' %}
-    {% endcreate_breadcrumb %}
-    {% create_breadcrumb request.path %} 
+    {% endbreadcrumb_item %}
+    {% breadcrumb_item %} 
         {{ responsible }}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_semester_send_reminder.html
+++ b/evap/staff/templates/staff_semester_send_reminder.html
@@ -5,10 +5,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url 'staff:semester_preparation_reminder' semester.id as prep_reminder_url %}
-    {% breadcrumb_item prep_reminder_url %} 
+    {% breadcrumb_item_url 'staff:semester_preparation_reminder' semester.id %} 
         {% translate 'Preparation reminder' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
     {% breadcrumb_item %} 
         {{ responsible }}
     {% endbreadcrumb_item %}

--- a/evap/staff/templates/staff_semester_send_reminder.html
+++ b/evap/staff/templates/staff_semester_send_reminder.html
@@ -1,11 +1,17 @@
 {% extends 'staff_evaluation_base.html' %}
 
 {% load evaluation_filters %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:semester_preparation_reminder' semester.id %}">{% translate 'Preparation reminder' %}</a></li>
-    <li class="breadcrumb-item">{{ responsible }}</li>
+    {% url 'staff:semester_preparation_reminder' semester.id as prep_reminder_url %}
+    {% create_breadcrumb prep_reminder_url %} 
+        {% translate 'Preparation reminder' %}
+    {% endcreate_breadcrumb %}
+    {% create_breadcrumb request.path %} 
+        {{ responsible }}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_template_form.html
+++ b/evap/staff/templates/staff_template_form.html
@@ -6,10 +6,10 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item %}
-    {% translate 'Templates' %}
+        {% translate 'Templates' %}
     {% endbreadcrumb_item %}
     {% breadcrumb_item %}
-    {{ template.name }}
+        {{ template.name }}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_template_form.html
+++ b/evap/staff/templates/staff_template_form.html
@@ -1,11 +1,16 @@
 {% extends 'staff_base.html' %}
 
 {% load static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Templates' %}</li>
-    <li class="breadcrumb-item">{{ template.name }}</li>
+    {% create_breadcrumb %} 
+        {% translate 'Templates' %}
+    {% endcreate_breadcrumb %}
+    {% create_breadcrumb %} 
+        {{ template.name }}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_template_form.html
+++ b/evap/staff/templates/staff_template_form.html
@@ -5,12 +5,12 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% create_breadcrumb %} 
+    {% breadcrumb_item %} 
         {% translate 'Templates' %}
-    {% endcreate_breadcrumb %}
-    {% create_breadcrumb %} 
+    {% endbreadcrumb_item %}
+    {% breadcrumb_item %} 
         {{ template.name }}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_text_answer_warnings.html
+++ b/evap/staff/templates/staff_text_answer_warnings.html
@@ -7,7 +7,7 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item %}
-    {% translate 'Text answer warnings' %}
+        {% translate 'Text answer warnings' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_text_answer_warnings.html
+++ b/evap/staff/templates/staff_text_answer_warnings.html
@@ -2,10 +2,13 @@
 
 {% load static %}
 {% load student_filters %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Text answer warnings' %}</li>
+    {% create_breadcrumb %} 
+        {% translate 'Text answer warnings' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_text_answer_warnings.html
+++ b/evap/staff/templates/staff_text_answer_warnings.html
@@ -6,9 +6,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% create_breadcrumb %} 
+    {% breadcrumb_item %} 
         {% translate 'Text answer warnings' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_bulk_update.html
+++ b/evap/staff/templates/staff_user_bulk_update.html
@@ -1,9 +1,16 @@
 {% extends 'staff_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
-    <li class="breadcrumb-item">{% translate 'Bulk update' %}</li>
+    {% url 'staff:user_index' as user_index_url %}
+    {% create_breadcrumb user_index_url %} 
+        {% translate 'Users' %}
+    {% endcreate_breadcrumb %}
+    {% create_breadcrumb request.path %} 
+        {% translate 'Bulk update' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_bulk_update.html
+++ b/evap/staff/templates/staff_user_bulk_update.html
@@ -5,12 +5,12 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% url 'staff:user_index' as user_index_url %}
-    {% create_breadcrumb user_index_url %} 
+    {% breadcrumb_item user_index_url %} 
         {% translate 'Users' %}
-    {% endcreate_breadcrumb %}
-    {% create_breadcrumb request.path %} 
+    {% endbreadcrumb_item %}
+    {% breadcrumb_item %} 
         {% translate 'Bulk update' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_bulk_update.html
+++ b/evap/staff/templates/staff_user_bulk_update.html
@@ -5,10 +5,10 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'staff:user_index' %}
-    {% translate 'Users' %}
+        {% translate 'Users' %}
     {% endbreadcrumb_item_url %}
     {% breadcrumb_item %}
-    {% translate 'Bulk update' %}
+        {% translate 'Bulk update' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_user_bulk_update.html
+++ b/evap/staff/templates/staff_user_bulk_update.html
@@ -4,10 +4,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url 'staff:user_index' as user_index_url %}
-    {% breadcrumb_item user_index_url %} 
+    {% breadcrumb_item_url 'staff:user_index' %} 
         {% translate 'Users' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
     {% breadcrumb_item %} 
         {% translate 'Bulk update' %}
     {% endbreadcrumb_item %}

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -1,14 +1,22 @@
 {% extends 'staff_base.html' %}
 
 {% load evaluation_filters %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
+    {% url 'staff:user_index' as user_index_url %}
+    {% create_breadcrumb user_index_url %} 
+        {% translate 'Users' %}
+    {% endcreate_breadcrumb %}
     {% if form.instance.id %}
-        <li class="breadcrumb-item">{{ form.instance.full_name }}</li>
+        {% create_breadcrumb %} 
+            {{ form.instance.full_name }}
+        {% endcreate_breadcrumb %}
     {% else %}
-        <li class="breadcrumb-item">{% translate 'Create user' %}</li>
+        {% create_breadcrumb %} 
+            {% translate 'Create user' %}
+        {% endcreate_breadcrumb %}
     {% endif %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -6,15 +6,15 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'staff:user_index' %}
-    {% translate 'Users' %}
+        {% translate 'Users' %}
     {% endbreadcrumb_item_url %}
     {% if form.instance.id %}
         {% breadcrumb_item %}
-        {{ form.instance.full_name }}
+            {{ form.instance.full_name }}
         {% endbreadcrumb_item %}
     {% else %}
         {% breadcrumb_item %}
-        {% translate 'Create user' %}
+            {% translate 'Create user' %}
         {% endbreadcrumb_item %}
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -6,17 +6,17 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% url 'staff:user_index' as user_index_url %}
-    {% create_breadcrumb user_index_url %} 
+    {% breadcrumb_item user_index_url %} 
         {% translate 'Users' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
     {% if form.instance.id %}
-        {% create_breadcrumb %} 
+        {% breadcrumb_item %} 
             {{ form.instance.full_name }}
-        {% endcreate_breadcrumb %}
+        {% endbreadcrumb_item %}
     {% else %}
-        {% create_breadcrumb %} 
+        {% breadcrumb_item %} 
             {% translate 'Create user' %}
-        {% endcreate_breadcrumb %}
+        {% endbreadcrumb_item %}
     {% endif %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -5,10 +5,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url 'staff:user_index' as user_index_url %}
-    {% breadcrumb_item user_index_url %} 
+    {% breadcrumb_item_url 'staff:user_index' %} 
         {% translate 'Users' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
     {% if form.instance.id %}
         {% breadcrumb_item %} 
             {{ form.instance.full_name }}

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -8,15 +8,9 @@
     {% breadcrumb_item_url 'staff:user_index' %}
         {% translate 'Users' %}
     {% endbreadcrumb_item_url %}
-    {% if form.instance.id %}
-        {% breadcrumb_item %}
-            {{ form.instance.full_name }}
-        {% endbreadcrumb_item %}
-    {% else %}
-        {% breadcrumb_item %}
-            {% translate 'Create user' %}
-        {% endbreadcrumb_item %}
-    {% endif %}
+    {% breadcrumb_item %}
+        {% if form.instance.id %}{{ form.instance.full_name }}{% else %}{% translate 'Create user' %}{% endif %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -6,12 +6,12 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% url 'staff:user_index' as user_index_url %}
-    {% create_breadcrumb user_index_url %} 
+    {% breadcrumb_item user_index_url %} 
         {% translate 'Users' %}
-    {% endcreate_breadcrumb %}
-    {% create_breadcrumb %} 
+    {% endbreadcrumb_item %}
+    {% breadcrumb_item %} 
         {% translate 'Import users' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -1,11 +1,17 @@
 {% extends 'staff_base.html' %}
 
 {% load static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
-    <li class="breadcrumb-item">{% translate 'Import users' %}</li>
+    {% url 'staff:user_index' as user_index_url %}
+    {% create_breadcrumb user_index_url %} 
+        {% translate 'Users' %}
+    {% endcreate_breadcrumb %}
+    {% create_breadcrumb %} 
+        {% translate 'Import users' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -6,10 +6,10 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'staff:user_index' %}
-    {% translate 'Users' %}
+        {% translate 'Users' %}
     {% endbreadcrumb_item_url %}
     {% breadcrumb_item %}
-    {% translate 'Import users' %}
+        {% translate 'Import users' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_user_import.html
+++ b/evap/staff/templates/staff_user_import.html
@@ -5,10 +5,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url 'staff:user_index' as user_index_url %}
-    {% breadcrumb_item user_index_url %} 
+    {% breadcrumb_item_url 'staff:user_index' %} 
         {% translate 'Users' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
     {% breadcrumb_item %} 
         {% translate 'Import users' %}
     {% endbreadcrumb_item %}

--- a/evap/staff/templates/staff_user_index.html
+++ b/evap/staff/templates/staff_user_index.html
@@ -6,7 +6,7 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'staff:user_index' %}
-    {% translate 'Users' %}
+        {% translate 'Users' %}
     {% endbreadcrumb_item_url %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_user_index.html
+++ b/evap/staff/templates/staff_user_index.html
@@ -1,10 +1,14 @@
 {% extends 'staff_base.html' %}
 
 {% load static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item">{% translate 'Users' %}</li>
+    {% url 'staff:user_index' as user_index_url %}
+    {% create_breadcrumb user_index_url %} 
+        {% translate 'Users' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_index.html
+++ b/evap/staff/templates/staff_user_index.html
@@ -5,10 +5,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url 'staff:user_index' as user_index_url %}
-    {% breadcrumb_item user_index_url %} 
+    {% breadcrumb_item_url 'staff:user_index' %} 
         {% translate 'Users' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_index.html
+++ b/evap/staff/templates/staff_user_index.html
@@ -6,9 +6,9 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% url 'staff:user_index' as user_index_url %}
-    {% create_breadcrumb user_index_url %} 
+    {% breadcrumb_item user_index_url %} 
         {% translate 'Users' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_list.html
+++ b/evap/staff/templates/staff_user_list.html
@@ -6,12 +6,12 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% url 'staff:user_index' as user_index_url %}
-    {% create_breadcrumb user_index_url %} 
+    {% breadcrumb_item user_index_url %} 
         {% translate 'Users' %}
-    {% endcreate_breadcrumb %}
-    {% create_breadcrumb %} 
+    {% endbreadcrumb_item %}
+    {% breadcrumb_item %} 
         {% translate 'User list' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_list.html
+++ b/evap/staff/templates/staff_user_list.html
@@ -1,11 +1,17 @@
 {% extends 'staff_base.html' %}
 
 {% load static %}
+{% load staff_templatetags %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
-    <li class="breadcrumb-item">{% translate 'User list' %}</li>
+    {% url 'staff:user_index' as user_index_url %}
+    {% create_breadcrumb user_index_url %} 
+        {% translate 'Users' %}
+    {% endcreate_breadcrumb %}
+    {% create_breadcrumb %} 
+        {% translate 'User list' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_list.html
+++ b/evap/staff/templates/staff_user_list.html
@@ -5,10 +5,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url 'staff:user_index' as user_index_url %}
-    {% breadcrumb_item user_index_url %} 
+    {% breadcrumb_item_url 'staff:user_index' %} 
         {% translate 'Users' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
     {% breadcrumb_item %} 
         {% translate 'User list' %}
     {% endbreadcrumb_item %}

--- a/evap/staff/templates/staff_user_list.html
+++ b/evap/staff/templates/staff_user_list.html
@@ -6,10 +6,10 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'staff:user_index' %}
-    {% translate 'Users' %}
+        {% translate 'Users' %}
     {% endbreadcrumb_item_url %}
     {% breadcrumb_item %}
-    {% translate 'User list' %}
+        {% translate 'User list' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -1,11 +1,17 @@
 {% extends 'staff_base.html' %}
 
+{% load staff_templatetags %}
 {% load evaluation_filters %}
 
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
-    <li class="breadcrumb-item">{% translate 'Merge users' %}</li>
+    {% url 'staff:user_index' as user_index_url %}
+    {% create_breadcrumb user_index_url %} 
+        {% translate 'Users' %}
+    {% endcreate_breadcrumb %}
+    {% create_breadcrumb %} 
+        {% translate 'Merge users' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -6,10 +6,10 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'staff:user_index' %}
-    {% translate 'Users' %}
+        {% translate 'Users' %}
     {% endbreadcrumb_item_url %}
     {% breadcrumb_item %}
-    {% translate 'Merge users' %}
+        {% translate 'Merge users' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -5,10 +5,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url 'staff:user_index' as user_index_url %}
-    {% breadcrumb_item user_index_url %} 
+    {% breadcrumb_item_url 'staff:user_index' %} 
         {% translate 'Users' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
     {% breadcrumb_item %} 
         {% translate 'Merge users' %}
     {% endbreadcrumb_item %}

--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -6,12 +6,12 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% url 'staff:user_index' as user_index_url %}
-    {% create_breadcrumb user_index_url %} 
+    {% breadcrumb_item user_index_url %} 
         {% translate 'Users' %}
-    {% endcreate_breadcrumb %}
-    {% create_breadcrumb %} 
+    {% endbreadcrumb_item %}
+    {% breadcrumb_item %} 
         {% translate 'Merge users' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_merge.html
+++ b/evap/staff/templates/staff_user_merge.html
@@ -8,9 +8,9 @@
     {% breadcrumb_item_url 'staff:user_index' %}
         {% translate 'Users' %}
     {% endbreadcrumb_item_url %}
-    {% breadcrumb_item %}
+    {% breadcrumb_item_url 'staff:user_merge_selection' %}
         {% translate 'Merge users' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_merge_selection.html
+++ b/evap/staff/templates/staff_user_merge_selection.html
@@ -4,10 +4,9 @@
 
 {% block breadcrumb %}
     {{ block.super }}
-    {% url 'staff:user_index' as user_index_url %}
-    {% breadcrumb_item user_index_url %} 
+    {% breadcrumb_item_url 'staff:user_index' %} 
         {% translate 'Users' %}
-    {% endbreadcrumb_item %}
+    {% endbreadcrumb_item_url %}
     {% breadcrumb_item %} 
         {% translate 'Merge users' %}
     {% endbreadcrumb_item %}

--- a/evap/staff/templates/staff_user_merge_selection.html
+++ b/evap/staff/templates/staff_user_merge_selection.html
@@ -1,9 +1,16 @@
 {% extends 'staff_base.html' %}
 
+{% load staff_templatetags %}
+
 {% block breadcrumb %}
     {{ block.super }}
-    <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% translate 'Users' %}</a></li>
-    <li class="breadcrumb-item">{% translate 'Merge users' %}</li>
+    {% url 'staff:user_index' as user_index_url %}
+    {% create_breadcrumb user_index_url %} 
+        {% translate 'Users' %}
+    {% endcreate_breadcrumb %}
+    {% create_breadcrumb %} 
+        {% translate 'Merge users' %}
+    {% endcreate_breadcrumb %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_merge_selection.html
+++ b/evap/staff/templates/staff_user_merge_selection.html
@@ -5,12 +5,12 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% url 'staff:user_index' as user_index_url %}
-    {% create_breadcrumb user_index_url %} 
+    {% breadcrumb_item user_index_url %} 
         {% translate 'Users' %}
-    {% endcreate_breadcrumb %}
-    {% create_breadcrumb %} 
+    {% endbreadcrumb_item %}
+    {% breadcrumb_item %} 
         {% translate 'Merge users' %}
-    {% endcreate_breadcrumb %}
+    {% endbreadcrumb_item %}
 {% endblock %}
 
 {% block content %}

--- a/evap/staff/templates/staff_user_merge_selection.html
+++ b/evap/staff/templates/staff_user_merge_selection.html
@@ -5,10 +5,10 @@
 {% block breadcrumb %}
     {{ block.super }}
     {% breadcrumb_item_url 'staff:user_index' %}
-    {% translate 'Users' %}
+        {% translate 'Users' %}
     {% endbreadcrumb_item_url %}
     {% breadcrumb_item %}
-    {% translate 'Merge users' %}
+        {% translate 'Merge users' %}
     {% endbreadcrumb_item %}
 {% endblock %}
 

--- a/evap/staff/templatetags/staff_templatetags.py
+++ b/evap/staff/templatetags/staff_templatetags.py
@@ -19,8 +19,8 @@ def breadcrumb_item(context, content):
 
 
 @register.simple_block_tag(takes_context=True)
-def breadcrumb_item_url(context, content, url_path, *refs):
-    url = reverse(url_path, args=refs) if url_path is not None else None
+def breadcrumb_item_url(context, content, url_path, *args):
+    url = reverse(url_path, args=args) if url_path is not None else None
 
     request = context["request"]
     current_path = request.path

--- a/evap/staff/templatetags/staff_templatetags.py
+++ b/evap/staff/templatetags/staff_templatetags.py
@@ -1,6 +1,6 @@
 from django.template import Library
-from django.utils.html import format_html
 from django.urls import reverse
+from django.utils.html import format_html
 
 from evap.staff.forms import ExamEvaluationForm
 
@@ -29,6 +29,7 @@ def breadcrumb_item(context, content, url=None):
         url,
         content,
     )
+
 
 @register.simple_block_tag(takes_context=True)
 def breadcrumb_item_url(context, content, url_path, *refs):

--- a/evap/staff/templatetags/staff_templatetags.py
+++ b/evap/staff/templatetags/staff_templatetags.py
@@ -14,7 +14,14 @@ def create_exam_evaluation_form(evaluation):
 
 
 @register.simple_block_tag(takes_context=True)
-def breadcrumb_item(context, content, url=None):
+def breadcrumb_item(context, content):
+    return breadcrumb_item_url(context, content, None)
+
+
+@register.simple_block_tag(takes_context=True)
+def breadcrumb_item_url(context, content, url_path, *refs):
+    url = reverse(url_path, args=refs) if url_path is not None else None
+
     request = context["request"]
     current_path = request.path
 
@@ -29,8 +36,3 @@ def breadcrumb_item(context, content, url=None):
         url,
         content,
     )
-
-
-@register.simple_block_tag(takes_context=True)
-def breadcrumb_item_url(context, content, url_path, *refs):
-    return breadcrumb_item(context, content, reverse(url_path, args=refs))

--- a/evap/staff/templatetags/staff_templatetags.py
+++ b/evap/staff/templatetags/staff_templatetags.py
@@ -1,5 +1,6 @@
 from django.template import Library
 from django.utils.html import format_html
+from django.urls import reverse
 
 from evap.staff.forms import ExamEvaluationForm
 
@@ -28,3 +29,7 @@ def breadcrumb_item(context, content, url=None):
         url,
         content,
     )
+
+@register.simple_block_tag(takes_context=True)
+def breadcrumb_item_url(context, content, url_path, *refs):
+    return breadcrumb_item(context, content, reverse(url_path, args=refs))

--- a/evap/staff/templatetags/staff_templatetags.py
+++ b/evap/staff/templatetags/staff_templatetags.py
@@ -1,5 +1,5 @@
 from django.template import Library
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 
 from evap.staff.forms import ExamEvaluationForm
 
@@ -13,13 +13,18 @@ def create_exam_evaluation_form(evaluation):
 
 
 @register.simple_block_tag(takes_context=True)
-def create_breadcrumb(context, content, url=None):
+def breadcrumb_item(context, content, url=None):
     request = context["request"]
     current_path = request.path
+
     if url is None or current_path == url:
-        html = f'<li class="breadcrumb-item">{content}</li>'
-    else:
-        # create the href="link" string.
-        href_str = f'href="{url}"'
-        html = f'<li class="breadcrumb-item"><a {href_str}>{content}</a></li>'
-    return mark_safe(html)
+        return format_html(
+            '<li class="breadcrumb-item">{}</li>',
+            content,
+        )
+
+    return format_html(
+        '<li class="breadcrumb-item"><a href="{}">{}</a></li>',
+        url,
+        content,
+    )

--- a/evap/staff/templatetags/staff_templatetags.py
+++ b/evap/staff/templatetags/staff_templatetags.py
@@ -1,4 +1,5 @@
 from django.template import Library
+from django.utils.safestring import mark_safe
 
 from evap.staff.forms import ExamEvaluationForm
 
@@ -9,3 +10,16 @@ register = Library()
 def create_exam_evaluation_form(evaluation):
     form_id = f"exam_creation_form_{evaluation.id}"
     return ExamEvaluationForm(None, evaluation=evaluation, form_id=form_id)
+
+
+@register.simple_block_tag(takes_context=True)
+def create_breadcrumb(context, content, url=None):
+    request = context["request"]
+    current_path = request.path
+    if url is None or current_path == url:
+        html = f'<li class="breadcrumb-item">{content}</li>'
+    else:
+        # create the href="link" string.
+        href_str = f'href="{url}"'
+        html = f'<li class="breadcrumb-item"><a {href_str}>{content}</a></li>'
+    return mark_safe(html)

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -254,7 +254,6 @@ def semester_view(request, semester_id) -> HttpResponse:
         "semester": semester,
         "evaluations": evaluations,
         "Evaluation": Evaluation,
-        "disable_breadcrumb_semester": True,
         "rewards_active": rewards_active,
         "num_evaluations": len(evaluations),
         "program_stats": program_stats_with_total,

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -149,7 +149,6 @@ def index(request):
         "semesters": Semester.objects.all(),
         "templates": EmailTemplate.objects.all().order_by("id"),
         "sections": FaqSection.objects.all(),
-        "disable_breadcrumb_manager": True,
     }
     return render(request, "staff_index.html", template_data)
 
@@ -1126,7 +1125,6 @@ def course_copy(request, course_id):
             "semester": course.semester,
             "course_form": course_form,
             "editable": True,
-            "disable_breadcrumb_course": True,
         },
     )
 
@@ -1166,7 +1164,6 @@ class CourseEditView(SuccessMessageMixin, UpdateView):
         context_data = super().get_context_data(**kwargs) | {
             "semester": self.object.semester,
             "editable": self.object.can_be_edited_by_manager,
-            "disable_breadcrumb_course": True,
         }
         context_data["course_form"] = context_data.pop("form")
         return context_data
@@ -1985,13 +1982,7 @@ def questionnaire_edit(request, questionnaire_id):
         messages.success(request, _("Successfully updated questionnaire."))
         return redirect("staff:questionnaire_index")
 
-    template_data = {
-        "questionnaire": questionnaire,
-        "form": form,
-        "formset": formset,
-        "editable": editable,
-        "disable_breadcrumb_questionnaire": True,
-    }
+    template_data = {"questionnaire": questionnaire, "form": form, "formset": formset, "editable": editable}
     return render(request, "staff_questionnaire_form.html", template_data)
 
 

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -3,14 +3,19 @@
 {% load static %}
 {% load evaluation_filters %}
 {% load student_filters %}
+{% load staff_templatetags %}
 
 {% block title %}{{ evaluation.full_name }} - {% translate 'Evaluation' %} - {{ block.super }}{% endblock %}
 
 {% block breadcrumb_bar %}
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
-            <li class="breadcrumb-item">{{ evaluation.course.semester.name }}</li>
-            <li class="breadcrumb-item">{{ evaluation.full_name }}</li>
+                {% breadcrumb_item %} 
+                    {{ evaluation.course.semester.name }}
+                {% endbreadcrumb_item %}
+                {% breadcrumb_item %} 
+                    {{ evaluation.full_name }}
+                {% endbreadcrumb_item %}
         </ul>
     </div>
 {% endblock %}

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -11,10 +11,10 @@
     <div class="breadcrumb-bar">
         <ul class="breadcrumb">
             {% breadcrumb_item %}
-            {{ evaluation.course.semester.name }}
+                {{ evaluation.course.semester.name }}
             {% endbreadcrumb_item %}
             {% breadcrumb_item %}
-            {{ evaluation.full_name }}
+                {{ evaluation.full_name }}
             {% endbreadcrumb_item %}
         </ul>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ exclude = ["**/urls.py"]
 [tool.djangofmt]
 extend-exclude = ["evap/static/bootstrap"]
 html-void-self-closing = "unchanged"
+custom-blocks = ["breadcrumb_item", "breadcrumb_item_url"]
 
 ##############################################
 


### PR DESCRIPTION
This PR provides a solution to #2642 by adding a custom Django template tag that adds breadcrumbs that can automagically figure out if they are self-referencial ("link-if-not-self") and therefore disabled or not respectively.

One advantage of this is more standardisation for breadcrumbs across the website.
Furthermore, we can avoid using some of the "disable_breadcrumb_tags" in the project, slightly improving the backend code. 

Closes #2642 