### PR TITLE
prevent path coverage drop on thurdays

### DIFF
--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -290,7 +290,7 @@ class TestUpdateEvaluationStatesCommand(TestCase):
         self.assertEqual(mock.call_count, 1)
 
 
-@override_settings(REMIND_X_DAYS_AHEAD_OF_END_DATE=[0, 2])
+@override_settings(REMIND_X_DAYS_AHEAD_OF_END_DATE=[0, 2], TEXTANSWER_REVIEW_REMINDER_WEEKDAYS=[])
 class TestSendRemindersCommand(TestCase):
     def test_remind_user_about_one_evaluation(self):
         user_to_remind = baker.make(UserProfile)


### PR DESCRIPTION
in memorandum of "tests fail at specific time of day"

No test actually forces a reminder _not_ to be sent, and on a thursday, the reminder is always sent in all tests. So on thursday, there is a missing branch early returning from 
https://github.com/e-valuation/EvaP/blob/0a5f134af470b3264e354e018799d69c016168b7/evap/evaluation/management/commands/send_reminders.py#L73-L74