### PR TITLE
Use evap-dev shell for `./manage.py run` process

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
           pkgs = pkgsFor.${system};
           pc-modules = import ./nix/services.nix {
             inherit pkgs;
-            inherit (self.devShells.${system}.evap.passthru) venv;
+            inherit (self.devShells.${system}.evap-dev.passthru) venv;
           };
           make-process-compose = mode: (import inputs.process-compose-flake.lib { inherit pkgs; }).makeProcessCompose {
             modules = [


### PR DESCRIPTION
I wanted to use `debug_toolbar`, but our process-compose services used the minimal `evap` shell instead of the `evap-dev` one (which is the default for `nix develop`), so `debug_toolbar` was not available.

This makes all development dependencies available in the process-compose Python interpreter.
