### PR TITLE
Replace deprecated tseslint.config() call.

### DIFF
--- a/evap/static/ts/eslint.config.js
+++ b/evap/static/ts/eslint.config.js
@@ -1,9 +1,10 @@
 // @ts-check
 
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default defineConfig(
     eslint.configs.recommended,
     ...tseslint.configs.strictTypeChecked,
     ...tseslint.configs.stylisticTypeChecked,


### PR DESCRIPTION
Reading through https://typescript-eslint.io/packages/typescript-eslint/#migrating-to-defineconfig, it seems that this achieves exactly what we would like.

Closes #2639

