### PR TITLE
Fix footer height too small on small display width

### DIFF
--- a/evap/evaluation/templates/footer.html
+++ b/evap/evaluation/templates/footer.html
@@ -12,7 +12,7 @@
         <div class="collapse navbar-collapse justify-content-between">
             <ul class="navbar-nav justify-content-start">
                 <li class="nav-item my-auto">
-                    <a class="nav-link nav-link-multiline" href="{% legal_link %}">
+                    <a class="nav-link" href="{% legal_link %}">
                         <span>{% translate 'Legal Notice' %}</span>
                         <span class="fas fa-arrow-up-right-from-square ps-1"></span>
                     </a>

--- a/evap/static/scss/evap.scss
+++ b/evap/static/scss/evap.scss
@@ -45,10 +45,6 @@ body {
     a {
         white-space: nowrap;
     }
-
-    .navbar-nav .nav-link.nav-link-multiline {
-        line-height: 1.2;
-    }
 }
 
 .brand-image {


### PR DESCRIPTION
Before, when making the viewport have small width, the text on the footer would hug the color bar.
