### PR TITLE
Fix quoting in included `result_widget_tooltip` template

### DIFF
--- a/evap/results/templates/result_widget_tooltip.html
+++ b/evap/results/templates/result_widget_tooltip.html
@@ -16,13 +16,16 @@
     {% with question_result.question.is_bipolar_likert_question as is_bipolar %}
         <p>
             {% for count, name, color, value in question_result.zipped_choices %}
+                {# djangofmt:ignore #}
                 <span
-                    class="
+                    {# we must use single quotes for the `class` attribute because this file is included as a HTML
+                       attribute that is delimited by double quotes #}
+                    class='
                         vote-text-{{ color }} fas fa-fw-absolute
                         {% if is_bipolar and value < 0 %}fa-caret-down pole-icon
                         {% elif is_bipolar and value > 0 %}fa-caret-up pole-icon
                         {% else %}fa-square{% endif %}
-                    "
+                    '
                 ></span>
                 {{ name }}: {{ count }}/{{ question_result.count_sum }}
                 ({{ count|percentage_one_decimal:question_result.count_sum }})


### PR DESCRIPTION
In #2736 we introduced template formatting, which (among other things) normalizes the quotes used for element attributes like `class="..."`. In particular, the formatter changes the style to use double quotes by default.

In normal HTML, the type of quotes is insignificant. However, in `result_widget_tooltip`, we _need_ to use single quotes for the span's class attribute, because the entire file is included in other files as `<div title="{% include 'result_widget_tooltip.html' with ... %}">`. Thus, with single quotes, we get something like `title="<span class='abc'>"` whereas with double quotes we get `title="<span class="abc">"`, so the `title` attribute is terminated early and the `abc">"` spills into the surrounding HTML. This leads to the result page looking like this: 
<img width="2818" height="654" alt="image" src="https://github.com/user-attachments/assets/49faad30-8f5a-42de-9bad-1fa27bfa62bf" />

I checked:
- all occurrences of `{% include` on current main, we only include `result_widget_tooltip.html` in this way
- all occurrences of `='` in the diff of #2736, other places look fine