### PR TITLE
Use `QuestionAssignment.order` where we expect it

### DIFF
--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -57,13 +57,13 @@ class EvaluationForm(forms.ModelForm):
             Questionnaire.objects.general_questionnaires()
             .filter(Q(visibility=Questionnaire.Visibility.EDITORS) | Q(contributions__evaluation=self.instance))
             .distinct()
-            .prefetch_related("questions")
+            .prefetch_related("question_assignments", "question_assignments__question")
         )
         self.fields["dropout_questionnaires"].queryset = (
             Questionnaire.objects.dropout_questionnaires()
             .filter(Q(visibility=Questionnaire.Visibility.EDITORS) | Q(contributions__evaluation=self.instance))
             .distinct()
-            .prefetch_related("questions")
+            .prefetch_related("question_assignments", "question_assignments__question")
         )
 
         self.fields["vote_start_datetime"].localize = True
@@ -149,7 +149,7 @@ class EditorContributionForm(ContributionForm):
             Questionnaire.objects.contributor_questionnaires()
             .filter(Q(visibility=Questionnaire.Visibility.EDITORS) | Q(contributions__evaluation=self.evaluation))
             .distinct()
-            .prefetch_related("questions")
+            .prefetch_related("question_assignments", "question_assignments__question")
         )
         self.fields["contributor"].queryset = UserProfile.objects.filter(
             (Q(is_active=True) & Q(is_proxy_user=False)) | Q(pk=existing_contributor_pk)

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -275,11 +275,19 @@ class Questionnaire(models.Model):
 
     @property
     def text_questions(self) -> list["Question"]:
-        return [question for question in self.questions.all() if question.is_text_question]
+        return [
+            assignment.question
+            for assignment in self.question_assignments.all()
+            if assignment.question.is_text_question
+        ]
 
     @property
     def rating_questions(self) -> list["Question"]:
-        return [question for question in self.questions.all() if question.is_rating_question]
+        return [
+            assignment.question
+            for assignment in self.question_assignments.all()
+            if assignment.question.is_rating_question
+        ]
 
 
 class Program(models.Model):

--- a/evap/evaluation/templates/questionnaires_widget.html
+++ b/evap/evaluation/templates/questionnaires_widget.html
@@ -15,13 +15,13 @@
                 {{ questionnaire.description }}<br />
             {% endif %}
             <ul>
-                {% for question in questionnaire.questions.all %}
-                    {% if question.is_heading_question %}
+                {% for assignment in questionnaire.question_assignments.all %}
+                    {% if assignment.question.is_heading_question %}
                         </ul>
-                        {{ question.text }}
+                        {{ assignment.question.text }}
                         <ul>
                     {% else %}
-                        <li>{{ question.text }}</li>
+                        <li>{{ assignment.question.text }}</li>
                     {% endif %}
                 {% endfor %}
             </ul>

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -287,7 +287,9 @@ class ResultsExporter(ExcelExporter):
         # first cell of row is printed above
         self.write_empty_row_with_styles(["border_left_right"] * len(evaluations_with_results))
 
-        for question in self.filter_text_and_heading_questions(questionnaire.questions.all()):
+        for question in self.filter_text_and_heading_questions(
+            assignment.question for assignment in questionnaire.question_assignments.all()
+        ):
             self.write_cell(question.text, "italic" if question.is_heading_question else "default")
 
             for __, results in evaluations_with_results:

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -449,11 +449,17 @@ class EvaluationForm(forms.ModelForm):
             visible_questionnaires |= Q(contributions__evaluation=self.instance)
 
         self.fields["general_questionnaires"].queryset = (
-            Questionnaire.objects.general_questionnaires().filter(visible_questionnaires).distinct()
+            Questionnaire.objects.general_questionnaires()
+            .filter(visible_questionnaires)
+            .distinct()
+            .prefetch_related("question_assignments", "question_assignments__question")
         )
 
         self.fields["dropout_questionnaires"].queryset = (
-            Questionnaire.objects.dropout_questionnaires().filter(visible_questionnaires).distinct()
+            Questionnaire.objects.dropout_questionnaires()
+            .filter(visible_questionnaires)
+            .distinct()
+            .prefetch_related("question_assignments", "question_assignments__question")
         )
 
         queryset = UserProfile.objects.exclude(is_active=False)
@@ -633,6 +639,7 @@ class ContributionForm(forms.ModelForm):
                 | Q(contributions__evaluation=(self.evaluation if self.evaluation.pk else None))
             )
             .distinct()
