### PR TITLE
Remove no-op `utils.js` and `csrf-utils.js` script tag in `base.html`

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -73,9 +73,6 @@
         <script type="text/javascript" src="{% static 'js/plugins/jquery.formset.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/Sortable.min.js' %}"></script>
 
-        <script type="module" src="{% static 'js/csrf-utils.js' %}"></script>
-        <script type="module" src="{% static 'js/utils.js' %}"></script>
-
         <script type="module" src="{% static 'js/base-template.js' %}"></script>
         <script type="text/javascript">
             activateTooltips = function(selector = "", tooltipType = "tooltip", additionalOptions) {


### PR DESCRIPTION
Just noticed this while looking at #2718. Currently, `utils.js` and `csrf-utils.js` have no side effects, so having it like this does not do anything. We added the former in 93cf2413fcd59f6bf92d1020056c7259b5224796 because we added global side effects, but I removed those in 7ac051c16885e08ce9d38a091451466d086daf93.
