### PR TITLE
Rename nix/nix-python to nix/python

### DIFF
--- a/nix/nix-python
+++ b/nix/nix-python
@@ -1,4 +1,1 @@
-#!/bin/sh
-SCRIPTPATH=$(dirname "$0")
-FLAKEPATH=$(realpath "$SCRIPTPATH/..")
-exec nix develop "$FLAKEPATH" --command python "$@"
+python

--- a/nix/python
+++ b/nix/python
@@ -1,0 +1,4 @@
+#!/bin/sh
+SCRIPTPATH=$(dirname "$0")
+FLAKEPATH=$(realpath "$SCRIPTPATH/..")
+exec nix develop "$FLAKEPATH" --command python "$@"


### PR DESCRIPTION
Allows newer PyCharm versions to accept it as a local python interpreter.