+            .prefetch_related("question_assignments", "question_assignments__question")
         )
 
         if self.instance.pk:

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1843,7 +1843,7 @@ def questionnaire_index(request):
         Questionnaire.objects.all()
         .filter(questionnaires_filter)
         .order_by("order", "pk")
-        .prefetch_related("questions", "contributions__evaluation")
+        .prefetch_related("contributions__evaluation")
     )
 
     template_data = {

--- a/evap/student/forms.py
+++ b/evap/student/forms.py
@@ -59,7 +59,8 @@ class QuestionnaireVotingForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.questionnaire = questionnaire
 
-        for question in self.questionnaire.questions.all():
+        for assignment in self.questionnaire.question_assignments.all():
+            question = assignment.question
             if question.is_text_question:
                 field = TextAnswerField.from_question(question)
             elif question.is_rating_question:

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -266,24 +266,26 @@ class TestVoteView(WebTest):
         )
 
     def test_question_ordering(self):
+        # Reorder questions after creation, regression test for #2741
+        self.bottom_text_assignment.order = 4
+        self.bottom_text_assignment.save()
+        self.bottom_grade_assignment.order = 1
+        self.bottom_grade_assignment.save()
+
         page = self.app.get(self.url, user=self.voting_user1, status=200)
 
-        top_heading_index = page.body.decode().index(self.top_heading_assignment.question.text)
-        top_text_index = page.body.decode().index(self.top_text_assignment.question.text)
-
-        contributor_heading_index = page.body.decode().index(self.contributor_heading_assignment.question.text)
-        contributor_likert_index = page.body.decode().index(self.contributor_likert_assignment.question.text)
-
-        bottom_heading_index = page.body.decode().index(self.bottom_heading_assignment.question.text)
-        bottom_grade_index = page.body.decode().index(self.bottom_grade_assignment.question.text)
+        def index(assignment):
+            return page.body.decode().index(assignment.question.text)
 
         self.assertTrue(
-            top_heading_index
-            < top_text_index
-            < contributor_heading_index
-            < contributor_likert_index
-            < bottom_heading_index
-            < bottom_grade_index
+            index(self.top_heading_assignment)
+            < index(self.top_text_assignment)
+            < index(self.contributor_heading_assignment)
+            < index(self.contributor_likert_assignment)
+            < index(self.bottom_heading_assignment)
+            < index(self.bottom_grade_assignment)
+            < index(self.bottom_likert_assignment)
+            < index(self.bottom_text_assignment)
         )
 
     def fill_form(self, form, fill_general_complete=True, fill_contributors_complete=True):


### PR DESCRIPTION
Closes #2741

When we introduced `QuestionAssignment` we moved the `order` field from `Question` to `QuestionAssignment`. Semantically, this makes sense, because the same question might be ordered differently in different questionnaires. However, specifying an ordering on a through-model like this does not result in Django ordering the related instances as we expect (see https://code.djangoproject.com/ticket/30460). Instead, the order of the related model is used, which in our case (on `Question`) was unspecified, so the database just returned some arbitrary order.

The fix is to _not_ iterate over `questionnaire.questions` and instead prefer going via `questionnaire.question_assignments`. This ensures that the `QuestionAssignment` ordering is used. Another option would be to always prefetch with custom `Prefetch` objects like `Prefetch("questions", queryset=Question.objects.order_by("assignments"))`. However, this seems less robust then explicitly going via assignments in the right places and also uses the `order_by("through-model")` hack from the Django ticket which, as far as I can tell, is not documented.

The places from the issue seem to be fixed by this PR. I checked for other places by searching for the strings `.questions` and `questions"`.
