### PR TITLE
Fix contributor index switch button label white space preservation

### DIFF
--- a/evap/contributor/templates/contributor_index.html
+++ b/evap/contributor/templates/contributor_index.html
@@ -17,7 +17,7 @@
         </div>
         {% if user.is_delegate %}
             <div class="btn-switch btn-switch-light ms-2 d-print-none">
-                <div class="btn-switch-label text-break break-spaces">
+                <div class="btn-switch-label">
                     <span class="fas fa-people-arrows-left-right"></span> {% translate 'Delegated evaluations' %}
                 </div>
                 <div class="btn-switch btn-group">

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -278,7 +278,7 @@
                                     <button
                                         slot="show-button"
                                         type="button"
-                                        class="btn btn-sm btn-light{% if rewards_active %} active{% endif %}"
+                                        class="btn btn-sm btn-light{% if rewards_active %} active{% endif %} h-100"
                                     >
                                         <span class="fas fa-check" aria-hidden="true"></span>
                                     </button>

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -261,6 +261,7 @@
                                     type="submit"
                                     name="activation_status"
                                     value="on"
+                                    class="d-contents"
                                     confirm-button-class="btn-primary"
                                 >
                                     <span slot="title">{% translate 'Activate reward points' %}</span>
@@ -278,7 +279,7 @@
                                     <button
                                         slot="show-button"
                                         type="button"
-                                        class="btn btn-sm btn-light{% if rewards_active %} active{% endif %} h-100"
+                                        class="btn btn-sm btn-light{% if rewards_active %} active{% endif %}"
                                     >
                                         <span class="fas fa-check" aria-hidden="true"></span>
                                     </button>

--- a/evap/static/scss/_adjustments.scss
+++ b/evap/static/scss/_adjustments.scss
@@ -163,12 +163,6 @@ $alert-colors: (
     height: fit-content;
 }
 
-@include media-breakpoint-down(sm) {
-    .flex-column-mobile {
-        flex-direction: column;
-    }
-}
-
 // Hide the x in input fields on chrome
 input[type="search"]::-webkit-search-cancel-button {
 	-webkit-appearance: none;

--- a/evap/static/scss/_utilities.scss
+++ b/evap/static/scss/_utilities.scss
@@ -76,10 +76,6 @@ a.no-underline:hover {
     z-index: $zindex-fixed + 1;
 }
 
-.break-spaces {
-    white-space: break-spaces;
-}
-
 @for $i from 0 through 100 {
     .width-percent-#{$i} {
         width: $i * 1% !important;

--- a/evap/static/scss/components/_buttons.scss
+++ b/evap/static/scss/components/_buttons.scss
@@ -196,7 +196,7 @@ a:not([href]):not(.disabled) {
     border-color: $medium-gray !important;
 
     &:last-child {
-        width: 3.5rem;
+        width: 4rem;
     }
 
     .btn-check:focus-visible + & {
@@ -204,7 +204,6 @@ a:not([href]):not(.disabled) {
     }
 
     .vote-type-bipolar &:not(:last-child) {
-        width: 5rem;
         font-size: 0.8rem;
     }
 }

--- a/evap/static/scss/components/_buttons.scss
+++ b/evap/static/scss/components/_buttons.scss
@@ -1,3 +1,7 @@
+.btn {
+    align-content: center;
+}
+
 .btn.fas {
     font-weight: 900;
 }

--- a/evap/static/scss/components/_buttons.scss
+++ b/evap/static/scss/components/_buttons.scss
@@ -81,7 +81,6 @@ a:not([href]):not(.disabled) {
 .btn-switch-label {
     display: inline-block;
     font-weight: normal;
-    white-space: nowrap;
     vertical-align: middle;
     color: $darker-gray;
     padding: 0.25rem 0.25rem 0.25rem 0.5rem;

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -71,7 +71,7 @@
     <h3 class="mb-3 d-flex gap-2 justify-content-between align-items-end flex-column flex-md-row">
         <span>{{ evaluation.full_name }} ({{ evaluation.course.semester.name }})</span>
 
-        <div class="d-flex flex-shrink-0 justify-content-end height-fit-content">
+        <div class="flex-shrink-0 justify-content-end height-fit-content">
             <div class="btn-switch btn-switch-light btn-switch-evaluation-language">
                 <div class="btn-switch-label my-auto">
                     {% translate "Questionnaire language" %}

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -68,10 +68,10 @@
             </small>
         </div>
     {% endif %}
-    <h3 class="mb-3 d-flex justify-content-between flex-column-mobile">
-        {{ evaluation.full_name }} ({{ evaluation.course.semester.name }})
+    <h3 class="mb-3 d-flex gap-2 justify-content-between align-items-end flex-column flex-md-row">
+        <span>{{ evaluation.full_name }} ({{ evaluation.course.semester.name }})</span>
 
-        <div class="float-lg-end mt-3 mt-lg-0 d-flex justify-content-end height-fit-content">
+        <div class="d-flex flex-shrink-0 justify-content-end height-fit-content">
             <div class="btn-switch btn-switch-light btn-switch-evaluation-language">
                 <div class="btn-switch-label my-auto">
                     {% translate "Questionnaire language" %}


### PR DESCRIPTION
In https://github.com/e-valuation/EvaP/pull/2736, we [introduced additional in-html whitespace](https://github.com/e-valuation/EvaP/pull/2736/changes?diff=split#diff-4995b7ca622ef8bbd0be7e45487de4a809bd094c539e558f2468b4a8037011f2R20-R22) in the switch button label on the contributor index page. However, in https://github.com/e-valuation/EvaP/pull/2054, we added the classes `text-break break-spaces` to the button label, which applies this CSS:
```css
.break-spaces {
    white-space: break-spaces;
}
```
Now, this unintuitively does not mean "break my text at whitespaces". It also preserves original breaking whitespaces (aka newlines). So, the two newlines our formatting added are also included in the div, causing the switch button to look like this:
<img width="1318" height="247" alt="image" src="https://github.com/user-attachments/assets/33ecede2-f3f4-4f57-bb84-f7559a978a7b" />

I think we should get rid of this `break-spaces` class since it does not do what people would expect it to do. To still make our text wrap here, I discussed with @janno42 and we agreed that we should probably just allow text wrapping in `.btn-switch-label`.