### PR TITLE
Add scheduled workflow to tag stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: 'Tag stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: -1
+          days-before-pr-stale: 30
+          days-before-close: -1


### PR DESCRIPTION
From the docs, I think this is the correct configuration. There is a debug-only (= dry run) option, but I think we would have to merge this PR with it enabled to see what it does. We could do that and remove it once we saw what it does.
