### PR TITLE
Links on Flagged Textanswers Page

### DIFF
--- a/evap/staff/templates/staff_semester_flagged_textanswers.html
+++ b/evap/staff/templates/staff_semester_flagged_textanswers.html
@@ -17,7 +17,11 @@
 
                 {% for evaluation_flagged_textanswers in flagged_textanswers_by_evalaution %}
                     <h5 class="{% if not forloop.first %}mt-3{% endif %} mb-2">
-                        <a href="{% url 'staff:evaluation_textanswers' evaluation_flagged_textanswers.grouper.id %}?view=flagged">
+                        <a href="{% if evaluation_flagged_textanswers.grouper.state == evaluation_flagged_textanswers.grouper.State.PUBLISHED %}
+                                    {% url 'results:evaluation_detail' semester.id evaluation_flagged_textanswers.grouper.id %}
+                                {% else %}
+                                    {% url 'staff:evaluation_textanswers' evaluation_flagged_textanswers.grouper.id %}?view=flagged
+                                {% endif %}">
                             {{ evaluation_flagged_textanswers.grouper }}
                         </a>
                     </h5>


### PR DESCRIPTION
If the flagged textanswer already has the PUBLISHED state, then we link to the results page, otherwise exactly as before.

Closes #2705
