### PR TITLE
Fix tests in debug mode

### DIFF
--- a/evap/evaluation/tests/test_auth.py
+++ b/evap/evaluation/tests/test_auth.py
@@ -240,7 +240,7 @@ class LoginTests(WebTest):
             self.assertIsInstance(response.context["user"], AnonymousUser)
             self.assertNotContains(response, "Logout")
 
-        # correct password while password login is disabled. Disable the debug page
+        # correct password while password login is disabled. Disable the debug internal server error page
         with override_settings(ACTIVATE_OPEN_ID_LOGIN=True, DEBUG=False):
             self.assertFalse(auth.password_login_is_active())
 

--- a/evap/evaluation/tests/test_auth.py
+++ b/evap/evaluation/tests/test_auth.py
@@ -240,8 +240,8 @@ class LoginTests(WebTest):
             self.assertIsInstance(response.context["user"], AnonymousUser)
             self.assertNotContains(response, "Logout")
 
-        # correct password while password login is disabled
-        with override_settings(ACTIVATE_OPEN_ID_LOGIN=True):
+        # correct password while password login is disabled. Disable the debug page
+        with override_settings(ACTIVATE_OPEN_ID_LOGIN=True, DEBUG=False):
             self.assertFalse(auth.password_login_is_active())
 
             password_form["password"] = "evap"  # nosec

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -248,12 +248,18 @@ class TestEvaluations(WebTest):
             wait_for_grade_upload_before_publishing=False,
         )
 
-        with patch(
-            "evap.evaluation.models.Evaluation.end_evaluation", autospec=True, side_effect=Evaluation.end_evaluation
-        ) as mock:
+        with (
+            patch(
+                "evap.evaluation.models.Evaluation.end_evaluation", autospec=True, side_effect=Evaluation.end_evaluation
+            ) as evaluation_mock,
+            patch(
+                "evap.evaluation.models.Evaluation.end_review", autospec=True, side_effect=Evaluation.end_review
+            ) as review_mock,
+        ):
             Evaluation.update_evaluations()
 
-        self.assertEqual(mock.call_count, 1)
+        self.assertEqual(evaluation_mock.call_count, 1)
+        self.assertEqual(review_mock.call_count, 1)
 
     def test_approved_to_in_evaluation_sends_emails(self):
         """Regression test for #945"""

--- a/evap/evaluation/tests/test_models.py
+++ b/evap/evaluation/tests/test_models.py
@@ -248,7 +248,9 @@ class TestEvaluations(WebTest):
             wait_for_grade_upload_before_publishing=False,
         )
 
-        with patch("evap.evaluation.models.Evaluation.end_evaluation") as mock:
+        with patch(
+            "evap.evaluation.models.Evaluation.end_evaluation", autospec=True, side_effect=Evaluation.end_evaluation
+        ) as mock:
             Evaluation.update_evaluations()
 
         self.assertEqual(mock.call_count, 1)

--- a/evap/evaluation/tests/test_tools.py
+++ b/evap/evaluation/tests/test_tools.py
@@ -11,7 +11,7 @@ from model_bakery import baker
 
 from evap.evaluation.management.commands.tools import subprocess_run_or_exit
 from evap.evaluation.models import Contribution, Course, Evaluation, TextAnswer, UserProfile
-from evap.evaluation.tests.tools import SimpleTestCase, TestCase, WebTest
+from evap.evaluation.tests.tools import SimpleTestCase, TestCase, WebTest, assert_no_database_modifications
 from evap.evaluation.tools import (
     discard_cached_related_objects,
     get_object_from_dict_pk_entry_or_logged_40x,
@@ -231,6 +231,15 @@ class TestHelperMethods(TestCase):
 
         with self.assertRaises(SystemExit):
             subprocess_run_or_exit(["false"])
+
+    def test_assert_no_database_modifications(self):
+        with self.assertRaises(AssertionError) as context_manager:
+            with assert_no_database_modifications():
+                baker.make(UserProfile)
+
+        self.assertIn(
+            'Unexpected modifying query found: INSERT INTO "evaluation_userprofile"', str(context_manager.exception)
+        )
 
 
 class TestHelperMethodsWithoutTransaction(SimpleTestCase):

--- a/evap/evaluation/tests/tools.py
+++ b/evap/evaluation/tests/tools.py
@@ -314,11 +314,11 @@ def assert_no_database_modifications(*args, **kwargs):
     allowed_prefixes = ["select", "savepoint", "release savepoint", "rollback to savepoint"]
 
     conn = connections[DEFAULT_DB_ALIAS]
-    with CaptureQueriesContext(conn):
+    with CaptureQueriesContext(conn) as context:
         try:
             yield
         finally:
-            for query in conn.queries_log:
+            for query in context.captured_queries:
                 if (
                     query["sql"].startswith('INSERT INTO "testing_cache_sessions"')
                     or query["sql"].startswith('UPDATE "testing_cache_sessions"')


### PR DESCRIPTION
see https://github.com/e-valuation/EvaP/issues/1719#issuecomment-5181194424 following.

If we want to enable the debug mode in CI again is separate.

25b575f266ef3e9913a557ce3a88410878cae2be is unrelated to debug mode. It also triggers if `assert_no_database_modifications` is used after something else the activates a `CaptureQueriesContext`, e.g. the num queries asserter, whose queries would always leak into later calls to `assert_no_database_modifications`.